### PR TITLE
check: wait for goroutines also in the error path

### DIFF
--- a/snapshot/check.go
+++ b/snapshot/check.go
@@ -234,6 +234,7 @@ func (snap *Snapshot) Check(pathname string, opts *CheckOptions) error {
 	})
 	if err != nil {
 		snap.checkCache.PutVFSStatus(snap.Header.GetSource(0).VFS.Root, []byte(err.Error()))
+		wg.Wait()
 		return err
 	}
 	if err := wg.Wait(); err != nil {


### PR DESCRIPTION
Otherwise, we might return to the caller with goroutines still in-flight.  In plakar, this could be triggered with a ctrl-c: we exit from the WalkDir and return to the check subcommand, which will then close the cache with goroutines still trying to use it.