### PR TITLE
Fix symlink restoration with -to option

### DIFF
--- a/snapshot/restore.go
+++ b/snapshot/restore.go
@@ -91,25 +91,16 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 		// For non-directory entries, only process regular files.
 		if !e.Stat().Mode().IsRegular() {
 			if e.Stat().Mode().Type()&fs.ModeSymlink != 0 {
-				// Ensure the parent directory exists.
-				parentDir := path.Dir(dest)
-				if err := exp.CreateDirectory(snap.AppContext(), parentDir); err != nil {
-					err := fmt.Errorf("failed to create directory %q for symlink: %w", parentDir, err)
-					evt := events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error())
-					restoreContext.reportFailure(snap, err, evt)
-				} else {
-					if err := exp.CreateLink(snap.AppContext(), e.SymlinkTarget, dest, exporter.SYMLINK); err != nil {
-						evt := events.FileErrorEvent(snap.Header.Identifier, entrypath,
-							fmt.Sprintf("failed to restore symlink: %s\n", err.Error()))
-						restoreContext.reportFailure(snap, err, evt)
-					} else {
-						if !opts.SkipPermissions {
-							if err := exp.SetPermissions(snap.AppContext(), dest, e.Stat()); err != nil {
-								err := fmt.Errorf("failed to set permissions on symlink %q: %w", entrypath, err)
-								evt := events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error())
-								restoreContext.reportFailure(snap, err, evt)
-							}
-						}
+				if err := exp.CreateLink(snap.AppContext(), e.SymlinkTarget, dest, exporter.SYMLINK); err != nil {
+					evt := events.FileErrorEvent(snap.Header.Identifier, entrypath,
+						fmt.Sprintf("failed to restore symlink: %s\n", err.Error()))
+					return restoreContext.reportFailure(snap, err, evt)
+				}
+				if !opts.SkipPermissions {
+					if err := exp.SetPermissions(snap.AppContext(), dest, e.Stat()); err != nil {
+						err := fmt.Errorf("failed to set permissions on symlink %q: %w", entrypath, err)
+						evt := events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error())
+						return restoreContext.reportFailure(snap, err, evt)
 					}
 				}
 			}


### PR DESCRIPTION
- Ensure parent directory exists before creating symlinks
- Properly set permissions on restored symlinks

This prevents errors when restoring symlinks to different locations where the original target paths may not exist.