### PR TITLE
switch to IBytes

### DIFF
--- a/objects/fileinfo.go
+++ b/objects/fileinfo.go
@@ -104,7 +104,7 @@ func NewFileInfo(name string, size int64, mode os.FileMode, modTime time.Time, d
 }
 
 func (fileinfo *FileInfo) HumanSize() string {
-	return humanize.Bytes(uint64(fileinfo.Size()))
+	return humanize.IBytes(uint64(fileinfo.Size()))
 }
 
 func (fileinfo *FileInfo) Equal(fi *FileInfo) bool {

--- a/objects/fileinfo_test.go
+++ b/objects/fileinfo_test.go
@@ -167,7 +167,7 @@ func TestNewFileInfo(t *testing.T) {
 		t.Errorf("expected %#v but got %#v", reference, file)
 	}
 
-	if file.HumanSize() != "300 kB" {
+	if file.HumanSize() != "293 KiB" {
 		t.Errorf("expected %#v but got %#v", "300 kB", file.HumanSize())
 	}
 


### PR DESCRIPTION
humanize.Bytes is SI standard kB... 1000 bytes = 1 kB.

use humanize.IBytes for IEC kB where 1024 bytes = 1 kB.