### PR TITLE
caching/vfs: Support deletion of the cache dir.

### DIFF
--- a/caching/caching.go
+++ b/caching/caching.go
@@ -68,7 +68,7 @@ func (m *Manager) Close() error {
 	return nil
 }
 
-func (m *Manager) VFS(repositoryID uuid.UUID, scheme string, origin string) (*VFSCache, error) {
+func (m *Manager) VFS(repositoryID uuid.UUID, scheme string, origin string, deleteOnClose bool) (*VFSCache, error) {
 	if m.closed.Load() {
 		return nil, ErrClosed
 	}
@@ -82,7 +82,7 @@ func (m *Manager) VFS(repositoryID uuid.UUID, scheme string, origin string) (*VF
 		return cache, nil
 	}
 
-	if cache, err := newVFSCache(m, repositoryID, scheme, origin); err != nil {
+	if cache, err := newVFSCache(m, repositoryID, scheme, origin, deleteOnClose); err != nil {
 		return nil, err
 	} else {
 		m.vfsCache[key] = cache

--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -33,7 +33,7 @@ func TestManagerClose(t *testing.T) {
 	_, err = manager.Repository(repoID)
 	require.Equal(t, ErrClosed, err)
 
-	_, err = manager.VFS(repoID, "test", "origin")
+	_, err = manager.VFS(repoID, "test", "origin", false)
 	require.Equal(t, ErrClosed, err)
 
 	_, err = manager.Maintenance(repoID)
@@ -68,12 +68,12 @@ func TestManagerVFS(t *testing.T) {
 	origin := "test-origin"
 
 	// Test getting a new VFS cache
-	vfsCache, err := manager.VFS(repoID, scheme, origin)
+	vfsCache, err := manager.VFS(repoID, scheme, origin, false)
 	require.NoError(t, err)
 	require.NotNil(t, vfsCache)
 
 	// Test getting the same VFS cache again (should return cached instance)
-	vfsCache2, err := manager.VFS(repoID, scheme, origin)
+	vfsCache2, err := manager.VFS(repoID, scheme, origin, false)
 	require.NoError(t, err)
 	require.Equal(t, vfsCache, vfsCache2)
 }

--- a/caching/vfs_test.go
+++ b/caching/vfs_test.go
@@ -17,7 +17,7 @@ func TestVFSCache(t *testing.T) {
 	repoID := uuid.New()
 	scheme := "test"
 	origin := "test-origin"
-	cache, err := newVFSCache(manager, repoID, scheme, origin)
+	cache, err := newVFSCache(manager, repoID, scheme, origin, false)
 	require.NoError(t, err)
 	defer cache.Close()
 

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -46,12 +46,13 @@ type BackupContext struct {
 }
 
 type BackupOptions struct {
-	MaxConcurrency uint64
-	Name           string
-	Tags           []string
-	Excludes       []glob.Glob
-	NoCheckpoint   bool
-	NoCommit       bool
+	MaxConcurrency  uint64
+	Name            string
+	Tags            []string
+	Excludes        []glob.Glob
+	NoCheckpoint    bool
+	NoCommit        bool
+	CleanupVFSCache bool
 }
 
 func (bc *BackupContext) recordEntry(entry *vfs.Entry) error {
@@ -563,7 +564,7 @@ func (snap *Builder) prepareBackup(imp importer.Importer, backupOpts *BackupOpti
 		maxConcurrency = uint64(snap.AppContext().MaxConcurrency)
 	}
 
-	vfsCache, err := snap.AppContext().GetCache().VFS(snap.repository.Configuration().RepositoryID, imp.Type(), imp.Origin())
+	vfsCache, err := snap.AppContext().GetCache().VFS(snap.repository.Configuration().RepositoryID, imp.Type(), imp.Origin(), backupOpts.CleanupVFSCache)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Since the VFS cache is auto closed by the manager, add a creation time toggle to tell the cache to unlink it's dir upon close.

* Will be used for one-time klosets (like ptar).