### PR TITLE
packer: Provide a new "seq" packer strategy.

### DIFF
--- a/repository/packer/packer_seq.go
+++ b/repository/packer/packer_seq.go
@@ -8,7 +8,7 @@ import (
 	"hash"
 	"io"
 	"math/big"
-	"runtime"
+	randv2 "math/rand/v2"
 	"sync"
 	"time"
 
@@ -22,58 +22,54 @@ import (
 	"github.com/PlakarKorp/kloset/versioning"
 )
 
-func init() {
-	// used for padding random bytes
-	versioning.Register(resources.RT_RANDOM, versioning.FromString("1.0.0"))
-}
-
-type PackerManagerInt interface {
-	Run() error
-	Wait()
-	InsertIfNotPresent(Type resources.Type, mac objects.MAC) (bool, error)
-	Put(hint int, Type resources.Type, mac objects.MAC, data []byte) error
-	Exists(Type resources.Type, mac objects.MAC) (bool, error)
-}
-
-type packerManager struct {
+type seqPackerManager struct {
 	inflightMACs   map[resources.Type]*sync.Map
-	packerChan     chan PackerMsg
+	packerChan     []chan PackerMsg
 	packerChanDone chan struct{}
 
 	storageConf  *storage.Configuration
 	encodingFunc func(io.Reader) (io.Reader, error)
 	hashFactory  func() hash.Hash
 	appCtx       *kcontext.KContext
+	nChan        int
 
 	// XXX: Temporary hack callback-based to ease the transition diff.
 	// To be revisited with either an interface or moving this file inside repository/
 	flush func(*packfile.PackFile) error
 }
 
-func NewPackerManager(ctx *kcontext.KContext, storageConfiguration *storage.Configuration, encodingFunc func(io.Reader) (io.Reader, error), hashFactory func() hash.Hash, flusher func(*packfile.PackFile) error) PackerManagerInt {
+func NewSeqPackerManager(ctx *kcontext.KContext, maxConcurrency int, storageConfiguration *storage.Configuration, encodingFunc func(io.Reader) (io.Reader, error), hashFactory func() hash.Hash, flusher func(*packfile.PackFile) error) PackerManagerInt {
 	inflightsMACs := make(map[resources.Type]*sync.Map)
 	for _, Type := range resources.Types() {
 		inflightsMACs[Type] = &sync.Map{}
 	}
-	return &packerManager{
+
+	// VFS entries dedicated channel
+	nChan := maxConcurrency + 1
+	ret := &seqPackerManager{
 		inflightMACs:   inflightsMACs,
-		packerChan:     make(chan PackerMsg, runtime.NumCPU()*2+1),
+		packerChan:     make([]chan PackerMsg, nChan),
 		packerChanDone: make(chan struct{}),
 		storageConf:    storageConfiguration,
 		encodingFunc:   encodingFunc,
 		hashFactory:    hashFactory,
 		appCtx:         ctx,
 		flush:          flusher,
+		nChan:          nChan,
 	}
+
+	for i := range nChan {
+		ret.packerChan[i] = make(chan PackerMsg)
+	}
+
+	return ret
 }
 
-func (mgr *packerManager) Run() error {
-	concurrency := runtime.NumCPU()*2 + 1
-
-	packerResultChan := make(chan *packfile.PackFile, concurrency)
+func (mgr *seqPackerManager) Run() error {
+	packerResultChan := make(chan *packfile.PackFile, mgr.nChan)
 
 	flusherGroup, _ := errgroup.WithContext(context.TODO())
-	for range concurrency {
+	for range mgr.nChan {
 		flusherGroup.Go(func() error {
 			for pfile := range packerResultChan {
 				if pfile == nil || pfile.Size() == 0 {
@@ -103,7 +99,7 @@ func (mgr *packerManager) Run() error {
 	// pipeline and as such we might have valid packerManager.Put() happening
 	// while this background task was ripped under our feet.
 	workerGroup, workerCtx := errgroup.WithContext(context.TODO())
-	for range concurrency {
+	for i := range mgr.nChan {
 		workerGroup.Go(func() error {
 			var pfile *packfile.PackFile
 
@@ -111,7 +107,7 @@ func (mgr *packerManager) Run() error {
 				select {
 				case <-workerCtx.Done():
 					return workerCtx.Err()
-				case pm, ok := <-mgr.packerChan:
+				case pm, ok := <-mgr.packerChan[i]:
 					if !ok {
 						if pfile != nil && pfile.Size() > 0 {
 							packerResultChan <- pfile
@@ -152,12 +148,15 @@ func (mgr *packerManager) Run() error {
 	return nil
 }
 
-func (mgr *packerManager) Wait() {
-	close(mgr.packerChan)
+func (mgr *seqPackerManager) Wait() {
+	for i := range mgr.nChan {
+		close(mgr.packerChan[i])
+	}
+
 	<-mgr.packerChanDone
 }
 
-func (mgr *packerManager) InsertIfNotPresent(Type resources.Type, mac objects.MAC) (bool, error) {
+func (mgr *seqPackerManager) InsertIfNotPresent(Type resources.Type, mac objects.MAC) (bool, error) {
 	if _, exists := mgr.inflightMACs[Type].LoadOrStore(mac, struct{}{}); exists {
 		// tell prom exporter that we collided a blob
 		return true, nil
@@ -166,7 +165,7 @@ func (mgr *packerManager) InsertIfNotPresent(Type resources.Type, mac objects.MA
 	return false, nil
 }
 
-func (mgr *packerManager) Put(_ int, Type resources.Type, mac objects.MAC, data []byte) error {
+func (mgr *seqPackerManager) Put(hint int, Type resources.Type, mac objects.MAC, data []byte) error {
 	if encodedReader, err := mgr.encodingFunc(bytes.NewReader(data)); err != nil {
 		return err
 	} else {
@@ -175,12 +174,22 @@ func (mgr *packerManager) Put(_ int, Type resources.Type, mac objects.MAC, data 
 			return err
 		}
 
-		mgr.packerChan <- PackerMsg{Type: Type, Version: versioning.GetCurrentVersion(Type), Timestamp: time.Now(), MAC: mac, Data: encoded}
+		if Type != resources.RT_OBJECT && Type != resources.RT_CHUNK {
+			mgr.packerChan[mgr.nChan-1] <- PackerMsg{Type: Type, Version: versioning.GetCurrentVersion(Type), Timestamp: time.Now(), MAC: mac, Data: encoded}
+		} else {
+			if hint == -1 {
+				mgr.packerChan[randv2.IntN(mgr.nChan-1)] <- PackerMsg{Type: Type, Version: versioning.GetCurrentVersion(Type), Timestamp: time.Now(), MAC: mac, Data: encoded}
+			} else {
+				mgr.packerChan[hint] <- PackerMsg{Type: Type, Version: versioning.GetCurrentVersion(Type), Timestamp: time.Now(), MAC: mac, Data: encoded}
+			}
+
+		}
+
 		return nil
 	}
 }
 
-func (mgr *packerManager) Exists(Type resources.Type, mac objects.MAC) (bool, error) {
+func (mgr *seqPackerManager) Exists(Type resources.Type, mac objects.MAC) (bool, error) {
 	if _, exists := mgr.inflightMACs[Type].Load(mac); exists {
 		return true, nil
 	}
@@ -188,32 +197,7 @@ func (mgr *packerManager) Exists(Type resources.Type, mac objects.MAC) (bool, er
 	return false, nil
 }
 
-type PackerMsg struct {
-	Timestamp time.Time
-	Type      resources.Type
-	Version   versioning.Version
-	MAC       objects.MAC
-	Data      []byte
-	Flags     uint32
-}
-
-type Packer struct {
-	Blobs    map[resources.Type]map[[32]byte][]byte
-	Packfile *packfile.PackFile
-}
-
-func NewPacker(hasher hash.Hash) *Packer {
-	blobs := make(map[resources.Type]map[[32]byte][]byte)
-	for _, Type := range resources.Types() {
-		blobs[Type] = make(map[[32]byte][]byte)
-	}
-	return &Packer{
-		Packfile: packfile.New(hasher),
-		Blobs:    blobs,
-	}
-}
-
-func (mgr *packerManager) AddPadding(packfile *packfile.PackFile, maxSize int) error {
+func (mgr *seqPackerManager) AddPadding(packfile *packfile.PackFile, maxSize int) error {
 	if maxSize < 0 {
 		return fmt.Errorf("invalid padding size")
 	}
@@ -241,28 +225,4 @@ func (mgr *packerManager) AddPadding(packfile *packfile.PackFile, maxSize int) e
 
 	packfile.AddBlob(resources.RT_RANDOM, versioning.GetCurrentVersion(resources.RT_RANDOM), mac, buffer, 0)
 	return nil
-}
-
-func (packer *Packer) addBlobIfNotExists(Type resources.Type, version versioning.Version, mac [32]byte, data []byte, flags uint32) bool {
-	if _, ok := packer.Blobs[Type]; !ok {
-		packer.Blobs[Type] = make(map[[32]byte][]byte)
-	}
-	if _, ok := packer.Blobs[Type][mac]; ok {
-		return false
-	}
-	packer.Blobs[Type][mac] = data
-	packer.Packfile.AddBlob(Type, version, mac, data, flags)
-	return true
-}
-
-func (packer *Packer) size() uint32 {
-	return packer.Packfile.Size()
-}
-
-func (packer *Packer) Types() []resources.Type {
-	ret := make([]resources.Type, 0, len(packer.Blobs))
-	for k := range packer.Blobs {
-		ret = append(ret, k)
-	}
-	return ret
 }

--- a/repository/packer/packer_test.go
+++ b/repository/packer/packer_test.go
@@ -121,7 +121,7 @@ func TestPackerManager_Put(t *testing.T) {
 		mac := objects.MAC{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 		data := []byte("test data")
 
-		err := mgr.Put(resources.RT_CONFIG, mac, data)
+		err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 		require.NoError(t, err)
 	})
 
@@ -130,7 +130,7 @@ func TestPackerManager_Put(t *testing.T) {
 			mac := objects.MAC{byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i)}
 			data := []byte("test data " + string(rune(i+'0')))
 
-			err := mgr.Put(resources.RT_CONFIG, mac, data)
+			err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 			require.NoError(t, err)
 		}
 	})
@@ -163,7 +163,7 @@ func TestPackerManager_RunAndWait(t *testing.T) {
 			mac := objects.MAC{byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i)}
 			data := []byte("test data " + string(rune(i+'0')))
 
-			err := mgr.Put(resources.RT_CONFIG, mac, data)
+			err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 			require.NoError(t, err)
 		}
 
@@ -203,7 +203,7 @@ func TestPackerManager_AddPadding(t *testing.T) {
 	mac := objects.MAC{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 	data := []byte("test data")
 
-	err := mgr.Put(resources.RT_CONFIG, mac, data)
+	err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 	require.NoError(t, err)
 
 	// Wait for completion
@@ -309,7 +309,7 @@ func TestPackerManager_Concurrency(t *testing.T) {
 					mac := objects.MAC{byte(goroutineID), byte(j), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 					data := []byte("test data from goroutine " + string(rune(goroutineID+'0')) + " blob " + string(rune(j+'0')))
 
-					err := mgr.Put(resources.RT_CONFIG, mac, data)
+					err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 					require.NoError(t, err)
 				}
 			}(i)
@@ -360,7 +360,7 @@ func TestPackerManager_ErrorHandling(t *testing.T) {
 		mac := objects.MAC{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 		data := []byte("test data")
 
-		err := mgr.Put(resources.RT_CONFIG, mac, data)
+		err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 		require.NoError(t, err)
 
 		// Wait for completion

--- a/repository/packer/platar.go
+++ b/repository/packer/platar.go
@@ -125,7 +125,7 @@ func (mgr *platarPackerManager) InsertIfNotPresent(Type resources.Type, mac obje
 	return false, nil
 }
 
-func (mgr *platarPackerManager) Put(Type resources.Type, mac objects.MAC, data []byte) error {
+func (mgr *platarPackerManager) Put(_ int, Type resources.Type, mac objects.MAC, data []byte) error {
 	mgr.packerChan <- &PackerMsg{Type: Type, Version: versioning.GetCurrentVersion(Type), Timestamp: time.Now(), MAC: mac, Data: data}
 	return nil
 }

--- a/repository/packer/platar_test.go
+++ b/repository/packer/platar_test.go
@@ -139,7 +139,7 @@ func TestPlatarPackerManager_Put(t *testing.T) {
 		mac := objects.MAC{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 		data := []byte("test data")
 
-		err := mgr.Put(resources.RT_CONFIG, mac, data)
+		err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 		require.NoError(t, err)
 	})
 
@@ -148,7 +148,7 @@ func TestPlatarPackerManager_Put(t *testing.T) {
 			mac := objects.MAC{byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i)}
 			data := []byte("test data " + string(rune(i+'0')))
 
-			err := mgr.Put(resources.RT_CONFIG, mac, data)
+			err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 			require.NoError(t, err)
 		}
 	})
@@ -162,7 +162,7 @@ func TestPlatarPackerManager_Put(t *testing.T) {
 		mac := objects.MAC{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 		data := []byte("test data")
 
-		err = mgrWithFailingEncoding.Put(resources.RT_CONFIG, mac, data)
+		err = mgrWithFailingEncoding.Put(0, resources.RT_CONFIG, mac, data)
 		// Do not expect an error, as Put does not return encoding errors in platar.go
 	})
 }
@@ -238,7 +238,7 @@ func TestPlatarPackerManager_RunAndWait(t *testing.T) {
 		// Add some data to process
 		mac := objects.MAC{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 		data := []byte("test data")
-		err = mgr.Put(resources.RT_CONFIG, mac, data)
+		err = mgr.Put(0, resources.RT_CONFIG, mac, data)
 		require.NoError(t, err)
 
 		// Wait for completion
@@ -289,7 +289,7 @@ func TestPlatarPackerManager_RunAndWait(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			mac := objects.MAC{byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i), byte(i)}
 			data := []byte("test data " + string(rune(i+'0')))
-			err := mgr.Put(resources.RT_CONFIG, mac, data)
+			err := mgr.Put(0, resources.RT_CONFIG, mac, data)
 			require.NoError(t, err)
 		}
 

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -120,7 +120,7 @@ func (snapshot *Builder) skipExcludedPathname(backupCtx *BackupContext, record *
 	return doExclude
 }
 
-func (snap *Builder) processRecord(backupCtx *BackupContext, record *importer.ScanResult, stats *scanStats, chunker *chunkers.Chunker) {
+func (snap *Builder) processRecord(idx int, backupCtx *BackupContext, record *importer.ScanResult, stats *scanStats, chunker *chunkers.Chunker) {
 	switch {
 	case record.Error != nil:
 		record := record.Error
@@ -158,7 +158,7 @@ func (snap *Builder) processRecord(backupCtx *BackupContext, record *importer.Sc
 		}
 
 		snap.Event(events.FileEvent(snap.Header.Identifier, record.Pathname))
-		if err := snap.processFileRecord(backupCtx, record, chunker); err != nil {
+		if err := snap.processFileRecord(idx, backupCtx, record, chunker); err != nil {
 			snap.Event(events.FileErrorEvent(snap.Header.Identifier, record.Pathname, err.Error()))
 			backupCtx.recordError(record.Pathname, err)
 		} else {
@@ -200,8 +200,9 @@ func (snap *Builder) importerJob(backupCtx *BackupContext) error {
 	snap.Event(startEvent)
 
 	var stats scanStats
-	for _, cker := range ckers {
+	for i, cker := range ckers {
 		ck := cker
+		idx := i
 		wg.Go(func() error {
 			for {
 				select {
@@ -220,7 +221,7 @@ func (snap *Builder) importerJob(backupCtx *BackupContext) error {
 						continue
 					}
 
-					snap.processRecord(backupCtx, record, &stats, ck)
+					snap.processRecord(idx, backupCtx, record, &stats, ck)
 				}
 			}
 		})
@@ -401,7 +402,7 @@ func entropy(data []byte) (float64, [256]float64) {
 	return entropy, freq
 }
 
-func (snap *Builder) chunkify(chk *chunkers.Chunker, pathname string, rd io.Reader) (*objects.Object, int64, error) {
+func (snap *Builder) chunkify(cIdx int, chk *chunkers.Chunker, pathname string, rd io.Reader) (*objects.Object, int64, error) {
 	object := objects.NewObject()
 
 	objectHasher, releaseGlobalHasher := snap.repository.GetPooledMACHasher()
@@ -446,7 +447,7 @@ func (snap *Builder) chunkify(chk *chunkers.Chunker, pathname string, rd io.Read
 		totalEntropy += chunk.Entropy * float64(len(data))
 		totalDataSize += int64(len(data))
 
-		return snap.repository.PutBlobIfNotExists(resources.RT_CHUNK, chunk.ContentMAC, data)
+		return snap.repository.PutBlobIfNotExistsWithHint(cIdx, resources.RT_CHUNK, chunk.ContentMAC, data)
 	}
 
 	chk.Reset(rd)
@@ -631,7 +632,7 @@ func (snap *Builder) prepareBackup(imp importer.Importer, backupOpts *BackupOpti
 	return backupCtx, nil
 }
 
-func (snap *Builder) processFileRecord(backupCtx *BackupContext, record *importer.ScanRecord, chunker *chunkers.Chunker) error {
+func (snap *Builder) processFileRecord(idx int, backupCtx *BackupContext, record *importer.ScanRecord, chunker *chunkers.Chunker) error {
 	vfsCache := backupCtx.vfsCache
 
 	var err error
@@ -683,7 +684,7 @@ func (snap *Builder) processFileRecord(backupCtx *BackupContext, record *importe
 
 		if object == nil || !snap.repository.BlobExists(resources.RT_OBJECT, objectMAC) {
 			var dataSize int64
-			object, dataSize, err = snap.chunkify(chunker, record.Pathname, record.Reader)
+			object, dataSize, err = snap.chunkify(idx, chunker, record.Pathname, record.Reader)
 			if err != nil {
 				return err
 			}
@@ -703,7 +704,7 @@ func (snap *Builder) processFileRecord(backupCtx *BackupContext, record *importe
 				}
 			}
 
-			if err := snap.repository.PutBlob(resources.RT_OBJECT, objectMAC, objectSerialized); err != nil {
+			if err := snap.repository.PutBlobWithHint(idx, resources.RT_OBJECT, objectMAC, objectSerialized); err != nil {
 				return err
 			}
 		}
@@ -727,7 +728,7 @@ func (snap *Builder) processFileRecord(backupCtx *BackupContext, record *importe
 		}
 
 		fileEntryMAC := snap.repository.ComputeMAC(serialized)
-		if err := snap.repository.PutBlob(resources.RT_VFS_ENTRY, fileEntryMAC, serialized); err != nil {
+		if err := snap.repository.PutBlobWithHint(idx, resources.RT_VFS_ENTRY, fileEntryMAC, serialized); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
* Introduce a new packer interface, where the caller can specify an "hint" that let's ressource get grouped together.

* Introduce a new packer strategy, the seq packer that uses the hint to group together chunks and objects, and vfs others together.

* Alone this doesn't change much, but it'll let us grab bigger ranges at once avoiding heavy round trips time on remote storage.