### PR TITLE
restore: don't reopen the entry

### DIFF
--- a/snapshot/restore.go
+++ b/snapshot/restore.go
@@ -91,7 +91,7 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 				}
 			}
 
-			rd := e.Open(vfs)
+			rd := e.Open(restoreContext.vfs)
 			defer rd.Close()
 
 			// Ensure the parent directory exists.


### PR DESCRIPTION
No need to re-traverse the VFS, we already have the entry at hand, just open its object.