### PR TITLE
location: reject one-character protocols

### DIFF
--- a/location/location.go
+++ b/location/location.go
@@ -83,7 +83,12 @@ func (l *Location[T]) Lookup(uri string) (proto, location string, item T, flags 
 
 	for i, c := range uri {
 		if !allowedInUri(c) {
-			if i != 0 && strings.HasPrefix(uri[i:], ":") {
+			/*
+			 * don't accept one-character URI, it makes
+			 * things confusing for windows where
+			 * E:\path\to\foo is the norm.
+			 */
+			if i > 1 && strings.HasPrefix(uri[i:], ":") {
 				proto = uri[:i]
 				location = uri[i+1:]
 				location = strings.TrimPrefix(location, "//")

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -104,6 +104,14 @@ func TestLookup(t *testing.T) {
 			wantFound:    false,
 		},
 		{
+			name:         "windows absolute path",
+			uri:          "C:\\Users\\Plakup",
+			wantProto:    "default",
+			wantLocation: "C:\\Users\\Plakup",
+			wantValue:    "",
+			wantFound:    false,
+		},
+		{
 			name:         "empty string",
 			uri:          "",
 			wantProto:    "default",


### PR DESCRIPTION
Absolute paths on windows have a one-letter drive followed by a colon prefix, for e.g. C:\Users\Plakup.  These paths are parsed as protocol "C" and location "\Users\Plakup" which is very non friendly.

Instead, reject single-character "URI"s so C:\Users\Plakup can be parsed as location "C:\Users\Plakup" and the default protocol.