### PR TITLE
repository: don't close the storage in Inexistent

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -92,7 +92,6 @@ func Inexistent(ctx *kcontext.KContext, storeConfig map[string]string) (*Reposit
 	if err != nil {
 		return nil, err
 	}
-	defer st.Close()
 
 	return &Repository{
 		store:            st,


### PR DESCRIPTION
We need Inexistent just to access the store so it cannot be closed, otherwise the repository might not work.