### PR TITLE
repository: make a few method private

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -138,7 +138,7 @@ func New(ctx *kcontext.KContext, store storage.Store, config []byte) (*Repositor
 	}
 
 	r.macHasherPool = NewHasherPool(func() hash.Hash {
-		hasher := r.getMACHasher()
+		hasher := r.GetMACHasher()
 		hasher.Reset()
 		return hasher
 	})
@@ -193,7 +193,7 @@ func NewNoRebuild(ctx *kcontext.KContext, store storage.Store, config []byte) (*
 		storageSizeDirty: true,
 	}
 	r.macHasherPool = NewHasherPool(func() hash.Hash {
-		hasher := r.getMACHasher()
+		hasher := r.GetMACHasher()
 		hasher.Reset()
 		return hasher
 	})
@@ -392,18 +392,6 @@ func (r *Repository) EncodeBuffer(buffer []byte) ([]byte, error) {
 		return nil, err
 	}
 	return io.ReadAll(rd)
-}
-
-func (r *Repository) getMACHasher() hash.Hash {
-	secret := r.AppContext().GetSecret()
-	if secret == nil {
-		// unencrypted repo, derive 32-bytes "secret" from RepositoryID
-		// so ComputeMAC can be used similarly to encrypted repos
-		hasher := hashing.GetHasher(r.Configuration().Hashing.Algorithm)
-		hasher.Write(r.configuration.RepositoryID[:])
-		secret = hasher.Sum(nil)
-	}
-	return hashing.GetMACHasher(r.Configuration().Hashing.Algorithm, secret)
 }
 
 func (r *Repository) GetMACHasher() hash.Hash {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -316,10 +316,10 @@ func (r *Repository) Close() error {
 	return nil
 }
 
-func (r *Repository) Decode(input io.Reader) (io.Reader, error) {
+func (r *Repository) decode(input io.Reader) (io.Reader, error) {
 	t0 := time.Now()
 	defer func() {
-		r.Logger().Trace("repository", "Decode: %s", time.Since(t0))
+		r.Logger().Trace("repository", "decode: %s", time.Since(t0))
 	}()
 
 	stream := input
@@ -368,13 +368,13 @@ func (r *Repository) Encode(input io.Reader) (io.Reader, error) {
 	return stream, nil
 }
 
-func (r *Repository) DecodeBuffer(buffer []byte) ([]byte, error) {
+func (r *Repository) decodeBuffer(buffer []byte) ([]byte, error) {
 	t0 := time.Now()
 	defer func() {
-		r.Logger().Trace("repository", "Decode(%d bytes): %s", len(buffer), time.Since(t0))
+		r.Logger().Trace("repository", "decode(%d bytes): %s", len(buffer), time.Since(t0))
 	}()
 
-	rd, err := r.Decode(bytes.NewBuffer(buffer))
+	rd, err := r.decode(bytes.NewBuffer(buffer))
 	if err != nil {
 		return nil, err
 	}
@@ -541,7 +541,7 @@ func (r *Repository) GetState(mac objects.MAC) (versioning.Version, io.Reader, e
 		return versioning.Version(0), nil, err
 	}
 
-	rd, err = r.Decode(rd)
+	rd, err = r.decode(rd)
 	if err != nil {
 		return versioning.Version(0), nil, err
 	}
@@ -616,7 +616,7 @@ func (r *Repository) GetPackfile(mac objects.MAC) (*packfile.PackFile, error) {
 	footerbuf := rawPackfile[len(rawPackfile)-int(footerBufLength):]
 	rawPackfile = rawPackfile[:len(rawPackfile)-int(footerBufLength)]
 
-	footerbuf, err = r.DecodeBuffer(footerbuf)
+	footerbuf, err = r.decodeBuffer(footerbuf)
 	if err != nil {
 		return nil, err
 	}
@@ -629,7 +629,7 @@ func (r *Repository) GetPackfile(mac objects.MAC) (*packfile.PackFile, error) {
 	indexbuf := rawPackfile[int(footer.IndexOffset):]
 	rawPackfile = rawPackfile[:int(footer.IndexOffset)]
 
-	indexbuf, err = r.DecodeBuffer(indexbuf)
+	indexbuf, err = r.decodeBuffer(indexbuf)
 	if err != nil {
 		return nil, err
 	}
@@ -726,7 +726,7 @@ func (r *Repository) GetPackfileBlob(loc state.Location) (io.ReadSeeker, error) 
 	// discard the last lengthDelta bytes
 	data = data[:length]
 
-	decoded, err := r.DecodeBuffer(data)
+	decoded, err := r.decodeBuffer(data)
 	if err != nil {
 		return nil, err
 	}
@@ -954,7 +954,7 @@ func (r *Repository) GetLock(lockID objects.MAC) (versioning.Version, io.Reader,
 		return versioning.Version(0), nil, err
 	}
 
-	rd, err = r.Decode(rd)
+	rd, err = r.decode(rd)
 	if err != nil {
 		return versioning.Version(0), nil, err
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -342,7 +342,7 @@ func (r *Repository) decode(input io.Reader) (io.Reader, error) {
 	return stream, nil
 }
 
-func (r *Repository) Encode(input io.Reader) (io.Reader, error) {
+func (r *Repository) encode(input io.Reader) (io.Reader, error) {
 	t0 := time.Now()
 	defer func() {
 		r.Logger().Trace("repository", "Encode: %s", time.Since(t0))
@@ -381,13 +381,13 @@ func (r *Repository) decodeBuffer(buffer []byte) ([]byte, error) {
 	return io.ReadAll(rd)
 }
 
-func (r *Repository) EncodeBuffer(buffer []byte) ([]byte, error) {
+func (r *Repository) encodeBuffer(buffer []byte) ([]byte, error) {
 	t0 := time.Now()
 	defer func() {
 		r.Logger().Trace("repository", "Encode(%d): %s", len(buffer), time.Since(t0))
 	}()
 
-	rd, err := r.Encode(bytes.NewBuffer(buffer))
+	rd, err := r.encode(bytes.NewBuffer(buffer))
 	if err != nil {
 		return nil, err
 	}
@@ -542,7 +542,7 @@ func (r *Repository) PutState(mac objects.MAC, rd io.Reader) error {
 		r.Logger().Trace("repository", "PutState(%x, ...): %s", mac, time.Since(t0))
 	}()
 
-	rd, err := r.Encode(rd)
+	rd, err := r.encode(rd)
 	if err != nil {
 		return err
 	}
@@ -955,7 +955,7 @@ func (r *Repository) PutLock(lockID objects.MAC, rd io.Reader) (int64, error) {
 		r.Logger().Trace("repository", "PutLock(%x, ...): %s", lockID, time.Since(t0))
 	}()
 
-	rd, err := r.Encode(rd)
+	rd, err := r.encode(rd)
 	if err != nil {
 		return 0, err
 	}

--- a/repository/repositorywriter.go
+++ b/repository/repositorywriter.go
@@ -49,9 +49,9 @@ func (r *Repository) newRepositoryWriter(cache *caching.ScanCache, id objects.MA
 
 	switch typ {
 	case PtarType:
-		rw.PackerManager, _ = packer.NewPlatarPackerManager(rw.AppContext(), &rw.configuration, rw.Encode, rw.GetMACHasher, rw.PutPtarPackfile)
+		rw.PackerManager, _ = packer.NewPlatarPackerManager(rw.AppContext(), &rw.configuration, rw.encode, rw.GetMACHasher, rw.PutPtarPackfile)
 	default:
-		rw.PackerManager = packer.NewPackerManager(rw.AppContext(), &rw.configuration, rw.Encode, rw.GetMACHasher, rw.PutPackfile)
+		rw.PackerManager = packer.NewPackerManager(rw.AppContext(), &rw.configuration, rw.encode, rw.GetMACHasher, rw.PutPackfile)
 	}
 
 	// XXX: Better placement for this
@@ -179,12 +179,12 @@ func (r *RepositoryWriter) PutPackfile(pfile *packfile.PackFile) error {
 		return fmt.Errorf("could not serialize pack file footer %s", err.Error())
 	}
 
-	encryptedIndex, err := r.EncodeBuffer(serializedIndex)
+	encryptedIndex, err := r.encodeBuffer(serializedIndex)
 	if err != nil {
 		return err
 	}
 
-	encryptedFooter, err := r.EncodeBuffer(serializedFooter)
+	encryptedFooter, err := r.encodeBuffer(serializedFooter)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
These are not used outside of the repository so might as well just be private.

While here, dedup `GetMacHasher`, we can get by with just a single version of it :)