### PR TITLE
exporter: Add a new interface method for Links.

### DIFF
--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -18,9 +18,17 @@ type Options struct {
 	Stderr io.Writer
 }
 
+type LinkType int
+
+const (
+	HARDLINK LinkType = iota
+	SYMLINK
+)
+
 type Exporter interface {
 	Root(ctx context.Context) (string, error)
 	CreateDirectory(ctx context.Context, pathname string) error
+	CreateLink(ctx context.Context, oldname string, newname string, ltype LinkType) error
 	StoreFile(ctx context.Context, pathname string, fp io.Reader, size int64) error
 	SetPermissions(ctx context.Context, pathname string, fileinfo *objects.FileInfo) error
 	Close(ctx context.Context) error

--- a/snapshot/exporter/exporter_test.go
+++ b/snapshot/exporter/exporter_test.go
@@ -28,6 +28,10 @@ func (m MockedExporter) SetPermissions(ctx context.Context, pathname string, fil
 	return nil
 }
 
+func (m MockedExporter) CreateLink(ctx context.Context, oldname string, newname string, ltype LinkType) error {
+	return nil
+}
+
 func (m MockedExporter) Close(ctx context.Context) error {
 	return nil
 }

--- a/testing/exporter.go
+++ b/testing/exporter.go
@@ -51,6 +51,10 @@ func (e *MockExporter) StoreFile(ctx context.Context, pathname string, fp io.Rea
 	return nil
 }
 
+func (e *MockExporter) CreateLink(ctx context.Context, oldname string, newname string, ltype exporter.LinkType) error {
+	return nil
+}
+
 func (e *MockExporter) SetPermissions(ctx context.Context, pathname string, fileinfo *objects.FileInfo) error {
 	return nil
 }


### PR DESCRIPTION
* Supports both Symlinks and Hardlinks, for now this is only the interface change it is not yet plugged to the restore implementation.