### PR TITLE
Override record FileInfo from the cached value

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -770,6 +770,7 @@ func (snap *Builder) checkVFSCache(backupCtx *BackupContext, record *importer.Sc
 	if !same {
 		return nil, nil
 	}
+	record.FileInfo = pathinfo.FileInfo
 	return pathinfo, nil
 }
 


### PR DESCRIPTION
When size is -1, we get something out of the cache that is different from the value being processed. We need to override the record with the cached value before using it otherwise the MAC won't match.