### PR TITLE
connectors: Pass down a context everywhere.

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -296,12 +296,17 @@ func (r *Repository) Store() storage.Store {
 	return r.store
 }
 
-func (r *Repository) StorageSize() int64 {
+func (r *Repository) StorageSize() (int64, error) {
 	if r.storageSizeDirty {
-		r.storageSize = r.store.Size(r.appContext)
+		size, err := r.store.Size(r.appContext)
+		if err != nil {
+			return 0, err
+		}
+
+		r.storageSize = size
 		r.storageSizeDirty = false
 	}
-	return r.storageSize
+	return r.storageSize, nil
 }
 
 func (r *Repository) RBytes() int64 {
@@ -455,8 +460,8 @@ func (r *Repository) NewRepositoryWriter(cache *caching.ScanCache, id objects.MA
 	return r.newRepositoryWriter(cache, id, typ)
 }
 
-func (r *Repository) Location() string {
-	return r.store.Location()
+func (r *Repository) Location() (string, error) {
+	return r.store.Location(r.appContext)
 }
 
 func (r *Repository) Configuration() storage.Configuration {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -298,7 +298,7 @@ func (r *Repository) Store() storage.Store {
 
 func (r *Repository) StorageSize() int64 {
 	if r.storageSizeDirty {
-		r.storageSize = r.store.Size()
+		r.storageSize = r.store.Size(r.appContext)
 		r.storageSizeDirty = false
 	}
 	return r.storageSize
@@ -514,7 +514,7 @@ func (r *Repository) GetStates() ([]objects.MAC, error) {
 		r.Logger().Trace("repository", "GetStates(): %s", time.Since(t0))
 	}()
 
-	return r.store.GetStates()
+	return r.store.GetStates(r.appContext)
 }
 
 func (r *Repository) GetState(mac objects.MAC) (versioning.Version, io.ReadCloser, error) {
@@ -523,7 +523,7 @@ func (r *Repository) GetState(mac objects.MAC) (versioning.Version, io.ReadClose
 		r.Logger().Trace("repository", "GetState(%x): %s", mac, time.Since(t0))
 	}()
 
-	rd, err := r.store.GetState(mac)
+	rd, err := r.store.GetState(r.appContext, mac)
 	if err != nil {
 		return versioning.Version(0), nil, err
 	}
@@ -556,7 +556,7 @@ func (r *Repository) PutState(mac objects.MAC, rd io.Reader) error {
 		return err
 	}
 
-	nbytes, err := r.store.PutState(mac, rd)
+	nbytes, err := r.store.PutState(r.appContext, mac, rd)
 	r.wBytes.Add(nbytes)
 	return err
 }
@@ -567,7 +567,7 @@ func (r *Repository) DeleteState(mac objects.MAC) error {
 		r.Logger().Trace("repository", "DeleteState(%x, ...): %s", mac, time.Since(t0))
 	}()
 
-	return r.store.DeleteState(mac)
+	return r.store.DeleteState(r.appContext, mac)
 }
 
 func (r *Repository) GetPackfiles() ([]objects.MAC, error) {
@@ -576,7 +576,7 @@ func (r *Repository) GetPackfiles() ([]objects.MAC, error) {
 		r.Logger().Trace("repository", "GetPackfiles(): %s", time.Since(t0))
 	}()
 
-	return r.store.GetPackfiles()
+	return r.store.GetPackfiles(r.appContext)
 }
 
 func (r *Repository) GetPackfile(mac objects.MAC) (*packfile.PackFile, error) {
@@ -587,7 +587,7 @@ func (r *Repository) GetPackfile(mac objects.MAC) (*packfile.PackFile, error) {
 
 	hasher := r.GetMACHasher()
 
-	rd, err := r.store.GetPackfile(mac)
+	rd, err := r.store.GetPackfile(r.appContext, mac)
 	if err != nil {
 		return nil, err
 	}
@@ -701,7 +701,7 @@ func (r *Repository) GetPackfileBlob(loc state.Location) (io.ReadSeeker, error) 
 	lengthDelta := uint32(uint64(overhead) - offsetDelta)
 
 	realLen := length + uint32(offsetDelta) + lengthDelta
-	rd, err := r.store.GetPackfileBlob(loc.Packfile, offset+uint64(storage.STORAGE_HEADER_SIZE)-offsetDelta, realLen)
+	rd, err := r.store.GetPackfileBlob(r.appContext, loc.Packfile, offset+uint64(storage.STORAGE_HEADER_SIZE)-offsetDelta, realLen)
 	if err != nil {
 		return nil, err
 	}
@@ -732,7 +732,7 @@ func (r *Repository) DeletePackfile(mac objects.MAC) error {
 		r.Logger().Trace("repository", "DeletePackfile(%x): %s", mac, time.Since(t0))
 	}()
 
-	return r.store.DeletePackfile(mac)
+	return r.store.DeletePackfile(r.appContext, mac)
 }
 
 // Removes the packfile from the state, making it unreachable.
@@ -926,7 +926,7 @@ func (r *Repository) GetLocks() ([]objects.MAC, error) {
 		r.Logger().Trace("repository", "GetLocks(): %s", time.Since(t0))
 	}()
 
-	return r.store.GetLocks()
+	return r.store.GetLocks(r.appContext)
 }
 
 func (r *Repository) GetLock(lockID objects.MAC) (versioning.Version, io.ReadCloser, error) {
@@ -935,7 +935,7 @@ func (r *Repository) GetLock(lockID objects.MAC) (versioning.Version, io.ReadClo
 		r.Logger().Trace("repository", "GetLock(%x): %s", lockID, time.Since(t0))
 	}()
 
-	rd, err := r.store.GetLock(lockID)
+	rd, err := r.store.GetLock(r.appContext, lockID)
 	if err != nil {
 		return versioning.Version(0), nil, err
 	}
@@ -968,7 +968,7 @@ func (r *Repository) PutLock(lockID objects.MAC, rd io.Reader) (int64, error) {
 		return 0, err
 	}
 
-	return r.store.PutLock(lockID, rd)
+	return r.store.PutLock(r.appContext, lockID, rd)
 }
 
 func (r *Repository) DeleteLock(lockID objects.MAC) error {
@@ -977,5 +977,5 @@ func (r *Repository) DeleteLock(lockID objects.MAC) error {
 		r.Logger().Trace("repository", "DeleteLock(%x, ...): %s", lockID, time.Since(t0))
 	}()
 
-	return r.store.DeleteLock(lockID)
+	return r.store.DeleteLock(r.appContext, lockID)
 }

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -94,7 +94,8 @@ func TestRepository(t *testing.T) {
 	})
 
 	t.Run("StorageSize", func(t *testing.T) {
-		size := repo.StorageSize()
+		size, err := repo.StorageSize()
+		require.NoError(t, err)
 		require.GreaterOrEqual(t, size, int64(0))
 	})
 
@@ -237,7 +238,9 @@ func TestRepositoryCreation(t *testing.T) {
 		repo, err := repository.Inexistent(ctx, storeConfig)
 		require.NoError(t, err)
 		require.NotNil(t, repo)
-		require.Equal(t, int64(0), repo.StorageSize())
+		size, err := repo.StorageSize()
+		require.NoError(t, err)
+		require.Equal(t, int64(0), size)
 	})
 
 	t.Run("NewNoRebuild", func(t *testing.T) {
@@ -269,6 +272,8 @@ func TestRepositoryCreation(t *testing.T) {
 		repo, err := repository.NewNoRebuild(ctx, key, r, wrappedConfig)
 		require.NoError(t, err)
 		require.NotNil(t, repo)
-		require.Equal(t, int64(0), repo.StorageSize())
+		size, err := repo.StorageSize()
+		require.NoError(t, err)
+		require.Equal(t, int64(0), size)
 	})
 }

--- a/repository/repositorywriter.go
+++ b/repository/repositorywriter.go
@@ -204,7 +204,7 @@ func (r *RepositoryWriter) PutPackfile(pfile *packfile.PackFile) error {
 		return err
 	}
 
-	nbytes, err := r.store.PutPackfile(mac, rd)
+	nbytes, err := r.store.PutPackfile(r.appContext, mac, rd)
 	r.wBytes.Add(nbytes)
 	if err != nil {
 		return err
@@ -256,7 +256,7 @@ func (r *RepositoryWriter) PutPtarPackfile(packfile *packer.PackWriter) error {
 		return err
 	}
 
-	nbytes, err := r.store.PutPackfile(mac, rd)
+	nbytes, err := r.store.PutPackfile(r.appContext, mac, rd)
 	r.wBytes.Add(nbytes)
 	if err != nil {
 		return err

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -181,7 +181,7 @@ func (snap *Builder) importerJob(backupCtx *BackupContext) error {
 		ckers = append(ckers, cker)
 	}
 
-	scanner, err := backupCtx.imp.Scan()
+	scanner, err := backupCtx.imp.Scan(snap.AppContext())
 	if err != nil {
 		return err
 	}

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -134,7 +134,13 @@ func (snap *Builder) processRecord(backupCtx *BackupContext, record *importer.Sc
 		snap.Event(events.PathEvent(snap.Header.Identifier, record.Pathname))
 
 		// XXX: Remove this when we introduce the Location object.
-		repoLocation := snap.repository.Location()
+		repoLocation, err := snap.repository.Location()
+		if err != nil {
+			snap.Event(events.FileErrorEvent(snap.Header.Identifier, record.Pathname, err.Error()))
+			backupCtx.recordError(record.Pathname, err)
+			return
+		}
+
 		repoLocation = strings.TrimPrefix(repoLocation, "fs://")
 		repoLocation = strings.TrimPrefix(repoLocation, "ptar://")
 		if record.Pathname == repoLocation || strings.HasPrefix(record.Pathname, repoLocation+"/") {
@@ -308,12 +314,30 @@ func (snap *Builder) Backup(imp importer.Importer, options *BackupOptions) error
 	}
 	defer snap.Unlock(done)
 
-	snap.Header.GetSource(0).Importer.Origin = imp.Origin()
-	snap.Header.GetSource(0).Importer.Type = imp.Type()
+	origin, err := imp.Origin(snap.AppContext())
+	if err != nil {
+		snap.repository.PackerManager.Wait()
+		return err
+	}
+
+	typ, err := imp.Type(snap.AppContext())
+	if err != nil {
+		snap.repository.PackerManager.Wait()
+		return err
+	}
+
+	root, err := imp.Root(snap.AppContext())
+	if err != nil {
+		snap.repository.PackerManager.Wait()
+		return err
+	}
+
+	snap.Header.GetSource(0).Importer.Origin = origin
+	snap.Header.GetSource(0).Importer.Type = typ
 	snap.Header.Tags = append(snap.Header.Tags, options.Tags...)
 
 	if options.Name == "" {
-		snap.Header.Name = imp.Root() + " @ " + snap.Header.GetSource(0).Importer.Origin
+		snap.Header.Name = root + " @ " + snap.Header.GetSource(0).Importer.Origin
 	} else {
 		snap.Header.Name = options.Name
 	}
@@ -344,7 +368,7 @@ func (snap *Builder) Backup(imp importer.Importer, options *BackupOptions) error
 	}
 
 	snap.Header.Duration = time.Since(beginTime)
-	snap.Header.GetSource(0).Importer.Directory = imp.Root()
+	snap.Header.GetSource(0).Importer.Directory = root
 	snap.Header.GetSource(0).VFS = *vfsHeader
 	snap.Header.GetSource(0).Summary = *rootSummary
 	snap.Header.GetSource(0).Indexes = indexes
@@ -561,7 +585,17 @@ func (snap *Builder) prepareBackup(imp importer.Importer, backupOpts *BackupOpti
 		maxConcurrency = uint64(snap.AppContext().MaxConcurrency)
 	}
 
-	vfsCache, err := snap.AppContext().GetCache().VFS(snap.repository.Configuration().RepositoryID, imp.Type(), imp.Origin(), backupOpts.CleanupVFSCache)
+	typ, err := imp.Type(snap.AppContext())
+	if err != nil {
+		return nil, err
+	}
+
+	origin, err := imp.Origin(snap.AppContext())
+	if err != nil {
+		return nil, err
+	}
+
+	vfsCache, err := snap.AppContext().GetCache().VFS(snap.repository.Configuration().RepositoryID, typ, origin, backupOpts.CleanupVFSCache)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot/builder.go
+++ b/snapshot/builder.go
@@ -108,8 +108,13 @@ func (src *Snapshot) Fork() (*Builder, error) {
 		return nil, err
 	}
 
+	location, err := src.repository.Location()
+	if err != nil {
+		return nil, err
+	}
+
 	var packingStrategy repository.RepositoryType
-	if strings.HasPrefix(src.repository.Location(), "ptar:") {
+	if strings.HasPrefix(location, "ptar:") {
 		packingStrategy = repository.PtarType
 	} else {
 		packingStrategy = repository.DefaultType

--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -21,9 +21,9 @@ type Options struct {
 
 type Exporter interface {
 	Root() string
-	CreateDirectory(pathname string) error
-	StoreFile(pathname string, fp io.Reader, size int64) error
-	SetPermissions(pathname string, fileinfo *objects.FileInfo) error
+	CreateDirectory(ctx context.Context, pathname string) error
+	StoreFile(ctx context.Context, pathname string, fp io.Reader, size int64) error
+	SetPermissions(ctx context.Context, pathname string, fileinfo *objects.FileInfo) error
 	Close() error
 }
 

--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -20,11 +20,11 @@ type Options struct {
 }
 
 type Exporter interface {
-	Root() string
+	Root(ctx context.Context) (string, error)
 	CreateDirectory(ctx context.Context, pathname string) error
 	StoreFile(ctx context.Context, pathname string, fp io.Reader, size int64) error
 	SetPermissions(ctx context.Context, pathname string, fileinfo *objects.FileInfo) error
-	Close() error
+	Close(ctx context.Context) error
 }
 
 type ExporterFn func(context.Context, *Options, string, map[string]string) (Exporter, error)

--- a/snapshot/exporter/exporter_test.go
+++ b/snapshot/exporter/exporter_test.go
@@ -12,8 +12,8 @@ import (
 
 type MockedExporter struct{}
 
-func (m MockedExporter) Root() string {
-	return ""
+func (m MockedExporter) Root(ctx context.Context) (string, error) {
+	return "", nil
 }
 
 func (m MockedExporter) CreateDirectory(ctx context.Context, pathname string) error {
@@ -28,7 +28,7 @@ func (m MockedExporter) SetPermissions(ctx context.Context, pathname string, fil
 	return nil
 }
 
-func (m MockedExporter) Close() error {
+func (m MockedExporter) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/snapshot/exporter/exporter_test.go
+++ b/snapshot/exporter/exporter_test.go
@@ -16,15 +16,15 @@ func (m MockedExporter) Root() string {
 	return ""
 }
 
-func (m MockedExporter) CreateDirectory(pathname string) error {
+func (m MockedExporter) CreateDirectory(ctx context.Context, pathname string) error {
 	return nil
 }
 
-func (m MockedExporter) StoreFile(pathname string, fp io.Reader, size int64) error {
+func (m MockedExporter) StoreFile(ctx context.Context, pathname string, fp io.Reader, size int64) error {
 	return nil
 }
 
-func (m MockedExporter) SetPermissions(pathname string, fileinfo *objects.FileInfo) error {
+func (m MockedExporter) SetPermissions(ctx context.Context, pathname string, fileinfo *objects.FileInfo) error {
 	return nil
 }
 

--- a/snapshot/filesystem.go
+++ b/snapshot/filesystem.go
@@ -7,18 +7,25 @@ import (
 )
 
 func (s *Snapshot) Filesystem() (*vfs.Filesystem, error) {
-	if s.repository.Store().Mode()&storage.ModeRead == 0 {
+	if s.filesystem != nil {
+		return s.filesystem, nil
+	}
+
+	mode, err := s.repository.Store().Mode(s.AppContext())
+	if err != nil {
+		return nil, err
+	}
+
+	if mode&storage.ModeRead == 0 {
 		return nil, repository.ErrNotReadable
 	}
 
 	v := s.Header.GetSource(0).VFS
-
-	if s.filesystem != nil {
-		return s.filesystem, nil
-	} else if fs, err := vfs.NewFilesystem(s.repository, v.Root, v.Xattrs, v.Errors); err != nil {
+	fs, err := vfs.NewFilesystem(s.repository, v.Root, v.Xattrs, v.Errors)
+	if err != nil {
 		return nil, err
-	} else {
-		s.filesystem = fs
-		return fs, nil
 	}
+
+	s.filesystem = fs
+	return fs, nil
 }

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -68,7 +68,7 @@ type Importer interface {
 	Origin(ctx context.Context) (string, error)
 	Type(ctx context.Context) (string, error)
 	Root(ctx context.Context) (string, error)
-	Scan(context.Context) (<-chan *ScanResult, error)
+	Scan(ctx context.Context) (<-chan *ScanResult, error)
 	Close(ctx context.Context) error
 }
 

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -68,7 +68,7 @@ type Importer interface {
 	Origin() string
 	Type() string
 	Root() string
-	Scan() (<-chan *ScanResult, error)
+	Scan(context.Context) (<-chan *ScanResult, error)
 	Close() error
 }
 

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -65,11 +65,11 @@ type ScanError struct {
 }
 
 type Importer interface {
-	Origin() string
-	Type() string
-	Root() string
+	Origin(ctx context.Context) (string, error)
+	Type(ctx context.Context) (string, error)
+	Root(ctx context.Context) (string, error)
 	Scan(context.Context) (<-chan *ScanResult, error)
-	Close() error
+	Close(ctx context.Context) error
 }
 
 type Options struct {

--- a/snapshot/importer/importer_test.go
+++ b/snapshot/importer/importer_test.go
@@ -27,7 +27,7 @@ func (m MockedImporter) Root() string {
 	return ""
 }
 
-func (m MockedImporter) Scan() (<-chan *ScanResult, error) {
+func (m MockedImporter) Scan(ctx context.Context) (<-chan *ScanResult, error) {
 	return nil, nil
 }
 

--- a/snapshot/importer/importer_test.go
+++ b/snapshot/importer/importer_test.go
@@ -15,16 +15,16 @@ import (
 
 type MockedImporter struct{}
 
-func (m MockedImporter) Origin() string {
-	return ""
+func (m MockedImporter) Origin(ctx context.Context) (string, error) {
+	return "", nil
 }
 
-func (m MockedImporter) Type() string {
-	return ""
+func (m MockedImporter) Type(ctx context.Context) (string, error) {
+	return "", nil
 }
 
-func (m MockedImporter) Root() string {
-	return ""
+func (m MockedImporter) Root(ctx context.Context) (string, error) {
+	return "", nil
 }
 
 func (m MockedImporter) Scan(ctx context.Context) (<-chan *ScanResult, error) {
@@ -39,7 +39,7 @@ func (m MockedImporter) NewExtendedAttributeReader(string, string) (io.ReadClose
 	return nil, nil
 }
 
-func (m MockedImporter) Close() error {
+func (m MockedImporter) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/snapshot/restore.go
+++ b/snapshot/restore.go
@@ -45,7 +45,7 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 			snap.Event(events.DirectoryEvent(snap.Header.Identifier, entrypath))
 			// Create directory if not root.
 			if entrypath != "/" {
-				if err := exp.CreateDirectory(dest); err != nil {
+				if err := exp.CreateDirectory(snap.AppContext(), dest); err != nil {
 					err := fmt.Errorf("failed to create directory %q: %w", dest, err)
 					snap.Event(events.DirectoryErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
 					return err
@@ -54,7 +54,7 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 
 			// WalkDir handles recursion so we don’t need to iterate children manually.
 			if entrypath != "/" {
-				if err := exp.SetPermissions(dest, e.Stat()); err != nil {
+				if err := exp.SetPermissions(snap.AppContext(), dest, e.Stat()); err != nil {
 					err := fmt.Errorf("failed to set permissions on directory %q: %w", dest, err)
 					snap.Event(events.DirectoryErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
 					return err
@@ -95,16 +95,16 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 			defer rd.Close()
 
 			// Ensure the parent directory exists.
-			if err := exp.CreateDirectory(path.Dir(dest)); err != nil {
+			if err := exp.CreateDirectory(snap.AppContext(), path.Dir(dest)); err != nil {
 				err := fmt.Errorf("failed to create directory %q: %w", dest, err)
 				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
 			}
 
 			// Restore the file content.
-			if err := exp.StoreFile(dest, rd, e.Size()); err != nil {
+			if err := exp.StoreFile(snap.AppContext(), dest, rd, e.Size()); err != nil {
 				err := fmt.Errorf("failed to write file %q at %q: %w", entrypath, dest, err)
 				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
-			} else if err := exp.SetPermissions(dest, e.Stat()); err != nil {
+			} else if err := exp.SetPermissions(snap.AppContext(), dest, e.Stat()); err != nil {
 				err := fmt.Errorf("failed to set permissions on file %q: %w", entrypath, err)
 				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
 			} else {

--- a/snapshot/restore_test.go
+++ b/snapshot/restore_test.go
@@ -27,7 +27,7 @@ func TestRestore(t *testing.T) {
 	ctx := context.Background()
 	exporterInstance, err = ptesting.NewMockExporter(ctx, nil, "mock", map[string]string{"location": "mock://" + tmpRestoreDir})
 	require.NoError(t, err)
-	defer exporterInstance.Close()
+	defer exporterInstance.Close(ctx)
 
 	opts := &snapshot.RestoreOptions{
 		MaxConcurrency: 1,
@@ -46,7 +46,9 @@ func TestRestore(t *testing.T) {
 	}
 	require.NotEmpty(t, filepath)
 
-	err = snap.Restore(exporterInstance, exporterInstance.Root(), filepath, opts)
+	root, err := exporterInstance.Root(ctx)
+	require.NoError(t, err)
+	err = snap.Restore(exporterInstance, root, filepath, opts)
 	require.NoError(t, err)
 
 	mockExporter, ok := exporterInstance.(*ptesting.MockExporter)
@@ -55,7 +57,7 @@ func TestRestore(t *testing.T) {
 	files := mockExporter.Files()
 	require.Equal(t, 1, len(files))
 
-	contents, ok := files[fmt.Sprintf("%s/dummy.txt", exporterInstance.Root())]
+	contents, ok := files[fmt.Sprintf("%s/dummy.txt", root)]
 	require.True(t, ok)
 	require.Equal(t, "hello", string(contents))
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -121,9 +121,9 @@ const (
 type Store interface {
 	Create(ctx context.Context, config []byte) error
 	Open(ctx context.Context) ([]byte, error)
-	Location() string
-	Mode() Mode
-	Size(ctx context.Context) int64 // this can be costly, call with caution
+	Location(ctx context.Context) (string, error)
+	Mode(ctx context.Context) (Mode, error)
+	Size(ctx context.Context) (int64, error) // this can be costly, call with caution
 
 	GetStates(ctx context.Context) ([]objects.MAC, error)
 	PutState(ctx context.Context, mac objects.MAC, rd io.Reader) (int64, error)
@@ -141,7 +141,7 @@ type Store interface {
 	GetLock(ctx context.Context, lockID objects.MAC) (io.ReadCloser, error)
 	DeleteLock(ctx context.Context, lockID objects.MAC) error
 
-	Close() error
+	Close(ctx context.Context) error
 }
 
 type StoreFn func(context.Context, string, map[string]string) (Store, error)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -123,23 +123,23 @@ type Store interface {
 	Open(ctx context.Context) ([]byte, error)
 	Location() string
 	Mode() Mode
-	Size() int64 // this can be costly, call with caution
+	Size(ctx context.Context) int64 // this can be costly, call with caution
 
-	GetStates() ([]objects.MAC, error)
-	PutState(mac objects.MAC, rd io.Reader) (int64, error)
-	GetState(mac objects.MAC) (io.ReadCloser, error)
-	DeleteState(mac objects.MAC) error
+	GetStates(ctx context.Context) ([]objects.MAC, error)
+	PutState(ctx context.Context, mac objects.MAC, rd io.Reader) (int64, error)
+	GetState(ctx context.Context, mac objects.MAC) (io.ReadCloser, error)
+	DeleteState(ctx context.Context, mac objects.MAC) error
 
-	GetPackfiles() ([]objects.MAC, error)
-	PutPackfile(mac objects.MAC, rd io.Reader) (int64, error)
-	GetPackfile(mac objects.MAC) (io.ReadCloser, error)
-	GetPackfileBlob(mac objects.MAC, offset uint64, length uint32) (io.ReadCloser, error)
-	DeletePackfile(mac objects.MAC) error
+	GetPackfiles(ctx context.Context) ([]objects.MAC, error)
+	PutPackfile(ctx context.Context, mac objects.MAC, rd io.Reader) (int64, error)
+	GetPackfile(ctx context.Context, mac objects.MAC) (io.ReadCloser, error)
+	GetPackfileBlob(ctx context.Context, mac objects.MAC, offset uint64, length uint32) (io.ReadCloser, error)
+	DeletePackfile(ctx context.Context, mac objects.MAC) error
 
-	GetLocks() ([]objects.MAC, error)
-	PutLock(lockID objects.MAC, rd io.Reader) (int64, error)
-	GetLock(lockID objects.MAC) (io.ReadCloser, error)
-	DeleteLock(lockID objects.MAC) error
+	GetLocks(ctx context.Context) ([]objects.MAC, error)
+	PutLock(ctx context.Context, lockID objects.MAC, rd io.Reader) (int64, error)
+	GetLock(ctx context.Context, lockID objects.MAC) (io.ReadCloser, error)
+	DeleteLock(ctx context.Context, lockID objects.MAC) error
 
 	Close() error
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -23,8 +23,8 @@ func TestNewStore(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if store.Location() != "mock:///test/location" {
-		t.Errorf("expected location to be '/test/location', got %v", store.Location())
+	if loc, _ := store.Location(ctx); loc != "mock:///test/location" {
+		t.Errorf("expected location to be '/test/location', got %v", loc)
 	}
 
 	// should return an error as the backend does not exist
@@ -73,8 +73,8 @@ func TestOpenStore(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if store.Location() != "mock:///test/location" {
-		t.Errorf("expected location to be '/test/location', got %v", store.Location())
+	if loc, _ := store.Location(ctx); loc != "mock:///test/location" {
+		t.Errorf("expected location to be '/test/location', got %v", loc)
 	}
 
 	// should return an error as the backend Open will return an error
@@ -129,8 +129,8 @@ func TestNew(t *testing.T) {
 				t.Fatalf("expected no error, got %v", err)
 			}
 
-			if store.Location() != location {
-				t.Errorf("expected location to be '%s', got %v", location, store.Location())
+			if loc, _ := store.Location(ctx); loc != location {
+				t.Errorf("expected location to be '%s', got %v", location, loc)
 			}
 		})
 	}

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -179,7 +179,7 @@ func (mb *MockBackend) DeletePackfile(ctx context.Context, MAC objects.MAC) erro
 	return nil
 }
 
-func (mb *MockBackend) Close() error {
+func (mb *MockBackend) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -108,16 +108,16 @@ func (mb *MockBackend) Open(ctx context.Context) ([]byte, error) {
 	return mb.configuration, nil
 }
 
-func (mb *MockBackend) Location() string {
-	return mb.location
+func (mb *MockBackend) Location(ctx context.Context) (string, error) {
+	return mb.location, nil
 }
 
-func (mb *MockBackend) Mode() storage.Mode {
-	return storage.ModeRead | storage.ModeWrite
+func (mb *MockBackend) Mode(ctx context.Context) (storage.Mode, error) {
+	return storage.ModeRead | storage.ModeWrite, nil
 }
 
-func (mb *MockBackend) Size(ctx context.Context) int64 {
-	return 0
+func (mb *MockBackend) Size(ctx context.Context) (int64, error) {
+	return 0, nil
 }
 
 func (mb *MockBackend) GetStates(ctx context.Context) ([]objects.MAC, error) {

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -116,11 +116,11 @@ func (mb *MockBackend) Mode() storage.Mode {
 	return storage.ModeRead | storage.ModeWrite
 }
 
-func (mb *MockBackend) Size() int64 {
+func (mb *MockBackend) Size(ctx context.Context) int64 {
 	return 0
 }
 
-func (mb *MockBackend) GetStates() ([]objects.MAC, error) {
+func (mb *MockBackend) GetStates(ctx context.Context) ([]objects.MAC, error) {
 	ret := make([]objects.MAC, 0)
 	for MAC := range mb.stateMACs {
 		ret = append(ret, MAC)
@@ -128,25 +128,25 @@ func (mb *MockBackend) GetStates() ([]objects.MAC, error) {
 	return ret, nil
 }
 
-func (mb *MockBackend) PutState(MAC objects.MAC, rd io.Reader) (int64, error) {
+func (mb *MockBackend) PutState(ctx context.Context, MAC objects.MAC, rd io.Reader) (int64, error) {
 	var buffer bytes.Buffer
 	io.Copy(&buffer, rd)
 	mb.stateMACs[MAC] = buffer.Bytes()
 	return int64(buffer.Len()), nil
 }
 
-func (mb *MockBackend) GetState(MAC objects.MAC) (io.ReadCloser, error) {
+func (mb *MockBackend) GetState(ctx context.Context, MAC objects.MAC) (io.ReadCloser, error) {
 	var buffer bytes.Buffer
 	buffer.Write(mb.stateMACs[MAC])
 	return io.NopCloser(&buffer), nil
 }
 
-func (mb *MockBackend) DeleteState(MAC objects.MAC) error {
+func (mb *MockBackend) DeleteState(ctx context.Context, MAC objects.MAC) error {
 	delete(mb.stateMACs, MAC)
 	return nil
 }
 
-func (mb *MockBackend) GetPackfiles() ([]objects.MAC, error) {
+func (mb *MockBackend) GetPackfiles(ctx context.Context) ([]objects.MAC, error) {
 	ret := make([]objects.MAC, 0)
 	for MAC := range mb.packfileMACs {
 		ret = append(ret, MAC)
@@ -154,7 +154,7 @@ func (mb *MockBackend) GetPackfiles() ([]objects.MAC, error) {
 	return ret, nil
 }
 
-func (mb *MockBackend) PutPackfile(MAC objects.MAC, rd io.Reader) (int64, error) {
+func (mb *MockBackend) PutPackfile(ctx context.Context, MAC objects.MAC, rd io.Reader) (int64, error) {
 	mb.packfileMutex.Lock()
 	defer mb.packfileMutex.Unlock()
 
@@ -164,17 +164,17 @@ func (mb *MockBackend) PutPackfile(MAC objects.MAC, rd io.Reader) (int64, error)
 	return int64(buffer.Len()), nil
 }
 
-func (mb *MockBackend) GetPackfile(MAC objects.MAC) (io.ReadCloser, error) {
+func (mb *MockBackend) GetPackfile(ctx context.Context, MAC objects.MAC) (io.ReadCloser, error) {
 	buffer := bytes.NewReader(mb.packfileMACs[MAC])
 	return io.NopCloser(buffer), nil
 }
 
-func (mb *MockBackend) GetPackfileBlob(MAC objects.MAC, offset uint64, length uint32) (io.ReadCloser, error) {
+func (mb *MockBackend) GetPackfileBlob(ctx context.Context, MAC objects.MAC, offset uint64, length uint32) (io.ReadCloser, error) {
 	buffer := bytes.NewReader(mb.packfileMACs[MAC])
 	return io.NopCloser(io.NewSectionReader(buffer, int64(offset), int64(length))), nil
 }
 
-func (mb *MockBackend) DeletePackfile(MAC objects.MAC) error {
+func (mb *MockBackend) DeletePackfile(ctx context.Context, MAC objects.MAC) error {
 	delete(mb.packfileMACs, MAC)
 	return nil
 }
@@ -184,7 +184,7 @@ func (mb *MockBackend) Close() error {
 }
 
 /* Locks */
-func (mb *MockBackend) GetLocks() ([]objects.MAC, error) {
+func (mb *MockBackend) GetLocks(ctx context.Context) ([]objects.MAC, error) {
 	locks := make([]objects.MAC, 0)
 	for lock := range mb.locks {
 		locks = append(locks, lock)
@@ -192,18 +192,18 @@ func (mb *MockBackend) GetLocks() ([]objects.MAC, error) {
 	return locks, nil
 }
 
-func (mb *MockBackend) PutLock(lockID objects.MAC, rd io.Reader) (int64, error) {
+func (mb *MockBackend) PutLock(ctx context.Context, lockID objects.MAC, rd io.Reader) (int64, error) {
 	var buffer bytes.Buffer
 	io.Copy(&buffer, rd)
 	mb.locks[lockID] = buffer.Bytes()
 	return int64(buffer.Len()), nil
 }
 
-func (mb *MockBackend) GetLock(lockID objects.MAC) (io.ReadCloser, error) {
+func (mb *MockBackend) GetLock(ctx context.Context, lockID objects.MAC) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(mb.locks[lockID])), nil
 }
 
-func (mb *MockBackend) DeleteLock(lockID objects.MAC) error {
+func (mb *MockBackend) DeleteLock(ctx context.Context, lockID objects.MAC) error {
 	delete(mb.locks, lockID)
 	return nil
 }

--- a/testing/exporter.go
+++ b/testing/exporter.go
@@ -30,8 +30,8 @@ func NewMockExporter(appCtx context.Context, opt *exporter.Options, name string,
 	}, nil
 }
 
-func (e *MockExporter) Root() string {
-	return e.rootDir
+func (e *MockExporter) Root(ctx context.Context) (string, error) {
+	return e.rootDir, nil
 }
 
 func (e *MockExporter) CreateDirectory(ctx context.Context, pathname string) error {
@@ -55,7 +55,7 @@ func (e *MockExporter) SetPermissions(ctx context.Context, pathname string, file
 	return nil
 }
 
-func (e *MockExporter) Close() error {
+func (e *MockExporter) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/testing/exporter.go
+++ b/testing/exporter.go
@@ -34,11 +34,11 @@ func (e *MockExporter) Root() string {
 	return e.rootDir
 }
 
-func (e *MockExporter) CreateDirectory(pathname string) error {
+func (e *MockExporter) CreateDirectory(ctx context.Context, pathname string) error {
 	return nil
 }
 
-func (e *MockExporter) StoreFile(pathname string, fp io.Reader, size int64) error {
+func (e *MockExporter) StoreFile(ctx context.Context, pathname string, fp io.Reader, size int64) error {
 	if len(pathname) > 5 && pathname[:5] == "mock:" {
 		pathname = pathname[5:]
 	}
@@ -51,7 +51,7 @@ func (e *MockExporter) StoreFile(pathname string, fp io.Reader, size int64) erro
 	return nil
 }
 
-func (e *MockExporter) SetPermissions(pathname string, fileinfo *objects.FileInfo) error {
+func (e *MockExporter) SetPermissions(ctx context.Context, pathname string, fileinfo *objects.FileInfo) error {
 	return nil
 }
 

--- a/testing/importer.go
+++ b/testing/importer.go
@@ -60,7 +60,7 @@ func (p *MockImporter) Type() string {
 	return "mock"
 }
 
-func (p *MockImporter) Scan() (<-chan *importer.ScanResult, error) {
+func (p *MockImporter) Scan(ctx context.Context) (<-chan *importer.ScanResult, error) {
 	ch := make(chan *importer.ScanResult)
 	if p.gen != nil {
 		go p.gen(ch)

--- a/testing/importer.go
+++ b/testing/importer.go
@@ -52,12 +52,12 @@ func (p *MockImporter) SetGenerator(gen func(chan<- *importer.ScanResult)) {
 	p.gen = gen
 }
 
-func (p *MockImporter) Origin() string {
-	return "mock"
+func (p *MockImporter) Origin(ctx context.Context) (string, error) {
+	return "mock", nil
 }
 
-func (p *MockImporter) Type() string {
-	return "mock"
+func (p *MockImporter) Type(ctx context.Context) (string, error) {
+	return "mock", nil
 }
 
 func (p *MockImporter) Scan(ctx context.Context) (<-chan *importer.ScanResult, error) {
@@ -75,10 +75,10 @@ func (p *MockImporter) Scan(ctx context.Context) (<-chan *importer.ScanResult, e
 	return ch, nil
 }
 
-func (p *MockImporter) Close() error {
+func (p *MockImporter) Close(ctx context.Context) error {
 	return nil
 }
 
-func (p *MockImporter) Root() string {
-	return "/"
+func (p *MockImporter) Root(ctx context.Context) (string, error) {
+	return "/", nil
 }

--- a/testing/state/store.go
+++ b/testing/state/store.go
@@ -29,16 +29,16 @@ func (s *store) Open(ctx context.Context) ([]byte, error) {
 	return nil, unsupported
 }
 
-func (s *store) Location() string {
-	return "fake"
+func (s *store) Location(ctx context.Context) (string, error) {
+	return "fake", nil
 }
 
-func (s *store) Mode() storage.Mode {
-	return storage.ModeWrite
+func (s *store) Mode(ctx context.Context) (storage.Mode, error) {
+	return storage.ModeWrite, nil
 }
 
-func (s *store) Size(ctx context.Context) int64 {
-	return 0
+func (s *store) Size(ctx context.Context) (int64, error) {
+	return 0, nil
 }
 
 func (s *store) GetStates(ctx context.Context) ([]objects.MAC, error) {

--- a/testing/state/store.go
+++ b/testing/state/store.go
@@ -105,6 +105,6 @@ func (s *store) DeleteLock(ctx context.Context, lockID objects.MAC) error {
 	return nil
 }
 
-func (s *store) Close() error {
+func (s *store) Close(ctx context.Context) error {
 	return nil
 }

--- a/testing/state/store.go
+++ b/testing/state/store.go
@@ -37,11 +37,11 @@ func (s *store) Mode() storage.Mode {
 	return storage.ModeWrite
 }
 
-func (s *store) Size() int64 {
+func (s *store) Size(ctx context.Context) int64 {
 	return 0
 }
 
-func (s *store) GetStates() ([]objects.MAC, error) {
+func (s *store) GetStates(ctx context.Context) ([]objects.MAC, error) {
 	var all []objects.MAC
 	for k := range s.states {
 		all = append(all, k)
@@ -49,7 +49,7 @@ func (s *store) GetStates() ([]objects.MAC, error) {
 	return all, nil
 }
 
-func (s *store) PutState(mac objects.MAC, rd io.Reader) (int64, error) {
+func (s *store) PutState(ctx context.Context, mac objects.MAC, rd io.Reader) (int64, error) {
 	data, err := io.ReadAll(rd)
 	if err != nil {
 		return 0, err
@@ -59,49 +59,49 @@ func (s *store) PutState(mac objects.MAC, rd io.Reader) (int64, error) {
 	return int64(len(data)), nil
 }
 
-func (s *store) GetState(mac objects.MAC) (io.ReadCloser, error) {
+func (s *store) GetState(ctx context.Context, mac objects.MAC) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(s.states[mac])), nil
 }
 
-func (s *store) DeleteState(mac objects.MAC) error {
+func (s *store) DeleteState(ctx context.Context, mac objects.MAC) error {
 	panic("!!!")
 }
 
-func (s *store) GetPackfiles() ([]objects.MAC, error) {
+func (s *store) GetPackfiles(ctx context.Context) ([]objects.MAC, error) {
 	return nil, unsupported
 }
 
-func (s *store) PutPackfile(mac objects.MAC, rd io.Reader) (int64, error) {
+func (s *store) PutPackfile(ctx context.Context, mac objects.MAC, rd io.Reader) (int64, error) {
 	return 0, unsupported
 }
 
-func (s *store) GetPackfile(mac objects.MAC) (io.ReadCloser, error) {
+func (s *store) GetPackfile(ctx context.Context, mac objects.MAC) (io.ReadCloser, error) {
 	return nil, unsupported
 }
 
-func (s *store) GetPackfileBlob(mac objects.MAC, offset uint64, length uint32) (io.ReadCloser, error) {
+func (s *store) GetPackfileBlob(ctx context.Context, mac objects.MAC, offset uint64, length uint32) (io.ReadCloser, error) {
 	return nil, unsupported
 }
 
-func (s *store) DeletePackfile(mac objects.MAC) error {
+func (s *store) DeletePackfile(ctx context.Context, mac objects.MAC) error {
 	return unsupported
 }
 
 // pretend to be lockless
 
-func (s *store) GetLocks() ([]objects.MAC, error) {
+func (s *store) GetLocks(ctx context.Context) ([]objects.MAC, error) {
 	return nil, nil
 }
 
-func (s *store) PutLock(lockID objects.MAC, rd io.Reader) (int64, error) {
+func (s *store) PutLock(ctx context.Context, lockID objects.MAC, rd io.Reader) (int64, error) {
 	return 0, nil
 }
 
-func (s *store) GetLock(lockID objects.MAC) (io.ReadCloser, error) {
+func (s *store) GetLock(ctx context.Context, lockID objects.MAC) (io.ReadCloser, error) {
 	return nil, nil
 }
 
-func (s *store) DeleteLock(lockID objects.MAC) error {
+func (s *store) DeleteLock(ctx context.Context, lockID objects.MAC) error {
 	return nil
 }
 


### PR DESCRIPTION
This is needed _only_ for grpc, because otherwise the context we save at the beginning is the wrong context, and cancellation won't work properly.

Sadly this also means that a  bunch of non fallible Methods are now fallible....