### PR TITLE
caching/test: open the caches thru the manager

### DIFF
--- a/caching/check_test.go
+++ b/caching/check_test.go
@@ -14,7 +14,7 @@ func TestCheckCache(t *testing.T) {
 	defer manager.Close()
 
 	// Create a new check cache
-	cache, err := newCheckCache(manager)
+	cache, err := manager.Check()
 	require.NoError(t, err)
 	defer cache.Close()
 

--- a/caching/maintenance_test.go
+++ b/caching/maintenance_test.go
@@ -16,9 +16,8 @@ func TestMaintenanceCache(t *testing.T) {
 
 	// Create a new maintenance cache
 	repositoryID := uuid.New()
-	cache, err := newMaintenanceCache(manager, repositoryID)
+	cache, err := manager.Maintenance(repositoryID)
 	require.NoError(t, err)
-	defer cache.Close()
 
 	// Test snapshot operations
 	t.Run("Snapshot Operations", func(t *testing.T) {

--- a/caching/packing_test.go
+++ b/caching/packing_test.go
@@ -15,7 +15,7 @@ func TestPackingCache(t *testing.T) {
 	defer manager.Close()
 
 	// Create a new packing cache
-	cache, err := newPackingCache(manager)
+	cache, err := manager.Packing()
 	require.NoError(t, err)
 	defer cache.Close()
 

--- a/caching/repository_test.go
+++ b/caching/repository_test.go
@@ -17,9 +17,8 @@ func TestRepositoryCache(t *testing.T) {
 
 	// Create a new repository cache
 	repoID := uuid.New()
-	cache, err := newRepositoryCache(manager, repoID)
+	cache, err := manager.Repository(repoID)
 	require.NoError(t, err)
-	defer cache.Close()
 
 	// Test state operations
 	t.Run("State Operations", func(t *testing.T) {

--- a/caching/scan_test.go
+++ b/caching/scan_test.go
@@ -16,8 +16,11 @@ func TestScanCache(t *testing.T) {
 
 	// Create a new scan cache
 	snapshotID := [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
-	cache, err := newScanCache(manager, snapshotID)
+	cache, err := manager.Scan(snapshotID)
 	require.NoError(t, err)
+
+	// down below we close and re-open cache
+	defer func() { cache.Close() }()
 
 	// Test file operations
 	t.Run("File Operations", func(t *testing.T) {
@@ -285,9 +288,8 @@ func TestScanCache(t *testing.T) {
 	t.Run("Key Enumeration", func(t *testing.T) {
 		// Clear the cache by closing and reopening it
 		cache.Close()
-		cache, err = newScanCache(manager, snapshotID)
+		cache, err = manager.Scan(snapshotID)
 		require.NoError(t, err)
-		defer cache.Close()
 
 		// Add some test data
 		err := cache.PutFile(1, "/test/file1.txt", []byte("data1"))

--- a/caching/store_test.go
+++ b/caching/store_test.go
@@ -16,7 +16,7 @@ func TestDBStore(t *testing.T) {
 
 	// Create a new scan cache
 	snapshotID := objects.MAC{1, 2, 3}
-	cache, err := newScanCache(manager, snapshotID)
+	cache, err := manager.Scan(snapshotID)
 	require.NoError(t, err)
 	defer cache.Close()
 

--- a/caching/vfs_test.go
+++ b/caching/vfs_test.go
@@ -17,9 +17,8 @@ func TestVFSCache(t *testing.T) {
 	repoID := uuid.New()
 	scheme := "test"
 	origin := "test-origin"
-	cache, err := newVFSCache(manager, repoID, scheme, origin, false)
+	cache, err := manager.VFS(repoID, scheme, origin, false)
 	require.NoError(t, err)
-	defer cache.Close()
 
 	// Test filename operations
 	t.Run("Filename Operations", func(t *testing.T) {


### PR DESCRIPTION
Some caches are implicitly closed by the manager, but not all of them. In particular, the scan cache is also closed and re-opened.