### PR TITLE
Split Context

### DIFF
--- a/classifier/classifier.go
+++ b/classifier/classifier.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/snapshot/vfs"
 )
 
@@ -49,16 +49,16 @@ var muBackends sync.Mutex
 var backends map[string]func() Backend = make(map[string]func() Backend)
 
 type Classifier struct {
-	backend    []Backend
-	appcontext *appcontext.AppContext
+	backend  []Backend
+	kcontext *kcontext.KContext
 }
 
-func NewClassifier(ctx *appcontext.AppContext) (*Classifier, error) {
+func NewClassifier(ctx *kcontext.KContext) (*Classifier, error) {
 	muBackends.Lock()
 	defer muBackends.Unlock()
 
 	cf := &Classifier{}
-	cf.appcontext = ctx
+	cf.kcontext = ctx
 
 	for name, backend := range backends {
 		if inst := backend(); inst == nil {

--- a/kcontext/kcontext.go
+++ b/kcontext/kcontext.go
@@ -1,4 +1,4 @@
-package appcontext
+package kcontext
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 )
 
-type AppContext struct {
+type KContext struct {
 	events  *events.Receiver `msgpack:"-"`
 	cache   *caching.Manager `msgpack:"-"`
 	cookies *cookies.Manager `msgpack:"-"`
@@ -53,10 +53,10 @@ type AppContext struct {
 	Keypair  *keypair.KeyPair
 }
 
-func NewAppContext() *AppContext {
+func NewKContext() *KContext {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &AppContext{
+	return &KContext{
 		events:  events.New(),
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
@@ -65,71 +65,71 @@ func NewAppContext() *AppContext {
 	}
 }
 
-func NewAppContextFrom(template *AppContext) *AppContext {
+func NewKContextFrom(template *KContext) *KContext {
 	ctx := *template
 	ctx.events = events.New()
 	ctx.Context, ctx.Cancel = context.WithCancel(template.Context)
 	return &ctx
 }
 
-func (c *AppContext) Deadline() (time.Time, bool) {
+func (c *KContext) Deadline() (time.Time, bool) {
 	return c.Context.Deadline()
 }
 
-func (c *AppContext) Done() <-chan struct{} {
+func (c *KContext) Done() <-chan struct{} {
 	return c.Context.Done()
 }
 
-func (c *AppContext) Err() error {
+func (c *KContext) Err() error {
 	return c.Context.Err()
 }
 
-func (c *AppContext) Value(key any) any {
+func (c *KContext) Value(key any) any {
 	return c.Context.Value(key)
 }
 
-func (c *AppContext) Close() {
+func (c *KContext) Close() {
 	c.events.Close()
 	c.Cancel()
 }
 
-func (c *AppContext) Events() *events.Receiver {
+func (c *KContext) Events() *events.Receiver {
 	return c.events
 }
 
-func (c *AppContext) SetCache(cacheManager *caching.Manager) {
+func (c *KContext) SetCache(cacheManager *caching.Manager) {
 	c.cache = cacheManager
 }
 
-func (c *AppContext) GetCache() *caching.Manager {
+func (c *KContext) GetCache() *caching.Manager {
 	return c.cache
 }
 
-func (c *AppContext) SetCookies(cacheManager *cookies.Manager) {
+func (c *KContext) SetCookies(cacheManager *cookies.Manager) {
 	c.cookies = cacheManager
 }
 
-func (c *AppContext) GetCookies() *cookies.Manager {
+func (c *KContext) GetCookies() *cookies.Manager {
 	return c.cookies
 }
 
-func (c *AppContext) SetLogger(logger *logging.Logger) {
+func (c *KContext) SetLogger(logger *logging.Logger) {
 	c.logger = logger
 }
 
-func (c *AppContext) GetLogger() *logging.Logger {
+func (c *KContext) GetLogger() *logging.Logger {
 	return c.logger
 }
 
-func (c *AppContext) SetSecret(secret []byte) {
+func (c *KContext) SetSecret(secret []byte) {
 	c.secret = secret
 }
 
-func (c *AppContext) GetSecret() []byte {
+func (c *KContext) GetSecret() []byte {
 	return c.secret
 }
 
-func (c *AppContext) GetAuthToken(repository uuid.UUID) (string, error) {
+func (c *KContext) GetAuthToken(repository uuid.UUID) (string, error) {
 	if authToken, err := c.cookies.GetAuthToken(); err != nil {
 		return "", err
 	} else {

--- a/kcontext/kcontext_test.go
+++ b/kcontext/kcontext_test.go
@@ -1,4 +1,4 @@
-package appcontext
+package kcontext
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestContext_SettersAndGetters(t *testing.T) {
-	ctx := NewAppContext()
+	ctx := NewKContext()
 
 	defaultLogger := logging.NewLogger(nil, nil)
 	defaultCachingManager := caching.NewManager("/tmp/test_plakar")
@@ -189,7 +189,7 @@ func TestContext_SettersAndGetters(t *testing.T) {
 }
 
 func TestAppContextCloseEvents(t *testing.T) {
-	ctx := NewAppContext()
+	ctx := NewKContext()
 	events := ctx.Events()
 	if events == nil {
 		t.Errorf("events is nil")

--- a/repository/packer/packer.go
+++ b/repository/packer/packer.go
@@ -14,7 +14,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/packfile"
 	"github.com/PlakarKorp/kloset/resources"
@@ -43,14 +43,14 @@ type packerManager struct {
 	storageConf  *storage.Configuration
 	encodingFunc func(io.Reader) (io.Reader, error)
 	hashFactory  func() hash.Hash
-	appCtx       *appcontext.AppContext
+	appCtx       *kcontext.KContext
 
 	// XXX: Temporary hack callback-based to ease the transition diff.
 	// To be revisited with either an interface or moving this file inside repository/
 	flush func(*packfile.PackFile) error
 }
 
-func NewPackerManager(ctx *appcontext.AppContext, storageConfiguration *storage.Configuration, encodingFunc func(io.Reader) (io.Reader, error), hashFactory func() hash.Hash, flusher func(*packfile.PackFile) error) PackerManagerInt {
+func NewPackerManager(ctx *kcontext.KContext, storageConfiguration *storage.Configuration, encodingFunc func(io.Reader) (io.Reader, error), hashFactory func() hash.Hash, flusher func(*packfile.PackFile) error) PackerManagerInt {
 	inflightsMACs := make(map[resources.Type]*sync.Map)
 	for _, Type := range resources.Types() {
 		inflightsMACs[Type] = &sync.Map{}

--- a/repository/packer/platar.go
+++ b/repository/packer/platar.go
@@ -10,8 +10,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/PlakarKorp/kloset/appcontext"
 	"github.com/PlakarKorp/kloset/caching"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/resources"
 	"github.com/PlakarKorp/kloset/storage"
@@ -27,14 +27,14 @@ type platarPackerManager struct {
 	storageConf  *storage.Configuration
 	encodingFunc func(io.Reader) (io.Reader, error)
 	hashFactory  func() hash.Hash
-	appCtx       *appcontext.AppContext
+	appCtx       *kcontext.KContext
 
 	// XXX: Temporary hack callback-based to ease the transition diff.
 	// To be revisited with either an interface or moving this file inside repository/
 	flush func(*PackWriter) error
 }
 
-func NewPlatarPackerManager(ctx *appcontext.AppContext, storageConfiguration *storage.Configuration, encodingFunc func(io.Reader) (io.Reader, error), hashFactory func() hash.Hash, flusher func(*PackWriter) error) (PackerManagerInt, error) {
+func NewPlatarPackerManager(ctx *kcontext.KContext, storageConfiguration *storage.Configuration, encodingFunc func(io.Reader) (io.Reader, error), hashFactory func() hash.Hash, flusher func(*PackWriter) error) (PackerManagerInt, error) {
 	cache, err := ctx.GetCache().Packing()
 	if err != nil {
 		return nil, err

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -19,11 +19,11 @@ import (
 	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
 	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/fastcdc"
 	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/ultracdc"
-	"github.com/PlakarKorp/kloset/appcontext"
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/compression"
 	"github.com/PlakarKorp/kloset/encryption"
 	"github.com/PlakarKorp/kloset/hashing"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/packfile"
@@ -74,7 +74,7 @@ type Repository struct {
 	store         storage.Store
 	state         *state.LocalState
 	configuration storage.Configuration
-	appContext    *appcontext.AppContext
+	appContext    *kcontext.KContext
 
 	wBytes atomic.Int64
 	rBytes atomic.Int64
@@ -85,7 +85,7 @@ type Repository struct {
 	macHasherPool *HasherPool
 }
 
-func Inexistent(ctx *appcontext.AppContext, storeConfig map[string]string) (*Repository, error) {
+func Inexistent(ctx *kcontext.KContext, storeConfig map[string]string) (*Repository, error) {
 	st, err := storage.New(ctx, storeConfig)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func Inexistent(ctx *appcontext.AppContext, storeConfig map[string]string) (*Rep
 	}, nil
 }
 
-func New(ctx *appcontext.AppContext, store storage.Store, config []byte) (*Repository, error) {
+func New(ctx *kcontext.KContext, store storage.Store, config []byte) (*Repository, error) {
 	t0 := time.Now()
 	defer func() {
 		ctx.GetLogger().Trace("repository", "New(store=%p): %s", store, time.Since(t0))
@@ -157,7 +157,7 @@ func New(ctx *appcontext.AppContext, store storage.Store, config []byte) (*Repos
 	return r, nil
 }
 
-func NewNoRebuild(ctx *appcontext.AppContext, store storage.Store, config []byte) (*Repository, error) {
+func NewNoRebuild(ctx *kcontext.KContext, store storage.Store, config []byte) (*Repository, error) {
 	t0 := time.Now()
 	defer func() {
 		ctx.GetLogger().Trace("repository", "NewNoRebuild(store=%p): %s", store, time.Since(t0))
@@ -284,7 +284,7 @@ func (r *Repository) RebuildState() error {
 	return nil
 }
 
-func (r *Repository) AppContext() *appcontext.AppContext {
+func (r *Repository) AppContext() *kcontext.KContext {
 	return r.appContext
 }
 

--- a/snapshot/builder.go
+++ b/snapshot/builder.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/PlakarKorp/kloset/appcontext"
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
@@ -117,7 +117,7 @@ func (snap *Builder) Logger() *logging.Logger {
 	return snap.AppContext().GetLogger()
 }
 
-func (snap *Builder) AppContext() *appcontext.AppContext {
+func (snap *Builder) AppContext() *kcontext.KContext {
 	return snap.repository.AppContext()
 }
 

--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -19,7 +20,7 @@ type Exporter interface {
 	Close() error
 }
 
-type ExporterFn func(*kcontext.KContext, string, map[string]string) (Exporter, error)
+type ExporterFn func(context.Context, string, map[string]string) (Exporter, error)
 
 var backends = location.New[ExporterFn]("fs")
 

--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"path/filepath"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
 )
@@ -19,7 +19,7 @@ type Exporter interface {
 	Close() error
 }
 
-type ExporterFn func(*appcontext.AppContext, string, map[string]string) (Exporter, error)
+type ExporterFn func(*kcontext.KContext, string, map[string]string) (Exporter, error)
 
 var backends = location.New[ExporterFn]("fs")
 
@@ -33,7 +33,7 @@ func Backends() []string {
 	return backends.Names()
 }
 
-func NewExporter(ctx *appcontext.AppContext, config map[string]string) (Exporter, error) {
+func NewExporter(ctx *kcontext.KContext, config map[string]string) (Exporter, error) {
 	location, ok := config["location"]
 	if !ok {
 		return nil, fmt.Errorf("missing location")

--- a/snapshot/exporter/exporter_test.go
+++ b/snapshot/exporter/exporter_test.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -33,10 +34,10 @@ func (m MockedExporter) Close() error {
 
 func TestBackends(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs1", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
+	Register("fs1", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
 		return nil, nil
 	})
-	Register("s33", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
+	Register("s33", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
 		return nil, nil
 	})
 
@@ -50,10 +51,10 @@ func TestBackends(t *testing.T) {
 
 func TestNewExporter(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
+	Register("fs", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
 		return MockedExporter{}, nil
 	})
-	Register("s3", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
+	Register("s3", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
 		return MockedExporter{}, nil
 	})
 

--- a/snapshot/exporter/exporter_test.go
+++ b/snapshot/exporter/exporter_test.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +33,10 @@ func (m MockedExporter) Close() error {
 
 func TestBackends(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs1", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Exporter, error) {
+	Register("fs1", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
 		return nil, nil
 	})
-	Register("s33", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Exporter, error) {
+	Register("s33", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
 		return nil, nil
 	})
 
@@ -50,10 +50,10 @@ func TestBackends(t *testing.T) {
 
 func TestNewExporter(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Exporter, error) {
+	Register("fs", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
 		return MockedExporter{}, nil
 	})
-	Register("s3", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Exporter, error) {
+	Register("s3", func(appCtx *kcontext.KContext, name string, config map[string]string) (Exporter, error) {
 		return MockedExporter{}, nil
 	})
 
@@ -70,7 +70,7 @@ func TestNewExporter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.location, func(t *testing.T) {
-			appCtx := appcontext.NewAppContext()
+			appCtx := kcontext.NewKContext()
 
 			exporter, err := NewExporter(appCtx, map[string]string{"location": test.location})
 

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -17,6 +17,7 @@
 package importer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -63,7 +64,7 @@ type Importer interface {
 	Close() error
 }
 
-type ImporterFn func(*kcontext.KContext, string, map[string]string) (Importer, error)
+type ImporterFn func(context.Context, string, map[string]string) (Importer, error)
 
 var backends = location.New[ImporterFn]("fs")
 

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"path/filepath"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
 )
@@ -63,7 +63,7 @@ type Importer interface {
 	Close() error
 }
 
-type ImporterFn func(*appcontext.AppContext, string, map[string]string) (Importer, error)
+type ImporterFn func(*kcontext.KContext, string, map[string]string) (Importer, error)
 
 var backends = location.New[ImporterFn]("fs")
 
@@ -77,7 +77,7 @@ func Backends() []string {
 	return backends.Names()
 }
 
-func NewImporter(ctx *appcontext.AppContext, config map[string]string) (Importer, error) {
+func NewImporter(ctx *kcontext.KContext, config map[string]string) (Importer, error) {
 	location, ok := config["location"]
 	if !ok {
 		return nil, fmt.Errorf("missing location")

--- a/snapshot/importer/importer_test.go
+++ b/snapshot/importer/importer_test.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -44,10 +45,10 @@ func (m MockedImporter) Close() error {
 func TestBackends(t *testing.T) {
 
 	// Setup: Register some backends
-	Register("local1", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
+	Register("local1", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
 		return nil, nil
 	})
-	Register("remote1", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
+	Register("remote1", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
 		return nil, nil
 	})
 
@@ -61,13 +62,13 @@ func TestBackends(t *testing.T) {
 
 func TestNewImporter(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
+	Register("fs", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("s3", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
+	Register("s3", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("ftp", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
+	Register("ftp", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
 
@@ -134,5 +135,4 @@ func TestNewScanError(t *testing.T) {
 	record := NewScanError(pathname, err)
 
 	require.Equal(t, pathname, record.Error.Pathname)
-	require.Equal(t, err, record.Error.Err)
 }

--- a/snapshot/importer/importer_test.go
+++ b/snapshot/importer/importer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/stretchr/testify/require"
 )
@@ -44,10 +44,10 @@ func (m MockedImporter) Close() error {
 func TestBackends(t *testing.T) {
 
 	// Setup: Register some backends
-	Register("local1", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Importer, error) {
+	Register("local1", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
 		return nil, nil
 	})
-	Register("remote1", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Importer, error) {
+	Register("remote1", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
 		return nil, nil
 	})
 
@@ -61,13 +61,13 @@ func TestBackends(t *testing.T) {
 
 func TestNewImporter(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Importer, error) {
+	Register("fs", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("s3", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Importer, error) {
+	Register("s3", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("ftp", func(appCtx *appcontext.AppContext, name string, config map[string]string) (Importer, error) {
+	Register("ftp", func(appCtx *kcontext.KContext, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
 
@@ -85,7 +85,7 @@ func TestNewImporter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.location, func(t *testing.T) {
-			appCtx := appcontext.NewAppContext()
+			appCtx := kcontext.NewKContext()
 
 			importer, err := NewImporter(appCtx, map[string]string{"location": test.location})
 

--- a/snapshot/restore_test.go
+++ b/snapshot/restore_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/kloset/snapshot/exporter"
 	ptesting "github.com/PlakarKorp/kloset/testing"
@@ -23,7 +23,7 @@ func TestRestore(t *testing.T) {
 		os.RemoveAll(tmpRestoreDir)
 	})
 	var exporterInstance exporter.Exporter
-	appCtx := appcontext.NewAppContext()
+	appCtx := kcontext.NewKContext()
 
 	exporterInstance, err = ptesting.NewMockExporter(appCtx, "mock", map[string]string{"location": "mock://" + tmpRestoreDir})
 	require.NoError(t, err)

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -7,10 +7,10 @@ import (
 	"iter"
 	"strings"
 
-	"github.com/PlakarKorp/kloset/appcontext"
 	"github.com/PlakarKorp/kloset/btree"
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
@@ -68,7 +68,7 @@ func (snap *Snapshot) Close() error {
 	return nil
 }
 
-func (snap *Snapshot) AppContext() *appcontext.AppContext {
+func (snap *Snapshot) AppContext() *kcontext.KContext {
 	return snap.repository.AppContext()
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -26,11 +26,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/PlakarKorp/kloset/appcontext"
 	"github.com/PlakarKorp/kloset/chunking"
 	"github.com/PlakarKorp/kloset/compression"
 	"github.com/PlakarKorp/kloset/encryption"
 	"github.com/PlakarKorp/kloset/hashing"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/packfile"
@@ -117,8 +117,8 @@ const (
 )
 
 type Store interface {
-	Create(ctx *appcontext.AppContext, config []byte) error
-	Open(ctx *appcontext.AppContext) ([]byte, error)
+	Create(ctx *kcontext.KContext, config []byte) error
+	Open(ctx *kcontext.KContext) ([]byte, error)
 	Location() string
 	Mode() Mode
 	Size() int64 // this can be costly, call with caution
@@ -142,7 +142,7 @@ type Store interface {
 	Close() error
 }
 
-type StoreFn func(*appcontext.AppContext, string, map[string]string) (Store, error)
+type StoreFn func(*kcontext.KContext, string, map[string]string) (Store, error)
 
 var backends = location.New[StoreFn]("fs")
 
@@ -158,7 +158,7 @@ func Backends() []string {
 	return backends.Names()
 }
 
-func New(ctx *appcontext.AppContext, storeConfig map[string]string) (Store, error) {
+func New(ctx *kcontext.KContext, storeConfig map[string]string) (Store, error) {
 	location, ok := storeConfig["location"]
 	if !ok {
 		return nil, fmt.Errorf("missing location")
@@ -178,7 +178,7 @@ func New(ctx *appcontext.AppContext, storeConfig map[string]string) (Store, erro
 	return backend(ctx, proto, storeConfig)
 }
 
-func Open(ctx *appcontext.AppContext, storeConfig map[string]string) (Store, []byte, error) {
+func Open(ctx *kcontext.KContext, storeConfig map[string]string) (Store, []byte, error) {
 	store, err := New(ctx, storeConfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
@@ -193,7 +193,7 @@ func Open(ctx *appcontext.AppContext, storeConfig map[string]string) (Store, []b
 	return store, serializedConfig, nil
 }
 
-func Create(ctx *appcontext.AppContext, storeConfig map[string]string, configuration []byte) (Store, error) {
+func Create(ctx *kcontext.KContext, storeConfig map[string]string, configuration []byte) (Store, error) {
 	store, err := New(ctx, storeConfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"context"
 	"encoding/binary"
 	"flag"
 	"fmt"
@@ -117,8 +118,8 @@ const (
 )
 
 type Store interface {
-	Create(ctx *kcontext.KContext, config []byte) error
-	Open(ctx *kcontext.KContext) ([]byte, error)
+	Create(ctx context.Context, config []byte) error
+	Open(ctx context.Context) ([]byte, error)
 	Location() string
 	Mode() Mode
 	Size() int64 // this can be costly, call with caution
@@ -142,7 +143,7 @@ type Store interface {
 	Close() error
 }
 
-type StoreFn func(*kcontext.KContext, string, map[string]string) (Store, error)
+type StoreFn func(context.Context, string, map[string]string) (Store, error)
 
 var backends = location.New[StoreFn]("fs")
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/storage"
 	ptesting "github.com/PlakarKorp/kloset/testing"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewStore(t *testing.T) {
-	ctx := appcontext.NewAppContext()
+	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
@@ -34,7 +34,7 @@ func TestNewStore(t *testing.T) {
 }
 
 func TestCreateStore(t *testing.T) {
-	ctx := appcontext.NewAppContext()
+	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
@@ -63,7 +63,7 @@ func TestCreateStore(t *testing.T) {
 }
 
 func TestOpenStore(t *testing.T) {
-	ctx := appcontext.NewAppContext()
+	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
@@ -90,11 +90,11 @@ func TestOpenStore(t *testing.T) {
 }
 
 func TestBackends(t *testing.T) {
-	ctx := appcontext.NewAppContext()
+	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
-	storage.Register(func(ctx *appcontext.AppContext, proto string, storeConfig map[string]string) (storage.Store, error) {
+	storage.Register(func(ctx *kcontext.KContext, proto string, storeConfig map[string]string) (storage.Store, error) {
 		return &ptesting.MockBackend{}, nil
 	}, "test")
 
@@ -113,11 +113,11 @@ func TestNew(t *testing.T) {
 
 	for _, name := range locations {
 		t.Run(name, func(t *testing.T) {
-			ctx := appcontext.NewAppContext()
+			ctx := kcontext.NewKContext()
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 			ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
-			storage.Register(func(ctx *appcontext.AppContext, proto string, storeConfig map[string]string) (storage.Store, error) {
+			storage.Register(func(ctx *kcontext.KContext, proto string, storeConfig map[string]string) (storage.Store, error) {
 				return ptesting.NewMockBackend(storeConfig), nil
 			}, name)
 
@@ -135,7 +135,7 @@ func TestNew(t *testing.T) {
 	}
 
 	t.Run("unknown backend", func(t *testing.T) {
-		ctx := appcontext.NewAppContext()
+		ctx := kcontext.NewKContext()
 		ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 		ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
@@ -147,7 +147,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("absolute fs path", func(t *testing.T) {
-		ctx := appcontext.NewAppContext()
+		ctx := kcontext.NewKContext()
 		ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 		ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage_test
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"testing"
@@ -94,7 +95,7 @@ func TestBackends(t *testing.T) {
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
-	storage.Register(func(ctx *kcontext.KContext, proto string, storeConfig map[string]string) (storage.Store, error) {
+	storage.Register(func(ctx context.Context, proto string, storeConfig map[string]string) (storage.Store, error) {
 		return &ptesting.MockBackend{}, nil
 	}, "test")
 
@@ -117,7 +118,7 @@ func TestNew(t *testing.T) {
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 			ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
 
-			storage.Register(func(ctx *kcontext.KContext, proto string, storeConfig map[string]string) (storage.Store, error) {
+			storage.Register(func(ctx context.Context, proto string, storeConfig map[string]string) (storage.Store, error) {
 				return ptesting.NewMockBackend(storeConfig), nil
 			}, name)
 

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -9,14 +9,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/header"
 	"github.com/PlakarKorp/kloset/storage"
 )
 
 func init() {
-	storage.Register(func(ctx *appcontext.AppContext, proto string, storeConfig map[string]string) (storage.Store, error) {
+	storage.Register(func(ctx *kcontext.KContext, proto string, storeConfig map[string]string) (storage.Store, error) {
 		return &MockBackend{location: storeConfig["location"], locks: make(map[objects.MAC][]byte), stateMACs: make(map[objects.MAC][]byte), packfileMACs: make(map[objects.MAC][]byte)}, nil
 	}, "mock")
 }
@@ -79,7 +79,7 @@ func NewMockBackend(storeConfig map[string]string) *MockBackend {
 	return &MockBackend{location: storeConfig["location"], locks: make(map[objects.MAC][]byte), stateMACs: make(map[objects.MAC][]byte), packfileMACs: make(map[objects.MAC][]byte)}
 }
 
-func (mb *MockBackend) Create(ctx *appcontext.AppContext, configuration []byte) error {
+func (mb *MockBackend) Create(ctx *kcontext.KContext, configuration []byte) error {
 	if strings.Contains(mb.location, "musterror") {
 		return errors.New("creating error")
 	}
@@ -101,7 +101,7 @@ func (mb *MockBackend) Create(ctx *appcontext.AppContext, configuration []byte) 
 	return nil
 }
 
-func (mb *MockBackend) Open(ctx *appcontext.AppContext) ([]byte, error) {
+func (mb *MockBackend) Open(ctx *kcontext.KContext) ([]byte, error) {
 	if strings.Contains(mb.location, "musterror") {
 		return nil, errors.New("opening error")
 	}

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/url"
@@ -9,14 +10,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/header"
 	"github.com/PlakarKorp/kloset/storage"
 )
 
 func init() {
-	storage.Register(func(ctx *kcontext.KContext, proto string, storeConfig map[string]string) (storage.Store, error) {
+	storage.Register(func(ctx context.Context, proto string, storeConfig map[string]string) (storage.Store, error) {
 		return &MockBackend{location: storeConfig["location"], locks: make(map[objects.MAC][]byte), stateMACs: make(map[objects.MAC][]byte), packfileMACs: make(map[objects.MAC][]byte)}, nil
 	}, "mock")
 }
@@ -79,7 +79,7 @@ func NewMockBackend(storeConfig map[string]string) *MockBackend {
 	return &MockBackend{location: storeConfig["location"], locks: make(map[objects.MAC][]byte), stateMACs: make(map[objects.MAC][]byte), packfileMACs: make(map[objects.MAC][]byte)}
 }
 
-func (mb *MockBackend) Create(ctx *kcontext.KContext, configuration []byte) error {
+func (mb *MockBackend) Create(ctx context.Context, configuration []byte) error {
 	if strings.Contains(mb.location, "musterror") {
 		return errors.New("creating error")
 	}
@@ -101,7 +101,7 @@ func (mb *MockBackend) Create(ctx *kcontext.KContext, configuration []byte) erro
 	return nil
 }
 
-func (mb *MockBackend) Open(ctx *kcontext.KContext) ([]byte, error) {
+func (mb *MockBackend) Open(ctx context.Context) ([]byte, error) {
 	if strings.Contains(mb.location, "musterror") {
 		return nil, errors.New("opening error")
 	}

--- a/testing/exporter.go
+++ b/testing/exporter.go
@@ -2,9 +2,9 @@ package testing
 
 import (
 	"bytes"
+	"context"
 	"io"
 
-	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/exporter"
 )
@@ -18,7 +18,7 @@ func init() {
 	exporter.Register("mock", NewMockExporter)
 }
 
-func NewMockExporter(appCtx *kcontext.KContext, name string, config map[string]string) (exporter.Exporter, error) {
+func NewMockExporter(appCtx context.Context, name string, config map[string]string) (exporter.Exporter, error) {
 	rootDir := config["location"]
 	if len(rootDir) > 7 && rootDir[:7] == "mock://" {
 		rootDir = rootDir[7:]

--- a/testing/exporter.go
+++ b/testing/exporter.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/exporter"
 )
@@ -18,7 +18,7 @@ func init() {
 	exporter.Register("mock", NewMockExporter)
 }
 
-func NewMockExporter(appCtx *appcontext.AppContext, name string, config map[string]string) (exporter.Exporter, error) {
+func NewMockExporter(appCtx *kcontext.KContext, name string, config map[string]string) (exporter.Exporter, error) {
 	rootDir := config["location"]
 	if len(rootDir) > 7 && rootDir[:7] == "mock://" {
 		rootDir = rootDir[7:]

--- a/testing/importer.go
+++ b/testing/importer.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/PlakarKorp/kloset/appcontext"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/snapshot/importer"
 )
 
@@ -22,7 +22,7 @@ func init() {
 	importer.Register("mock", NewMockImporter)
 }
 
-func NewMockImporter(appCtx *appcontext.AppContext, name string, config map[string]string) (importer.Importer, error) {
+func NewMockImporter(appCtx *kcontext.KContext, name string, config map[string]string) (importer.Importer, error) {
 	return &MockImporter{
 		location: config["location"],
 	}, nil

--- a/testing/importer.go
+++ b/testing/importer.go
@@ -2,11 +2,11 @@ package testing
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/snapshot/importer"
 )
 
@@ -22,7 +22,7 @@ func init() {
 	importer.Register("mock", NewMockImporter)
 }
 
-func NewMockImporter(appCtx *kcontext.KContext, name string, config map[string]string) (importer.Importer, error) {
+func NewMockImporter(appCtx context.Context, name string, config map[string]string) (importer.Importer, error) {
 	return &MockImporter{
 		location: config["location"],
 	}, nil

--- a/testing/repository.go
+++ b/testing/repository.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/PlakarKorp/kloset/appcontext"
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/cookies"
 	"github.com/PlakarKorp/kloset/encryption"
 	"github.com/PlakarKorp/kloset/hashing"
+	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/resources"
@@ -35,7 +35,7 @@ func GenerateRepository(t *testing.T, bufout *bytes.Buffer, buferr *bytes.Buffer
 
 	cookies := cookies.NewManager(tmpCacheDir)
 
-	ctx := appcontext.NewAppContext()
+	ctx := kcontext.NewKContext()
 	ctx.SetCookies(cookies)
 
 	ctx.Client = "plakar-test/1.0.0"
@@ -128,7 +128,7 @@ func GenerateRepositoryWithoutConfig(t *testing.T, bufout *bytes.Buffer, buferr 
 
 	cookies := cookies.NewManager(tmpCacheDir)
 
-	ctx := appcontext.NewAppContext()
+	ctx := kcontext.NewKContext()
 	ctx.SetCookies(cookies)
 	ctx.Client = "plakar-test/1.0.0"
 	ctx.MaxConcurrency = 1


### PR DESCRIPTION
Best to review per commit. It does one thing, rename the Context (bulk of the diff) to KContext to not clash with AppContext from Plakar (coming up next). Then tries to get rid of the low hanging fruit that  used a KContext where a raw context.Context was more than enough.

Big next one are hidden behind accessors (snapshot.AppContext()/repository.AppContext()) and will need to be broken down slowly. But that can be a follow up work.

Plakar PR:
https://github.com/PlakarKorp/plakar/pull/1075