### PR TITLE
importer: add ImporterOptions

### DIFF
--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -72,7 +72,18 @@ type Importer interface {
 	Close() error
 }
 
-type ImporterFn func(context.Context, string, map[string]string) (Importer, error)
+type ImporterOptions struct {
+	Hostname        string
+	OperatingSystem string
+	Architecture    string
+	CWD             string
+	MaxConcurrency  int
+
+	Stdout io.Writer `msgpack:"-"`
+	Stderr io.Writer `msgpack:"-"`
+}
+
+type ImporterFn func(context.Context, *ImporterOptions, string, map[string]string) (Importer, error)
 
 var backends = location.New[ImporterFn]("fs")
 
@@ -86,7 +97,7 @@ func Backends() []string {
 	return backends.Names()
 }
 
-func NewImporter(ctx *kcontext.KContext, config map[string]string) (Importer, error) {
+func NewImporter(ctx *kcontext.KContext, opts *ImporterOptions, config map[string]string) (Importer, error) {
 	location, ok := config["location"]
 	if !ok {
 		return nil, fmt.Errorf("missing location")
@@ -103,7 +114,7 @@ func NewImporter(ctx *kcontext.KContext, config map[string]string) (Importer, er
 	} else {
 		config["location"] = proto + "://" + location
 	}
-	return backend(ctx, proto, config)
+	return backend(ctx, opts, proto, config)
 }
 
 func NewScanRecord(pathname, target string, fileinfo objects.FileInfo, xattr []string, read func() (io.ReadCloser, error)) *ScanResult {

--- a/snapshot/importer/importer_test.go
+++ b/snapshot/importer/importer_test.go
@@ -45,10 +45,10 @@ func (m MockedImporter) Close() error {
 func TestBackends(t *testing.T) {
 
 	// Setup: Register some backends
-	Register("local1", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
+	Register("local1", func(appCtx context.Context, opts *ImporterOptions, name string, config map[string]string) (Importer, error) {
 		return nil, nil
 	})
-	Register("remote1", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
+	Register("remote1", func(appCtx context.Context, opts *ImporterOptions, name string, config map[string]string) (Importer, error) {
 		return nil, nil
 	})
 
@@ -62,13 +62,13 @@ func TestBackends(t *testing.T) {
 
 func TestNewImporter(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
+	Register("fs", func(appCtx context.Context, opts *ImporterOptions, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("s3", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
+	Register("s3", func(appCtx context.Context, opts *ImporterOptions, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("ftp", func(appCtx context.Context, name string, config map[string]string) (Importer, error) {
+	Register("ftp", func(appCtx context.Context, opts *ImporterOptions, name string, config map[string]string) (Importer, error) {
 		return MockedImporter{}, nil
 	})
 
@@ -88,7 +88,7 @@ func TestNewImporter(t *testing.T) {
 		t.Run(test.location, func(t *testing.T) {
 			appCtx := kcontext.NewKContext()
 
-			importer, err := NewImporter(appCtx, map[string]string{"location": test.location})
+			importer, err := NewImporter(appCtx, nil, map[string]string{"location": test.location})
 
 			if test.expectedError != "" {
 				require.Error(t, err)

--- a/testing/importer.go
+++ b/testing/importer.go
@@ -18,7 +18,7 @@ func init() {
 	importer.Register("mock", NewMockImporter)
 }
 
-func NewMockImporter(appCtx context.Context, name string, config map[string]string) (importer.Importer, error) {
+func NewMockImporter(appCtx context.Context, opts *importer.ImporterOptions, name string, config map[string]string) (importer.Importer, error) {
 	return &MockImporter{
 		location: config["location"],
 	}, nil

--- a/testing/snapshot.go
+++ b/testing/snapshot.go
@@ -129,7 +129,8 @@ func GenerateSnapshot(t *testing.T, repo *repository.Repository, files []MockFil
 	require.NoError(t, err)
 	require.NotNil(t, builder)
 
-	imp, err := NewMockImporter(repo.AppContext(), "mock", map[string]string{"location": "mock://place"})
+	imp, err := NewMockImporter(repo.AppContext(), &importer.ImporterOptions{},
+		"mock", map[string]string{"location": "mock://place"})
 	require.NoError(t, err)
 	require.NotNil(t, imp)
 


### PR DESCRIPTION
We need to pass some general information to the importer, so introduce ImporterOptions.  As of now, only Hostname is really used, but soon the stdio importer will use opts.Stdin (to add) and other importers could use MaxConcurrency or things like that.

CWD will also be needed by Filesystem, ptar and sqlite (at least.)

Passing also some runtime.* params is useful for when we'll have remote plugins.