### PR TITLE
repository: Fix over prefetching.

### DIFF
--- a/snapshot/vfs/entry_test.go
+++ b/snapshot/vfs/entry_test.go
@@ -168,7 +168,7 @@ func TestBigFile(t *testing.T) {
 	require.Equal(t, int64(0), seeked)
 
 	for i := int64(0); i < size/6; i++ {
-		n, err := fp.Read(buf[:6])
+		n, err := io.ReadFull(fp, buf[:6])
 		require.NoError(t, err, "at iteration %v", i)
 		require.Equal(t, 6, n, "at iteration %v", i)
 		require.Equal(t, "hello\n", string(buf[:n]), "at iteration %v", i)


### PR DESCRIPTION
* When prefetching an object content, respect the maxSize parameter.

* The problem lied in the fact that we keep track of the current "segment" size through the `size` variable, but this gets reset on the next segment construction. Since the VFS prefetcher uses 20mb as maxSize and our packfiles are around 20MB we were always crossing a boundary therefore resetting that `size` variable hence never exiting the iteration. Meaning that the prefetch buffer would grow up to the size of the file.

* Fix this by introducing an accumulatedSize that tracks well, the actual number of bytes we have been giving to the caller and that stops when we are above the threshold.