### PR TITLE
cast math.MaxUint32 to uint64

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -1061,7 +1061,7 @@ func (backupCtx *BackupContext) processChildren(builder *Builder, dirEntry *vfs.
 func writeFrame(builder *Builder, w io.Writer, typ DirPackEntry, data []byte) error {
 	mac := builder.repository.ComputeMAC(data)
 	overflowCheck := uint64(len(data)) + uint64(len(mac))
-	if overflowCheck > math.MaxUint32 {
+	if overflowCheck > uint64(math.MaxUint32) {
 		return ErrOutOfRange
 	}
 


### PR DESCRIPTION
math.MaxUint32 is an untyped int, which means it could not be allowed to be compared to a uint64 depending on the OS and architecture.

Spotted by Alban on discord; thanks!