### PR TITLE
exporter: introduce options

### DIFF
--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -12,6 +12,13 @@ import (
 	"github.com/PlakarKorp/kloset/objects"
 )
 
+type Options struct {
+	MaxConcurrency uint64
+
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
 type Exporter interface {
 	Root() string
 	CreateDirectory(pathname string) error
@@ -20,7 +27,7 @@ type Exporter interface {
 	Close() error
 }
 
-type ExporterFn func(context.Context, string, map[string]string) (Exporter, error)
+type ExporterFn func(context.Context, *Options, string, map[string]string) (Exporter, error)
 
 var backends = location.New[ExporterFn]("fs")
 
@@ -52,5 +59,11 @@ func NewExporter(ctx *kcontext.KContext, config map[string]string) (Exporter, er
 		config["location"] = proto + "://" + location
 	}
 
-	return backend(ctx, proto, config)
+	opts := &Options{
+		MaxConcurrency: uint64(ctx.MaxConcurrency),
+		Stdout:         ctx.Stdout,
+		Stderr:         ctx.Stderr,
+	}
+
+	return backend(ctx, opts, proto, config)
 }

--- a/snapshot/exporter/exporter_test.go
+++ b/snapshot/exporter/exporter_test.go
@@ -34,10 +34,10 @@ func (m MockedExporter) Close() error {
 
 func TestBackends(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs1", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
+	Register("fs1", func(appCtx context.Context, opts *Options, name string, config map[string]string) (Exporter, error) {
 		return nil, nil
 	})
-	Register("s33", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
+	Register("s33", func(appCtx context.Context, opts *Options, name string, config map[string]string) (Exporter, error) {
 		return nil, nil
 	})
 
@@ -51,10 +51,10 @@ func TestBackends(t *testing.T) {
 
 func TestNewExporter(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
+	Register("fs", func(appCtx context.Context, opts *Options, name string, config map[string]string) (Exporter, error) {
 		return MockedExporter{}, nil
 	})
-	Register("s3", func(appCtx context.Context, name string, config map[string]string) (Exporter, error) {
+	Register("s3", func(appCtx context.Context, opts *Options, name string, config map[string]string) (Exporter, error) {
 		return MockedExporter{}, nil
 	})
 

--- a/snapshot/restore_test.go
+++ b/snapshot/restore_test.go
@@ -1,12 +1,12 @@
 package snapshot_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 
-	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/kloset/snapshot/exporter"
 	ptesting "github.com/PlakarKorp/kloset/testing"
@@ -23,9 +23,9 @@ func TestRestore(t *testing.T) {
 		os.RemoveAll(tmpRestoreDir)
 	})
 	var exporterInstance exporter.Exporter
-	appCtx := kcontext.NewKContext()
 
-	exporterInstance, err = ptesting.NewMockExporter(appCtx, "mock", map[string]string{"location": "mock://" + tmpRestoreDir})
+	ctx := context.Background()
+	exporterInstance, err = ptesting.NewMockExporter(ctx, nil, "mock", map[string]string{"location": "mock://" + tmpRestoreDir})
 	require.NoError(t, err)
 	defer exporterInstance.Close()
 

--- a/testing/exporter.go
+++ b/testing/exporter.go
@@ -18,7 +18,7 @@ func init() {
 	exporter.Register("mock", NewMockExporter)
 }
 
-func NewMockExporter(appCtx context.Context, name string, config map[string]string) (exporter.Exporter, error) {
+func NewMockExporter(appCtx context.Context, opt *exporter.Options, name string, config map[string]string) (exporter.Exporter, error) {
 	rootDir := config["location"]
 	if len(rootDir) > 7 && rootDir[:7] == "mock://" {
 		rootDir = rootDir[7:]


### PR DESCRIPTION
We need to pass some bits of information down to the exporter, like stdin/out/err, and maybe even other things in the future.