### PR TITLE
update go-cdc-chunkers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/PlakarKorp/kloset
 go 1.23.3
 
 require (
-	github.com/PlakarKorp/go-cdc-chunkers v1.0.0
+	github.com/PlakarKorp/go-cdc-chunkers v1.0.1
 	github.com/cockroachdb/pebble/v2 v2.0.6
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gabriel-vasile/mimetype v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5 h1:5BIUS5
 github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5/go.mod h1:w5D10RxC0NmPYxmQ438CC1S07zaC1zpvuNW7s5sUk2Q=
 github.com/PlakarKorp/go-cdc-chunkers v1.0.0 h1:Nmu5JuQt3t0npidW7M8sCn93uRGQBiM1H7TEvJaNX0Y=
 github.com/PlakarKorp/go-cdc-chunkers v1.0.0/go.mod h1:BfBmO/foiZaqX+Iet67EHnLcLeq9ymOnYJqWzR4b/o8=
+github.com/PlakarKorp/go-cdc-chunkers v1.0.1 h1:7yNCCMxfZwVcZJ7O4TTCROm/pKTlZv5vhw/9yqt2giM=
+github.com/PlakarKorp/go-cdc-chunkers v1.0.1/go.mod h1:y7ag92JABKPBDoSOPwedssQ5NIOgjRm4Mu6yTBpmUMY=
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f h1:JjxwchlOepwsUWcQwD2mLUAGE9aCp0/ehy6yCHFBOvo=
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f/go.mod h1:tMDTce/yLLN/SK8gMOxQfnyeMeCg8KGzp0D1cbECEeo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
move to the new v1.0.1 go-cdc-chunkers package using a single factored implementation.

this has been verified to be compatible in cutpoints.