### PR TITLE
PoolpOrg/dup

### DIFF
--- a/snapshot/dup.go
+++ b/snapshot/dup.go
@@ -1,0 +1,13 @@
+package snapshot
+
+func (snap *Snapshot) Dup() (*Snapshot, error) {
+	newSnapshot, err := snap.Fork()
+	if err != nil {
+		return nil, err
+	}
+	if err := newSnapshot.Commit(&BackupContext{}, true); err != nil {
+		return nil, err
+	}
+
+	return Load(snap.repository, newSnapshot.Header.GetIndexID())
+}


### PR DESCRIPTION
an exact copy, but will later be extended to provide editing capabilities
to snapshot (create a copy with a different tag or tiemstamp)