### PR TITLE
source: No need to take flags in the ctor.

### DIFF
--- a/snapshot/source.go
+++ b/snapshot/source.go
@@ -28,10 +28,9 @@ type Source struct {
 	failure error
 }
 
-func NewSource(ctx context.Context, flags location.Flags, importers ...importer.Importer) (*Source, error) {
+func NewSource(ctx context.Context, importers ...importer.Importer) (*Source, error) {
 	s := &Source{
 		ctx:      ctx,
-		flags:    flags,
 		excludes: exclude.NewRuleSet(),
 	}
 

--- a/snapshot/source_test.go
+++ b/snapshot/source_test.go
@@ -20,7 +20,7 @@ func TestSourceDedupEqual(t *testing.T) {
 		FakeRoot: "/home/bar",
 	}
 
-	s, err := snapshot.NewSource(context.Background(), 0, imp1, imp2, imp3)
+	s, err := snapshot.NewSource(context.Background(), imp1, imp2, imp3)
 	require.NoError(t, err)
 
 	require.Len(t, s.Importers(), 1)
@@ -43,7 +43,7 @@ func TestSourceDedupCommonPrefix(t *testing.T) {
 		FakeRoot: "/home/bar",
 	}
 
-	s, err := snapshot.NewSource(t.Context(), 0, imp1, imp2, imp3, imp4, imp5)
+	s, err := snapshot.NewSource(t.Context(), imp1, imp2, imp3, imp4, imp5)
 	require.NoError(t, err)
 
 	roots := []string{}

--- a/snapshot/synchronize.go
+++ b/snapshot/synchronize.go
@@ -153,7 +153,7 @@ func (src *Snapshot) Synchronize(dst *Builder) error {
 	dst.Header.Tags = src.Header.Tags
 	dst.Header.Context = src.Header.Context
 
-	source, err := NewSource(dst.AppContext(), 0, imp)
+	source, err := NewSource(dst.AppContext(), imp)
 	if err != nil {
 		return err
 	}

--- a/testing/snapshot.go
+++ b/testing/snapshot.go
@@ -147,7 +147,7 @@ func GenerateSnapshot(t *testing.T, repo *repository.Repository, files []MockFil
 		imp.(*MockImporter).SetFiles(files)
 	}
 
-	s, err := snapshot.NewSource(repo.AppContext(), 0, imp)
+	s, err := snapshot.NewSource(repo.AppContext(), imp)
 	require.NoError(t, err)
 
 	err = s.SetExcludes(o.excludes)


### PR DESCRIPTION
* The importer interface now exposes a Flags() accessor making Source handling simpler.