### PR TITLE
vfs: Do not return -1 on Read error.

### DIFF
--- a/snapshot/vfs/reader.go
+++ b/snapshot/vfs/reader.go
@@ -33,7 +33,7 @@ func (or *ObjectReader) Read(p []byte) (int, error) {
 			rd, err := or.repo.GetBlob(resources.RT_CHUNK,
 				or.object.Chunks[or.objoff].ContentMAC)
 			if err != nil {
-				return -1, err
+				return 0, err
 			}
 			or.rd = rd
 		}


### PR DESCRIPTION
* The specs says you Read() should return 0 <= n <= len(p), we can't return -1.

* This would panic on a failed GetBlob deep inside the chains of Readers for compression/encryption.