### PR TITLE
restore: record all errors and provide a "force" mode

### DIFF
--- a/snapshot/restore.go
+++ b/snapshot/restore.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/PlakarKorp/kloset/events"
 	"github.com/PlakarKorp/kloset/objects"
@@ -16,8 +17,9 @@ import (
 )
 
 type RestoreOptions struct {
-	MaxConcurrency uint64
-	Strip          string
+	MaxConcurrency  uint64
+	Strip           string
+	ForceCompletion bool
 }
 
 type restoreContext struct {
@@ -25,6 +27,9 @@ type restoreContext struct {
 	hardlinksMutex sync.Mutex
 	vfs            *vfs.Filesystem
 	directories    []dirRec
+
+	errors atomic.Uint64
+	force  bool
 }
 
 type dirRec struct {
@@ -32,11 +37,23 @@ type dirRec struct {
 	info *objects.FileInfo
 }
 
+func (ctx *restoreContext) reportFailure(snap *Snapshot, err error, evt events.Event) error {
+	if evt != nil {
+		snap.Event(evt)
+	}
+	ctx.errors.Add(1)
+
+	if ctx.force {
+		return nil
+	}
+	return err
+}
+
 func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, opts *RestoreOptions, restoreContext *restoreContext, wg *errgroup.Group) func(entrypath string, e *vfs.Entry, err error) error {
 	return func(entrypath string, e *vfs.Entry, err error) error {
 		if err != nil {
-			snap.Event(events.PathErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
-			return err
+			evt := events.PathErrorEvent(snap.Header.Identifier, entrypath, err.Error())
+			return restoreContext.reportFailure(snap, err, evt)
 		}
 
 		if err := snap.AppContext().Err(); err != nil {
@@ -55,8 +72,8 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 			if entrypath != "/" {
 				if err := exp.CreateDirectory(snap.AppContext(), dest); err != nil {
 					err := fmt.Errorf("failed to create directory %q: %w", dest, err)
-					snap.Event(events.DirectoryErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
-					return err
+					evt := events.DirectoryErrorEvent(snap.Header.Identifier, entrypath, err.Error())
+					return restoreContext.reportFailure(snap, err, evt)
 				}
 			}
 
@@ -72,7 +89,9 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 		if !e.Stat().Mode().IsRegular() {
 			if e.Stat().Mode().Type()&fs.ModeSymlink != 0 {
 				if err := exp.CreateLink(snap.AppContext(), e.SymlinkTarget, dest, exporter.SYMLINK); err != nil {
-					snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, fmt.Sprintf("failed to restore symlink: %s\n", err.Error())))
+					evt := events.FileErrorEvent(snap.Header.Identifier, entrypath,
+						fmt.Sprintf("failed to restore symlink: %s\n", err.Error()))
+					restoreContext.reportFailure(snap, err, evt)
 				}
 			}
 			return nil
@@ -86,7 +105,8 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 				v, ok := restoreContext.hardlinks[key]
 				if ok {
 					if err := exp.CreateLink(snap.AppContext(), v, dest, exporter.HARDLINK); err != nil {
-						snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
+						evt := events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error())
+						restoreContext.reportFailure(snap, err, evt)
 					}
 					restoreContext.hardlinksMutex.Unlock()
 					return nil
@@ -95,7 +115,8 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 
 			rd, err := e.Open(restoreContext.vfs)
 			if err != nil {
-				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
+				restoreContext.reportFailure(snap, err,
+					events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
 				return nil
 			}
 			defer rd.Close()
@@ -103,7 +124,8 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 			// Ensure the parent directory exists.
 			if err := exp.CreateDirectory(snap.AppContext(), path.Dir(dest)); err != nil {
 				err := fmt.Errorf("failed to create directory %q: %w", dest, err)
-				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
+				restoreContext.reportFailure(snap, err,
+					events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
 			}
 
 			// Restore the file content.
@@ -115,10 +137,12 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 
 			if err := exp.StoreFile(snap.AppContext(), dest, rd, e.Size()); err != nil {
 				err := fmt.Errorf("failed to write file %q at %q: %w", entrypath, dest, err)
-				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
+				evt := events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error())
+				restoreContext.reportFailure(snap, err, evt)
 			} else if err := exp.SetPermissions(snap.AppContext(), dest, e.Stat()); err != nil {
 				err := fmt.Errorf("failed to set permissions on file %q: %w", entrypath, err)
-				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
+				evt := events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error())
+				restoreContext.reportFailure(snap, err, evt)
 			} else {
 				snap.Event(events.FileOKEvent(snap.Header.Identifier, entrypath, e.Size()))
 			}
@@ -147,6 +171,7 @@ func (snap *Snapshot) Restore(exp exporter.Exporter, base string, pathname strin
 		hardlinksMutex: sync.Mutex{},
 		vfs:            fs,
 		directories:    make([]dirRec, 0, 256),
+		force:          opts.ForceCompletion,
 	}
 
 	base = path.Clean(base)
@@ -177,6 +202,14 @@ func (snap *Snapshot) Restore(exp exporter.Exporter, base string, pathname strin
 			err := fmt.Errorf("failed to set permissions on directory %q: %w", d.path, err)
 			snap.Event(events.DirectoryErrorEvent(snap.Header.Identifier, d.path, err.Error()))
 		}
+	}
+
+	if n := restoreContext.errors.Load(); n > 0 {
+		errors := "errors"
+		if n == 1 {
+			errors = "error"
+		}
+		return fmt.Errorf("restoration completed with %v %s", n, errors)
 	}
 	return nil
 }


### PR DESCRIPTION
Previously we only reported events for failure in restoring files*, so attempt to keep track of all the errors and report them at the end.

While here, also provide a "force" mode that keeps going on after errors occur, but it still reports the status at the end.

\* not completely accurate, only inside the error group we didn't raise errors.