### PR TITLE
Refactor compression tests and improve coverage

### DIFF
--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -2,6 +2,7 @@ package compression_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"io"
 	"testing"
@@ -60,6 +61,59 @@ func TestLookupDefaultConfiguration(t *testing.T) {
 	})
 }
 
+type errorReader struct{}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("forced read error")
+}
+
+func TestDeflateGzipStream(t *testing.T) {
+	t.Run("CompressData", func(t *testing.T) {
+		data := []byte("hello gzip")
+
+		compressedReader, err := cprss.DeflateGzipStream(bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		gzipReader, err := gzip.NewReader(compressedReader)
+		require.NoError(t, err)
+		require.NotNil(t, gzipReader)
+
+		decompressedData, err := io.ReadAll(gzipReader)
+		require.NoError(t, err)
+		require.NoError(t, gzipReader.Close())
+		require.NotEmpty(t, decompressedData)
+
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("CompressEmptyData", func(t *testing.T) {
+		data := []byte{}
+
+		compressedReader, err := cprss.DeflateGzipStream(bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		gzipReader, err := gzip.NewReader(compressedReader)
+		require.NoError(t, err)
+		require.NotNil(t, gzipReader)
+
+		decompressedData, err := io.ReadAll(gzipReader)
+		require.NoError(t, err)
+		require.NoError(t, gzipReader.Close())
+		require.Empty(t, decompressedData)
+	})
+
+	t.Run("Fails_IfSourceReaderFails", func(t *testing.T) {
+		compressedReader, err := cprss.DeflateGzipStream(&errorReader{})
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		_, readErr := io.ReadAll(compressedReader)
+		require.ErrorContains(t, readErr, "forced read error")
+	})
+}
+
 // Helper function to compress and then decompress data and verify correctness
 func testCompressionDecompression(t *testing.T, algorithm string, data []byte) {
 	// Compress data
@@ -115,12 +169,6 @@ func TestUnsupportedAlgorithm(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for unsupported compression method, got nil")
 	}
-}
-
-type errorReader struct{}
-
-func (e *errorReader) Read(p []byte) (n int, err error) {
-	return 0, errors.New("forced read error")
 }
 
 func TestDeflateStreamErrorHandling(t *testing.T) {

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -286,51 +286,6 @@ func TestInflateLZ4Stream(t *testing.T) {
 	})
 }
 
-// Helper function to compress and then decompress data and verify correctness
-func testCompressionDecompression(t *testing.T, algorithm string, data []byte) {
-	// Compress data
-	compressedReader, err := cprss.DeflateStream(algorithm, bytes.NewReader(data))
-	if err != nil {
-		t.Fatalf("DeflateStream failed for %s: %v", algorithm, err)
-	}
-
-	// Decompress data
-	decompressedReader, err := cprss.InflateStream(algorithm, io.NopCloser(compressedReader))
-	if err != nil {
-		t.Fatalf("InflateStream failed for %s: %v", algorithm, err)
-	}
-
-	// Read decompressed data
-	var decompressedData bytes.Buffer
-	_, err = io.Copy(&decompressedData, decompressedReader)
-	if err != nil {
-		t.Fatalf("Reading decompressed data failed for %s: %v", algorithm, err)
-	}
-
-	// Compare original and decompressed data
-	if !bytes.Equal(data, decompressedData.Bytes()) {
-		t.Errorf("Decompressed data does not match original for %s. Got: %v, Want: %v", algorithm, decompressedData.Bytes(), data)
-	}
-}
-
-func TestCompression(t *testing.T) {
-	tests := []struct {
-		algorithm string
-		data      []byte
-	}{
-		{"GZIP", []byte("Hello, world!")},
-		{"GZIP", []byte{}}, // Test empty buffer for gzip
-		{"LZ4", []byte("Hello, world!")},
-		{"LZ4", []byte{}}, // Test empty buffer for lz4
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.algorithm, func(t *testing.T) {
-			testCompressionDecompression(t, tt.algorithm, tt.data)
-		})
-	}
-}
-
 func TestUnsupportedAlgorithm(t *testing.T) {
 	_, err := cprss.DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
 	if err == nil {

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -286,6 +286,91 @@ func TestInflateLZ4Stream(t *testing.T) {
 	})
 }
 
+func TestDeflateStream(t *testing.T) {
+	t.Run("DispatchGZIP", func(t *testing.T) {
+		data := []byte("hello gzip")
+
+		compressedReader, err := cprss.DeflateStream("GZIP", bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedData := decompressDataForTest(t, "GZIP", compressedReader)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("DispatchLZ4", func(t *testing.T) {
+		data := []byte("hello lz4")
+
+		compressedReader, err := cprss.DeflateStream("LZ4", bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedData := decompressDataForTest(t, "LZ4", compressedReader)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("PartialReadOnGZIPData", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello gzip"), 128)
+
+		compressedReader, err := cprss.DeflateStream("GZIP", bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		firstChunk := make([]byte, 8)
+		n, err := compressedReader.Read(firstChunk)
+		require.NoError(t, err)
+		require.Greater(t, n, 0)
+
+		remainingCompressedData, err := io.ReadAll(compressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, remainingCompressedData)
+
+		fullCompressedData := append(firstChunk[:n], remainingCompressedData...)
+		decompressedData := decompressDataForTest(t, "GZIP", bytes.NewReader(fullCompressedData))
+		require.NotEmpty(t, remainingCompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("PartialReadOnLZ4Data", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello lz4"), 128)
+
+		compressedReader, err := cprss.DeflateStream("LZ4", bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		firstChunk := make([]byte, 8)
+		n, err := compressedReader.Read(firstChunk)
+		require.NoError(t, err)
+		require.Greater(t, n, 0)
+
+		remainingCompressedData, err := io.ReadAll(compressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, remainingCompressedData)
+
+		fullCompressedData := append(firstChunk[:n], remainingCompressedData...)
+		decompressedData := decompressDataForTest(t, "LZ4", bytes.NewReader(fullCompressedData))
+		require.NotEmpty(t, remainingCompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("Fails_IfSourceReaderFails", func(t *testing.T) {
+		compressedReader, err := cprss.DeflateStream("GZIP", &errorReader{})
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		_, err = io.ReadAll(compressedReader)
+		require.ErrorContains(t, err, "forced read error")
+	})
+
+	t.Run("FailOnUnsupportedAlgorithm", func(t *testing.T) {
+		compressedReader, err := cprss.DeflateStream("UNKNOWN", bytes.NewReader([]byte("test data")))
+		require.Nil(t, compressedReader)
+		require.EqualError(t, err, `unsupported compression method "UNKNOWN"`)
+	})
+}
+
 func TestUnsupportedAlgorithm(t *testing.T) {
 	_, err := cprss.DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
 	if err == nil {

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -8,7 +8,57 @@ import (
 
 	cprss "github.com/PlakarKorp/kloset/compression"
 	"github.com/pierrec/lz4/v4"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNewDefaultConfiguration(t *testing.T) {
+	t.Run("CheckDefaults", func(t *testing.T) {
+		cfg := cprss.NewDefaultConfiguration()
+
+		require.NotNil(t, cfg)
+		require.Equal(t, "LZ4", cfg.Algorithm)
+		require.Equal(t, int(lz4.Level9), cfg.Level)
+		require.Equal(t, -1, cfg.WindowSize)
+		require.Equal(t, -1, cfg.ChunkSize)
+		require.Equal(t, -1, cfg.BlockSize)
+		require.False(t, cfg.EnableCRC)
+	})
+}
+
+func TestLookupDefaultConfiguration(t *testing.T) {
+	t.Run("CheckLZ4Defaults", func(t *testing.T) {
+		cfg, err := cprss.LookupDefaultConfiguration("LZ4")
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.Equal(t, "LZ4", cfg.Algorithm)
+		require.Equal(t, int(lz4.Level9), cfg.Level)
+		require.Equal(t, -1, cfg.WindowSize)
+		require.Equal(t, -1, cfg.ChunkSize)
+		require.Equal(t, -1, cfg.BlockSize)
+		require.False(t, cfg.EnableCRC)
+	})
+
+	t.Run("CheckGZIPDefaults", func(t *testing.T) {
+		cfg, err := cprss.LookupDefaultConfiguration("GZIP")
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.Equal(t, "GZIP", cfg.Algorithm)
+		require.Equal(t, -1, cfg.Level)
+		require.Equal(t, -1, cfg.WindowSize)
+		require.Equal(t, -1, cfg.ChunkSize)
+		require.Equal(t, -1, cfg.BlockSize)
+		require.False(t, cfg.EnableCRC)
+	})
+
+	t.Run("CheckUnknownAlgorithm", func(t *testing.T) {
+		cfg, err := cprss.LookupDefaultConfiguration("UNKNOWN")
+
+		require.Nil(t, cfg)
+		require.EqualError(t, err, "unknown hashing algorithm: UNKNOWN")
+	})
+}
 
 // Helper function to compress and then decompress data and verify correctness
 func testCompressionDecompression(t *testing.T, algorithm string, data []byte) {
@@ -52,15 +102,6 @@ func TestCompression(t *testing.T) {
 		t.Run(tt.algorithm, func(t *testing.T) {
 			testCompressionDecompression(t, tt.algorithm, tt.data)
 		})
-	}
-}
-
-func TestDefaultAlgorithm(t *testing.T) {
-	expected := "LZ4"
-	result := cprss.NewDefaultConfiguration().Algorithm
-
-	if result != expected {
-		t.Errorf("DefaultAlgorithm failed: expected %v, got %v", expected, result)
 	}
 }
 
@@ -144,38 +185,5 @@ func TestLargeDataCompression(t *testing.T) {
 
 	if !bytes.Equal(largeData, decompressedData.Bytes()) {
 		t.Errorf("Decompressed large data does not match original. Lengths differ")
-	}
-}
-
-func TestLookupNewDefaultConfigurationLZ4(t *testing.T) {
-	config, err := cprss.LookupDefaultConfiguration("LZ4")
-	if err != nil {
-		t.Errorf("LookupNewDefaultConfiguration(LZ4) returned an error: %v", err)
-	}
-	if config.Algorithm != "LZ4" {
-		t.Errorf("LookupNewDefaultConfiguration(LZ4) returned incorrect algorithm: %s", config.Algorithm)
-	}
-	if config.Level != int(lz4.Level9) {
-		t.Errorf("LookupNewDefaultConfiguration(LZ4) returned incorrect level: %d", config.Level)
-	}
-}
-
-func TestLookupNewDefaultConfigurationGZIP(t *testing.T) {
-	config, err := cprss.LookupDefaultConfiguration("GZIP")
-	if err != nil {
-		t.Errorf("LookupNewDefaultConfiguration(GZIP) returned an error: %v", err)
-	}
-	if config.Algorithm != "GZIP" {
-		t.Errorf("LookupNewDefaultConfiguration(GZIP) returned incorrect algorithm: %s", config.Algorithm)
-	}
-	if config.Level != -1 {
-		t.Errorf("LookupNewDefaultConfiguration(GZIP) returned incorrect level: %d", config.Level)
-	}
-}
-
-func TestLookupNewDefaultConfigurationUnknown(t *testing.T) {
-	_, err := cprss.LookupDefaultConfiguration("unknown")
-	if err == nil {
-		t.Errorf("LookupNewDefaultConfiguration(unknown) did not return an error")
 	}
 }

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -67,6 +67,57 @@ func (e *errorReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("forced read error")
 }
 
+func compressDataForTest(t *testing.T, algorithm string, data []byte) []byte {
+	t.Helper()
+
+	var compressedData bytes.Buffer
+	var writer io.WriteCloser
+
+	switch algorithm {
+	case "GZIP":
+		writer = gzip.NewWriter(&compressedData)
+	case "LZ4":
+		writer = lz4.NewWriter(&compressedData)
+	default:
+		require.FailNow(t, "unsupported algorithm", "algorithm=%s", algorithm)
+	}
+
+	_, err := writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return compressedData.Bytes()
+}
+
+func decompressDataForTest(t *testing.T, algorithm string, r io.Reader) []byte {
+	t.Helper()
+
+	var reader io.Reader
+	var closer io.Closer
+
+	switch algorithm {
+	case "GZIP":
+		r, err := gzip.NewReader(r)
+		require.NoError(t, err)
+		reader = r
+		closer = r
+	case "LZ4":
+		reader = lz4.NewReader(r)
+		closer = nil
+	default:
+		require.FailNow(t, "unsupported algorithm", "algorithm=%s", algorithm)
+	}
+
+	decompressedData, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	if closer != nil {
+		require.NoError(t, closer.Close())
+	}
+
+	return decompressedData
+}
+
 func TestDeflateGzipStream(t *testing.T) {
 	t.Run("CompressData", func(t *testing.T) {
 		data := []byte("hello gzip")
@@ -75,15 +126,8 @@ func TestDeflateGzipStream(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, compressedReader)
 
-		gzipReader, err := gzip.NewReader(compressedReader)
-		require.NoError(t, err)
-		require.NotNil(t, gzipReader)
-
-		decompressedData, err := io.ReadAll(gzipReader)
-		require.NoError(t, err)
-		require.NoError(t, gzipReader.Close())
+		decompressedData := decompressDataForTest(t, "GZIP", compressedReader)
 		require.NotEmpty(t, decompressedData)
-
 		require.Equal(t, data, decompressedData)
 	})
 
@@ -94,13 +138,7 @@ func TestDeflateGzipStream(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, compressedReader)
 
-		gzipReader, err := gzip.NewReader(compressedReader)
-		require.NoError(t, err)
-		require.NotNil(t, gzipReader)
-
-		decompressedData, err := io.ReadAll(gzipReader)
-		require.NoError(t, err)
-		require.NoError(t, gzipReader.Close())
+		decompressedData := decompressDataForTest(t, "GZIP", compressedReader)
 		require.Empty(t, decompressedData)
 	})
 
@@ -117,45 +155,28 @@ func TestDeflateGzipStream(t *testing.T) {
 func TestInflateGzipStream(t *testing.T) {
 	t.Run("InflateData", func(t *testing.T) {
 		data := []byte("hello gzip")
+		compressedData := compressDataForTest(t, "GZIP", data)
 
-		var compressedData bytes.Buffer
-		gzipWriter := gzip.NewWriter(&compressedData)
-		require.NotNil(t, gzipWriter)
-
-		_, err := gzipWriter.Write(data)
-		require.NoError(t, err)
-		require.NoError(t, gzipWriter.Close())
-
-		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(compressedData.Bytes())))
+		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(compressedData)))
 		require.NoError(t, err)
 		require.NotNil(t, decompressedReader)
 
 		decompressedData, err := io.ReadAll(decompressedReader)
 		require.NoError(t, err)
-		require.NoError(t, decompressedReader.Close())
 		require.NotEmpty(t, decompressedData)
-
 		require.Equal(t, data, decompressedData)
 	})
 
 	t.Run("CompressEmptyData", func(t *testing.T) {
 		data := []byte{}
+		compressedData := compressDataForTest(t, "GZIP", data)
 
-		var compressedData bytes.Buffer
-		gzipWriter := gzip.NewWriter(&compressedData)
-		require.NotNil(t, gzipWriter)
-
-		_, err := gzipWriter.Write(data)
-		require.NoError(t, err)
-		require.NoError(t, gzipWriter.Close())
-
-		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(compressedData.Bytes())))
+		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(compressedData)))
 		require.NoError(t, err)
 		require.NotNil(t, decompressedReader)
 
 		decompressedData, err := io.ReadAll(decompressedReader)
 		require.NoError(t, err)
-		require.NoError(t, decompressedReader.Close())
 		require.Empty(t, decompressedData)
 	})
 
@@ -167,16 +188,8 @@ func TestInflateGzipStream(t *testing.T) {
 
 	t.Run("FailsOnCorruptedData", func(t *testing.T) {
 		data := []byte("hello gzip")
-
-		var compressedData bytes.Buffer
-		gzipWriter := gzip.NewWriter(&compressedData)
-		require.NotNil(t, gzipWriter)
-
-		_, err := gzipWriter.Write(data)
-		require.NoError(t, err)
-		require.NoError(t, gzipWriter.Close())
-
-		corruptedData := compressedData.Bytes()[:len(compressedData.Bytes())-1]
+		compressedData := compressDataForTest(t, "GZIP", data)
+		corruptedData := compressedData[:len(compressedData)-4]
 
 		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(corruptedData)))
 		require.NoError(t, err)
@@ -184,7 +197,6 @@ func TestInflateGzipStream(t *testing.T) {
 
 		_, err = io.ReadAll(decompressedReader)
 		require.Error(t, err)
-		require.NoError(t, decompressedReader.Close())
 	})
 }
 

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -234,6 +234,58 @@ func TestDeflateLZ4Stream(t *testing.T) {
 	})
 }
 
+func TestInflateLZ4Stream(t *testing.T) {
+	t.Run("InflateData", func(t *testing.T) {
+		data := []byte("hello lz4")
+		compressedData := compressDataForTest(t, "LZ4", data)
+
+		decompressedReader, err := cprss.InflateLZ4Stream(io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("CompressEmptyData", func(t *testing.T) {
+		data := []byte{}
+		compressedData := compressDataForTest(t, "LZ4", data)
+
+		decompressedReader, err := cprss.InflateLZ4Stream(io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.Empty(t, decompressedData)
+	})
+
+	t.Run("FailOnInvalidData", func(t *testing.T) {
+		decompressedReader, err := cprss.InflateLZ4Stream(io.NopCloser(bytes.NewReader([]byte("not lz4"))))
+
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		_, err = io.ReadAll(decompressedReader)
+		require.Error(t, err)
+	})
+
+	t.Run("FailsOnCorruptedData", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello lz4"), 1024)
+		compressedData := compressDataForTest(t, "LZ4", data)
+		corruptedData := compressedData[:len(compressedData)-1]
+
+		decompressedReader, err := cprss.InflateLZ4Stream(io.NopCloser(bytes.NewReader(corruptedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		_, err = io.ReadAll(decompressedReader)
+		require.Error(t, err)
+	})
+}
+
 // Helper function to compress and then decompress data and verify correctness
 func testCompressionDecompression(t *testing.T, algorithm string, data []byte) {
 	// Compress data

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -200,6 +200,40 @@ func TestInflateGzipStream(t *testing.T) {
 	})
 }
 
+func TestDeflateLZ4Stream(t *testing.T) {
+	t.Run("CompressData", func(t *testing.T) {
+		data := []byte("hello lz4")
+
+		compressedReader, err := cprss.DeflateLZ4Stream(bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedData := decompressDataForTest(t, "LZ4", compressedReader)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("CompressEmptyData", func(t *testing.T) {
+		data := []byte{}
+
+		compressedReader, err := cprss.DeflateLZ4Stream(bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedData := decompressDataForTest(t, "LZ4", compressedReader)
+		require.Empty(t, decompressedData)
+	})
+
+	t.Run("Fails_IfSourceReaderFails", func(t *testing.T) {
+		compressedReader, err := cprss.DeflateLZ4Stream(&errorReader{})
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		_, err = io.ReadAll(compressedReader)
+		require.ErrorContains(t, err, "forced read error")
+	})
+}
+
 // Helper function to compress and then decompress data and verify correctness
 func testCompressionDecompression(t *testing.T, algorithm string, data []byte) {
 	// Compress data

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -457,29 +457,44 @@ func TestInflateStream(t *testing.T) {
 	})
 }
 
-func TestLargeDataCompression(t *testing.T) {
-	largeData := make([]byte, 10*1024*1024) // 10MB of data
-	for i := range largeData {
-		largeData[i] = byte(i % 256)
-	}
+func TestLargeData(t *testing.T) {
+	t.Run("GZIP", func(t *testing.T) {
+		data := make([]byte, 10*1024*1024)
+		for i := range data {
+			data[i] = byte(i % 251)
+		}
 
-	compressedReader, err := cprss.DeflateStream("LZ4", bytes.NewReader(largeData))
-	if err != nil {
-		t.Fatalf("DeflateStream failed for large data: %v", err)
-	}
+		compressedReader, err := cprss.DeflateStream("GZIP", bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
 
-	decompressedReader, err := cprss.InflateStream("LZ4", io.NopCloser(compressedReader))
-	if err != nil {
-		t.Fatalf("InflateStream failed for large data: %v", err)
-	}
+		decompressedReader, err := cprss.InflateStream("GZIP", io.NopCloser(compressedReader))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
 
-	var decompressedData bytes.Buffer
-	_, err = io.Copy(&decompressedData, decompressedReader)
-	if err != nil {
-		t.Fatalf("Reading decompressed data failed for large data: %v", err)
-	}
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
 
-	if !bytes.Equal(largeData, decompressedData.Bytes()) {
-		t.Errorf("Decompressed large data does not match original. Lengths differ")
-	}
+	t.Run("LZ4", func(t *testing.T) {
+		data := make([]byte, 10*1024*1024)
+		for i := range data {
+			data[i] = byte(i % 251)
+		}
+
+		compressedReader, err := cprss.DeflateStream("LZ4", bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedReader, err := cprss.InflateStream("LZ4", io.NopCloser(compressedReader))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
 }

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -114,6 +114,80 @@ func TestDeflateGzipStream(t *testing.T) {
 	})
 }
 
+func TestInflateGzipStream(t *testing.T) {
+	t.Run("InflateData", func(t *testing.T) {
+		data := []byte("hello gzip")
+
+		var compressedData bytes.Buffer
+		gzipWriter := gzip.NewWriter(&compressedData)
+		require.NotNil(t, gzipWriter)
+
+		_, err := gzipWriter.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, gzipWriter.Close())
+
+		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(compressedData.Bytes())))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NoError(t, decompressedReader.Close())
+		require.NotEmpty(t, decompressedData)
+
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("CompressEmptyData", func(t *testing.T) {
+		data := []byte{}
+
+		var compressedData bytes.Buffer
+		gzipWriter := gzip.NewWriter(&compressedData)
+		require.NotNil(t, gzipWriter)
+
+		_, err := gzipWriter.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, gzipWriter.Close())
+
+		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(compressedData.Bytes())))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NoError(t, decompressedReader.Close())
+		require.Empty(t, decompressedData)
+	})
+
+	t.Run("FailOnInvalidData", func(t *testing.T) {
+		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader([]byte("not gzip"))))
+		require.Error(t, err)
+		require.Nil(t, decompressedReader)
+	})
+
+	t.Run("FailsOnCorruptedData", func(t *testing.T) {
+		data := []byte("hello gzip")
+
+		var compressedData bytes.Buffer
+		gzipWriter := gzip.NewWriter(&compressedData)
+		require.NotNil(t, gzipWriter)
+
+		_, err := gzipWriter.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, gzipWriter.Close())
+
+		corruptedData := compressedData.Bytes()[:len(compressedData.Bytes())-1]
+
+		decompressedReader, err := cprss.InflateGzipStream(io.NopCloser(bytes.NewReader(corruptedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		_, err = io.ReadAll(decompressedReader)
+		require.Error(t, err)
+		require.NoError(t, decompressedReader.Close())
+	})
+}
+
 // Helper function to compress and then decompress data and verify correctness
 func testCompressionDecompression(t *testing.T, algorithm string, data []byte) {
 	// Compress data

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -1,4 +1,4 @@
-package compression
+package compression_test
 
 import (
 	"bytes"
@@ -6,19 +6,20 @@ import (
 	"io"
 	"testing"
 
+	cprss "github.com/PlakarKorp/kloset/compression"
 	"github.com/pierrec/lz4/v4"
 )
 
 // Helper function to compress and then decompress data and verify correctness
 func testCompressionDecompression(t *testing.T, algorithm string, data []byte) {
 	// Compress data
-	compressedReader, err := DeflateStream(algorithm, bytes.NewReader(data))
+	compressedReader, err := cprss.DeflateStream(algorithm, bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("DeflateStream failed for %s: %v", algorithm, err)
 	}
 
 	// Decompress data
-	decompressedReader, err := InflateStream(algorithm, io.NopCloser(compressedReader))
+	decompressedReader, err := cprss.InflateStream(algorithm, io.NopCloser(compressedReader))
 	if err != nil {
 		t.Fatalf("InflateStream failed for %s: %v", algorithm, err)
 	}
@@ -56,19 +57,20 @@ func TestCompression(t *testing.T) {
 
 func TestDefaultAlgorithm(t *testing.T) {
 	expected := "LZ4"
-	result := NewDefaultConfiguration().Algorithm
+	result := cprss.NewDefaultConfiguration().Algorithm
 
 	if result != expected {
 		t.Errorf("DefaultAlgorithm failed: expected %v, got %v", expected, result)
 	}
 }
+
 func TestUnsupportedAlgorithm(t *testing.T) {
-	_, err := DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
+	_, err := cprss.DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
 	if err == nil {
 		t.Error("Expected error for unsupported compression method, got nil")
 	}
 
-	_, err = InflateStream("unsupported", io.NopCloser(bytes.NewReader([]byte("test data"))))
+	_, err = cprss.InflateStream("unsupported", io.NopCloser(bytes.NewReader([]byte("test data"))))
 	if err == nil {
 		t.Error("Expected error for unsupported compression method, got nil")
 	}
@@ -81,24 +83,24 @@ func (e *errorReader) Read(p []byte) (n int, err error) {
 }
 
 func TestDeflateStreamErrorHandling(t *testing.T) {
-	_, err := DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
+	_, err := cprss.DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
 	if err == nil {
 		t.Error("Expected error for unsupported compression method, got nil")
 	}
 
-	_, err = DeflateStream("gzip", &errorReader{})
+	_, err = cprss.DeflateStream("gzip", &errorReader{})
 	if err == nil {
 		t.Error("Expected error for reader failure, got nil")
 	}
 }
 
 func TestInflateStreamErrorHandling(t *testing.T) {
-	_, err := InflateStream("unsupported", io.NopCloser(bytes.NewReader([]byte("test data"))))
+	_, err := cprss.InflateStream("unsupported", io.NopCloser(bytes.NewReader([]byte("test data"))))
 	if err == nil {
 		t.Error("Expected error for unsupported compression method, got nil")
 	}
 
-	_, err = InflateStream("gzip", io.NopCloser(&errorReader{}))
+	_, err = cprss.InflateStream("gzip", io.NopCloser(&errorReader{}))
 	if err == nil {
 		t.Error("Expected error for reader failure, got nil")
 	}
@@ -106,7 +108,7 @@ func TestInflateStreamErrorHandling(t *testing.T) {
 
 func TestDeflateStreamRewindLogic(t *testing.T) {
 	data := []byte("test rewind logic")
-	compressedReader, err := DeflateStream("GZIP", bytes.NewReader(data))
+	compressedReader, err := cprss.DeflateStream("GZIP", bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("DeflateStream failed: %v", err)
 	}
@@ -124,12 +126,12 @@ func TestLargeDataCompression(t *testing.T) {
 		largeData[i] = byte(i % 256)
 	}
 
-	compressedReader, err := DeflateStream("LZ4", bytes.NewReader(largeData))
+	compressedReader, err := cprss.DeflateStream("LZ4", bytes.NewReader(largeData))
 	if err != nil {
 		t.Fatalf("DeflateStream failed for large data: %v", err)
 	}
 
-	decompressedReader, err := InflateStream("LZ4", io.NopCloser(compressedReader))
+	decompressedReader, err := cprss.InflateStream("LZ4", io.NopCloser(compressedReader))
 	if err != nil {
 		t.Fatalf("InflateStream failed for large data: %v", err)
 	}
@@ -146,7 +148,7 @@ func TestLargeDataCompression(t *testing.T) {
 }
 
 func TestLookupNewDefaultConfigurationLZ4(t *testing.T) {
-	config, err := LookupDefaultConfiguration("LZ4")
+	config, err := cprss.LookupDefaultConfiguration("LZ4")
 	if err != nil {
 		t.Errorf("LookupNewDefaultConfiguration(LZ4) returned an error: %v", err)
 	}
@@ -159,7 +161,7 @@ func TestLookupNewDefaultConfigurationLZ4(t *testing.T) {
 }
 
 func TestLookupNewDefaultConfigurationGZIP(t *testing.T) {
-	config, err := LookupDefaultConfiguration("GZIP")
+	config, err := cprss.LookupDefaultConfiguration("GZIP")
 	if err != nil {
 		t.Errorf("LookupNewDefaultConfiguration(GZIP) returned an error: %v", err)
 	}
@@ -172,7 +174,7 @@ func TestLookupNewDefaultConfigurationGZIP(t *testing.T) {
 }
 
 func TestLookupNewDefaultConfigurationUnknown(t *testing.T) {
-	_, err := LookupDefaultConfiguration("unknown")
+	_, err := cprss.LookupDefaultConfiguration("unknown")
 	if err == nil {
 		t.Errorf("LookupNewDefaultConfiguration(unknown) did not return an error")
 	}

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -371,6 +371,92 @@ func TestDeflateStream(t *testing.T) {
 	})
 }
 
+func TestInflateStream(t *testing.T) {
+	t.Run("InitializationError", func(t *testing.T) {
+		decompressedReader, err := cprss.InflateStream("GZIP", io.NopCloser(bytes.NewReader([]byte("not gzip"))))
+		require.Nil(t, decompressedReader)
+		require.Error(t, err)
+	})
+
+	t.Run("DispatchGZIP", func(t *testing.T) {
+		data := []byte("hello gzip")
+		compressedData := compressDataForTest(t, "GZIP", data)
+
+		decompressedReader, err := cprss.InflateStream("GZIP", io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("DispatchLZ4", func(t *testing.T) {
+		data := []byte("hello lz4")
+		compressedData := compressDataForTest(t, "LZ4", data)
+
+		decompressedReader, err := cprss.InflateStream("LZ4", io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("PartialReadOnGZIPData", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello gzip"), 128)
+		compressedData := compressDataForTest(t, "GZIP", data)
+
+		decompressedReader, err := cprss.InflateStream("GZIP", io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		firstChunk := make([]byte, 8)
+		n, err := decompressedReader.Read(firstChunk)
+		require.NoError(t, err)
+		require.Greater(t, n, 0)
+
+		remainingDecompressedData, err := io.ReadAll(decompressedReader)
+		require.NotEmpty(t, remainingDecompressedData)
+		require.NoError(t, err)
+
+		fullDecompressedData := append(firstChunk[:n], remainingDecompressedData...)
+		require.NotEmpty(t, fullDecompressedData)
+		require.Equal(t, data, fullDecompressedData)
+	})
+
+	t.Run("PartialReadOnLZ4Data", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello lz4"), 128)
+		compressedData := compressDataForTest(t, "LZ4", data)
+
+		decompressedReader, err := cprss.InflateStream("LZ4", io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		firstChunk := make([]byte, 8)
+		n, err := decompressedReader.Read(firstChunk)
+		require.NoError(t, err)
+		require.Greater(t, n, 0)
+
+		remainingDecompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, remainingDecompressedData)
+
+		fullDecompressedData := append(firstChunk[:n], remainingDecompressedData...)
+		require.NotEmpty(t, fullDecompressedData)
+		require.Equal(t, data, fullDecompressedData)
+	})
+
+	t.Run("FailOnUnsupportedAlgorithm", func(t *testing.T) {
+		decompressedReader, err := cprss.InflateStream("UNKNOWN", io.NopCloser(bytes.NewReader([]byte("test data"))))
+		require.Nil(t, decompressedReader)
+		require.EqualError(t, err, `unsupported compression method "UNKNOWN"`)
+	})
+}
+
 func TestUnsupportedAlgorithm(t *testing.T) {
 	_, err := cprss.DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
 	if err == nil {

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -457,56 +457,6 @@ func TestInflateStream(t *testing.T) {
 	})
 }
 
-func TestUnsupportedAlgorithm(t *testing.T) {
-	_, err := cprss.DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
-	if err == nil {
-		t.Error("Expected error for unsupported compression method, got nil")
-	}
-
-	_, err = cprss.InflateStream("unsupported", io.NopCloser(bytes.NewReader([]byte("test data"))))
-	if err == nil {
-		t.Error("Expected error for unsupported compression method, got nil")
-	}
-}
-
-func TestDeflateStreamErrorHandling(t *testing.T) {
-	_, err := cprss.DeflateStream("unsupported", bytes.NewReader([]byte("test data")))
-	if err == nil {
-		t.Error("Expected error for unsupported compression method, got nil")
-	}
-
-	_, err = cprss.DeflateStream("gzip", &errorReader{})
-	if err == nil {
-		t.Error("Expected error for reader failure, got nil")
-	}
-}
-
-func TestInflateStreamErrorHandling(t *testing.T) {
-	_, err := cprss.InflateStream("unsupported", io.NopCloser(bytes.NewReader([]byte("test data"))))
-	if err == nil {
-		t.Error("Expected error for unsupported compression method, got nil")
-	}
-
-	_, err = cprss.InflateStream("gzip", io.NopCloser(&errorReader{}))
-	if err == nil {
-		t.Error("Expected error for reader failure, got nil")
-	}
-}
-
-func TestDeflateStreamRewindLogic(t *testing.T) {
-	data := []byte("test rewind logic")
-	compressedReader, err := cprss.DeflateStream("GZIP", bytes.NewReader(data))
-	if err != nil {
-		t.Fatalf("DeflateStream failed: %v", err)
-	}
-
-	buf := make([]byte, 1)
-	n, err := compressedReader.Read(buf)
-	if err != nil || n != 1 {
-		t.Fatalf("Rewind logic test failed: expected 1 byte read, got %d, error: %v", n, err)
-	}
-}
-
 func TestLargeDataCompression(t *testing.T) {
 	largeData := make([]byte, 10*1024*1024) // 10MB of data
 	for i := range largeData {


### PR DESCRIPTION
This PR rewrites the `compression` test suite to make it more explicit, more consistent, and closer to black-box testing. It also replaces weak assertions with `testify/require`. 

# Changes

- add dedicated tests for:
  - `NewDefaultConfiguration`
  - `LookupDefaultConfiguration`
  - `DeflateGzipStream`
  - `InflateGzipStream`
  - `DeflateLZ4Stream`
  - `InflateLZ4Stream`
  - `DeflateStream`
  - `InflateStream`
- add reusable test helpers for compression/decompression setup
- improve coverage for:
  - default values
  - unsupported algorithms
  - invalid and corrupted compressed data
  - source reader failures
  - partial reads on streamed data
  - large data round-trips for GZIP and LZ4 
- remove or replace older broad round-trip tests
- remove misleading tests around unsupported algorithm handling
- replace weaker checks with stricter assertions based on observable behavior 

# Results

## Before

```
github.com/PlakarKorp/kloset/compression/compression.go:21:	NewDefaultConfiguration		100.0%
github.com/PlakarKorp/kloset/compression/compression.go:32:	LookupDefaultConfiguration	100.0%
github.com/PlakarKorp/kloset/compression/compression.go:57:	DeflateStream				100.0%
github.com/PlakarKorp/kloset/compression/compression.go:68:	DeflateGzipStream			88.9%
github.com/PlakarKorp/kloset/compression/compression.go:83:	DeflateLZ4Stream			88.9%
github.com/PlakarKorp/kloset/compression/compression.go:97:	InflateStream				100.0%
github.com/PlakarKorp/kloset/compression/compression.go:108:	InflateGzipStream		81.8%
github.com/PlakarKorp/kloset/compression/compression.go:132:	InflateLZ4Stream		90.0%
total:								(statements)										90.4%
```


## After

```
github.com/PlakarKorp/kloset/compression/compression.go:21:	NewDefaultConfiguration		100.0%
github.com/PlakarKorp/kloset/compression/compression.go:32:	LookupDefaultConfiguration	100.0%
github.com/PlakarKorp/kloset/compression/compression.go:57:	DeflateStream				100.0%
github.com/PlakarKorp/kloset/compression/compression.go:68:	DeflateGzipStream			100.0%
github.com/PlakarKorp/kloset/compression/compression.go:83:	DeflateLZ4Stream			100.0%
github.com/PlakarKorp/kloset/compression/compression.go:97:	InflateStream				100.0%
github.com/PlakarKorp/kloset/compression/compression.go:108:	InflateGzipStream		100.0%
github.com/PlakarKorp/kloset/compression/compression.go:132:	InflateLZ4Stream		100.0%
total:								(statements)										100.0%
```
