### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/PlakarKorp/kloset
 go 1.23.3
 
 require (
-	github.com/PlakarKorp/go-cdc-chunkers v1.0.1
+	github.com/PlakarKorp/go-cdc-chunkers v1.0.2
 	github.com/cockroachdb/pebble/v2 v2.0.6
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gabriel-vasile/mimetype v1.4.9


### PR DESCRIPTION
bump dependency to latest version of go-cdc-chunkers that fixes the trailing empty chunk issue that could happen when perfectly aligned data input led to cutpoint at last offset of file.

the fix can lead to some objects wrapper being recomputed, their content however remains valid as all chunks share same cutpoints, and last empty chunk will be skipped now.