### PR TITLE
Refactor importer tests and improve API coverage

### DIFF
--- a/connectors/importer/importer_test.go
+++ b/connectors/importer/importer_test.go
@@ -2,8 +2,10 @@ package importer_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -163,44 +165,166 @@ func TestBackends(t *testing.T) {
 }
 
 func TestNewImporter(t *testing.T) {
-	// Setup: Register some backends
-	con.Register("fs", location.FLAG_LOCALFS, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
-		return MockedImporter{}, nil
-	})
-	con.Register("s3", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
-		return MockedImporter{}, nil
-	})
-	con.Register("ftp", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
-		return MockedImporter{}, nil
-	})
+	registerBackend := func(
+		t *testing.T,
+		name string,
+		flags location.Flags,
+		backendFn con.ImporterFn,
+	) {
+		t.Helper()
 
-	tests := []struct {
-		location        string
-		expectedError   string
-		expectedBackend string
-	}{
-		{location: "/", expectedError: "", expectedBackend: "fs"},
-		{location: "fs://some/path", expectedError: "", expectedBackend: "fs"},
-		{location: "s3://bucket/path", expectedError: "", expectedBackend: "s3"},
-		{location: "ftp://some/path", expectedError: "", expectedBackend: "ftp"},
-		{location: "http://unsupported", expectedError: "unsupported importer protocol", expectedBackend: ""},
+		err := con.Register(name, flags, backendFn)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = con.Unregister(name) })
 	}
 
-	for _, test := range tests {
-		t.Run(test.location, func(t *testing.T) {
-			appCtx := kcontext.NewKContext()
+	t.Run("FailsIfLocationIsMissing", func(t *testing.T) {
+		appCtx := kcontext.NewKContext()
 
-			importer, err := con.NewImporter(appCtx, nil, map[string]string{"location": test.location})
+		importer, err := con.NewImporter(appCtx, nil, map[string]string{})
+		require.Nil(t, importer)
+		require.EqualError(t, err, "missing location")
+	})
 
-			if test.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), test.expectedError)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, importer)
-			}
+	t.Run("FailsIfProtocolIsUnsupported", func(t *testing.T) {
+		appCtx := kcontext.NewKContext()
+
+		importer, err := con.NewImporter(appCtx, nil, map[string]string{
+			"location": "unsupported://some/path",
 		})
-	}
+		require.Nil(t, importer)
+		require.EqualError(t, err, "unsupported importer protocol")
+	})
+
+	t.Run("UseDefaultFSProtocolForRelativeLocalPath", func(t *testing.T) {
+		var (
+			called           bool
+			receivedCtx      context.Context
+			receivedOpts     *connectors.Options
+			receivedProto    string
+			receivedLocation string
+		)
+
+		backend := func(
+			ctx context.Context,
+			opts *connectors.Options,
+			proto string,
+			config map[string]string,
+		) (con.Importer, error) {
+			called = true
+			receivedCtx = ctx
+			receivedOpts = opts
+			receivedProto = proto
+			receivedLocation = config["location"]
+			return MockedImporter{}, nil
+		}
+
+		registerBackend(t, "fs", location.FLAG_LOCALFS, backend)
+
+		appCtx := kcontext.NewKContext()
+		appCtx.CWD = t.TempDir()
+
+		opts := &connectors.Options{}
+		config := map[string]string{
+			"location": "relative/path",
+		}
+
+		importer, err := con.NewImporter(appCtx, opts, config)
+		require.NoError(t, err)
+		require.NotNil(t, importer)
+		require.True(t, called)
+		require.Same(t, appCtx, receivedCtx)
+		require.Same(t, opts, receivedOpts)
+		require.Equal(t, "fs", receivedProto)
+
+		expectedLocation := "fs://" + filepath.Join(appCtx.CWD, "relative/path")
+		require.Equal(t, expectedLocation, receivedLocation)
+		require.Equal(t, expectedLocation, config["location"])
+	})
+
+	t.Run("KeepAbsoluteLocalPathUnchanged", func(t *testing.T) {
+		var receivedLocation string
+
+		backend := func(
+			ctx context.Context,
+			opts *connectors.Options,
+			proto string,
+			config map[string]string,
+		) (con.Importer, error) {
+			receivedLocation = config["location"]
+			return MockedImporter{}, nil
+		}
+
+		registerBackend(t, "fs", location.FLAG_LOCALFS, backend)
+
+		appCtx := kcontext.NewKContext()
+		absolutePath := filepath.Join(t.TempDir(), "some", "path")
+		config := map[string]string{
+			"location": "fs://" + absolutePath,
+		}
+
+		importer, err := con.NewImporter(appCtx, nil, config)
+		require.NoError(t, err)
+		require.NotNil(t, importer)
+		require.Equal(t, "fs://"+absolutePath, receivedLocation)
+		require.Equal(t, "fs://"+absolutePath, config["location"])
+	})
+
+	t.Run("DoNotRewriteNonLocalLocation", func(t *testing.T) {
+		var (
+			receivedProto    string
+			receivedLocation string
+		)
+
+		backend := func(
+			ctx context.Context,
+			opts *connectors.Options,
+			proto string,
+			config map[string]string,
+		) (con.Importer, error) {
+			receivedProto = proto
+			receivedLocation = config["location"]
+			return MockedImporter{}, nil
+		}
+
+		registerBackend(t, "s3", 0, backend)
+
+		appCtx := kcontext.NewKContext()
+		config := map[string]string{
+			"location": "s3://bucket/path",
+		}
+
+		importer, err := con.NewImporter(appCtx, nil, config)
+		require.NoError(t, err)
+		require.NotNil(t, importer)
+		require.Equal(t, "s3", receivedProto)
+		require.Equal(t, "s3://bucket/path", receivedLocation)
+		require.Equal(t, "s3://bucket/path", config["location"])
+	})
+
+	t.Run("PropagateBackendError", func(t *testing.T) {
+		expectedErr := errors.New("backend failure")
+
+		backend := func(
+			ctx context.Context,
+			opts *connectors.Options,
+			proto string,
+			config map[string]string,
+		) (con.Importer, error) {
+			return nil, expectedErr
+		}
+		registerBackend(t, "ftp", 0, backend)
+
+		appCtx := kcontext.NewKContext()
+		config := map[string]string{
+			"location": "ftp://some/path",
+		}
+
+		importer, err := con.NewImporter(appCtx, nil, config)
+		require.Nil(t, importer)
+		require.ErrorIs(t, err, expectedErr)
+	})
 }
 
 func TestNewScanRecord(t *testing.T) {

--- a/connectors/importer/importer_test.go
+++ b/connectors/importer/importer_test.go
@@ -3,17 +3,14 @@ package importer_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/PlakarKorp/kloset/connectors"
 	con "github.com/PlakarKorp/kloset/connectors/importer"
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/location"
-	"github.com/PlakarKorp/kloset/objects"
 	"github.com/stretchr/testify/require"
 )
 
@@ -325,40 +322,4 @@ func TestNewImporter(t *testing.T) {
 		require.Nil(t, importer)
 		require.ErrorIs(t, err, expectedErr)
 	})
-}
-
-func TestNewScanRecord(t *testing.T) {
-	pathname := "/path/to/file"
-	target := "target"
-	now := time.Now().Local()
-
-	fileinfo := objects.NewFileInfo("file", 300000, 0644, now, 1, 2, 3, 4, 5)
-	xattr := []string{"attr1", "attr2"}
-
-	record := connectors.NewRecord(pathname, target, fileinfo, xattr, nil)
-
-	require.Equal(t, pathname, record.Pathname)
-	require.Equal(t, target, record.Target)
-	require.Equal(t, fileinfo, record.FileInfo)
-	require.ElementsMatch(t, xattr, record.ExtendedAttributes)
-}
-
-func TestNewScanXattr(t *testing.T) {
-	pathname := "/path/to/file"
-	xattrname := "foo/bar"
-
-	record := connectors.NewXattr(pathname, xattrname, objects.AttributeExtended, nil)
-
-	require.Equal(t, pathname, record.Pathname)
-	require.Equal(t, xattrname, record.XattrName)
-	require.True(t, record.IsXattr)
-}
-
-func TestNewScanError(t *testing.T) {
-	pathname := "/path/to/file"
-	err := fmt.Errorf("some error")
-
-	record := connectors.NewError(pathname, err)
-
-	require.Equal(t, pathname, record.Pathname)
 }

--- a/connectors/importer/importer_test.go
+++ b/connectors/importer/importer_test.go
@@ -43,6 +43,38 @@ func (m MockedImporter) Close(ctx context.Context) error {
 	return nil
 }
 
+func TestRegister(t *testing.T) {
+	backendFn := func(
+		ctx context.Context,
+		opts *connectors.Options,
+		proto string,
+		config map[string]string,
+	) (con.Importer, error) {
+		return nil, nil
+	}
+
+	t.Run("ValidBackendRegistration", func(t *testing.T) {
+		backendName := "test-register-backend"
+
+		err := con.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		t.Cleanup(func() { _ = con.Unregister(backendName) })
+
+		require.NoError(t, err)
+	})
+
+	t.Run("FailsIfBackendAlreadyRegistered", func(t *testing.T) {
+		backendName := "test-register-duplicate"
+
+		err := con.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = con.Unregister(backendName) })
+
+		err = con.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.EqualError(t, err, "importer backend 'test-register-duplicate' already registered")
+	})
+}
+
 func TestBackends(t *testing.T) {
 	// Setup: Register some backends
 	con.Register("local1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {

--- a/connectors/importer/importer_test.go
+++ b/connectors/importer/importer_test.go
@@ -1,4 +1,4 @@
-package importer
+package importer_test
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/PlakarKorp/kloset/connectors"
+	con "github.com/PlakarKorp/kloset/connectors/importer"
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
@@ -43,18 +44,17 @@ func (m MockedImporter) Close(ctx context.Context) error {
 }
 
 func TestBackends(t *testing.T) {
-
 	// Setup: Register some backends
-	Register("local1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (Importer, error) {
+	con.Register("local1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
 		return nil, nil
 	})
-	Register("remote1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (Importer, error) {
+	con.Register("remote1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
 		return nil, nil
 	})
 
 	// Test: Retrieve the list of registered backends
 	expectedBackends := []string{"local1", "remote1"}
-	actualBackends := Backends()
+	actualBackends := con.Backends()
 
 	// Assert: Check if the actual backends match the expected
 	require.ElementsMatch(t, expectedBackends, actualBackends)
@@ -62,13 +62,13 @@ func TestBackends(t *testing.T) {
 
 func TestNewImporter(t *testing.T) {
 	// Setup: Register some backends
-	Register("fs", location.FLAG_LOCALFS, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (Importer, error) {
+	con.Register("fs", location.FLAG_LOCALFS, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("s3", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (Importer, error) {
+	con.Register("s3", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
 		return MockedImporter{}, nil
 	})
-	Register("ftp", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (Importer, error) {
+	con.Register("ftp", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
 		return MockedImporter{}, nil
 	})
 
@@ -88,7 +88,7 @@ func TestNewImporter(t *testing.T) {
 		t.Run(test.location, func(t *testing.T) {
 			appCtx := kcontext.NewKContext()
 
-			importer, err := NewImporter(appCtx, nil, map[string]string{"location": test.location})
+			importer, err := con.NewImporter(appCtx, nil, map[string]string{"location": test.location})
 
 			if test.expectedError != "" {
 				require.Error(t, err)

--- a/connectors/importer/importer_test.go
+++ b/connectors/importer/importer_test.go
@@ -119,20 +119,47 @@ func TestUnregister(t *testing.T) {
 }
 
 func TestBackends(t *testing.T) {
-	// Setup: Register some backends
-	con.Register("local1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
+	backendFn := func(
+		ctx context.Context,
+		opts *connectors.Options,
+		proto string,
+		config map[string]string,
+	) (con.Importer, error) {
 		return nil, nil
-	})
-	con.Register("remote1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {
-		return nil, nil
+	}
+
+	t.Run("GetRegisteredBackends", func(t *testing.T) {
+		backendName1 := "test-backends-first"
+		backendName2 := "test-backends-second"
+
+		err := con.Register(backendName1, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = con.Register(backendName2, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_ = con.Unregister(backendName1)
+			_ = con.Unregister(backendName2)
+		})
+
+		backends := con.Backends()
+		require.Contains(t, backends, backendName1)
+		require.Contains(t, backends, backendName2)
 	})
 
-	// Test: Retrieve the list of registered backends
-	expectedBackends := []string{"local1", "remote1"}
-	actualBackends := con.Backends()
+	t.Run("DoNotGetUnregisteredBackends", func(t *testing.T) {
+		backendName := "test-backends-removed"
 
-	// Assert: Check if the actual backends match the expected
-	require.ElementsMatch(t, expectedBackends, actualBackends)
+		err := con.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = con.Unregister(backendName)
+		require.NoError(t, err)
+
+		backends := con.Backends()
+		require.NotContains(t, backends, backendName)
+	})
 }
 
 func TestNewImporter(t *testing.T) {

--- a/connectors/importer/importer_test.go
+++ b/connectors/importer/importer_test.go
@@ -75,6 +75,49 @@ func TestRegister(t *testing.T) {
 	})
 }
 
+func TestUnregister(t *testing.T) {
+	backendFn := func(
+		ctx context.Context,
+		opts *connectors.Options,
+		proto string,
+		config map[string]string,
+	) (con.Importer, error) {
+		return nil, nil
+	}
+
+	t.Run("ValidBackendUnregistration", func(t *testing.T) {
+		backendName := "test-unregister-backend"
+
+		err := con.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = con.Unregister(backendName)
+		require.NoError(t, err)
+	})
+
+	t.Run("FailsIfBackendIsNotRegistered", func(t *testing.T) {
+		backendName := "test-unregister-missing"
+
+		err := con.Unregister(backendName)
+		require.EqualError(t, err, "importer backend 'test-unregister-missing' not registered")
+	})
+
+	t.Run("Register->Unregister->Register", func(t *testing.T) {
+		backendName := "test-unregister-backend"
+
+		err := con.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = con.Unregister(backendName)
+		require.NoError(t, err)
+
+		err = con.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = con.Unregister(backendName) })
+	})
+}
+
 func TestBackends(t *testing.T) {
 	// Setup: Register some backends
 	con.Register("local1", 0, func(appCtx context.Context, opts *connectors.Options, name string, config map[string]string) (con.Importer, error) {


### PR DESCRIPTION
This PR refactors the `connectors/importer` test suite to make it more explicit, more consistent, and closer to black-box testing.

##Changes

- switch tests to the external `importer_test` package
- add dedicated tests for:
  - `Register`
  - `Unregister`
  - `Backends`
  - `NewImporter`
- replace weak or broad checks with stricter `require` assertions
- successful backend registration
- duplicate backend registration errors
- successful backend unregistration
- unregistration errors for unknown backends
- backend listing for registered and unregistered entries
- `NewImporter` failure when `location` is missing
- `NewImporter` failure on unsupported protocols
- default `fs` resolution for relative local paths
- preservation of absolute local paths
- no path rewriting for non-local backends
- backend error propagation

# Results

## Before

```
github.com/PlakarKorp/kloset/connectors/importer/importer.go:43:	Register	66.7%
github.com/PlakarKorp/kloset/connectors/importer/importer.go:50:	Unregister	0.0%
github.com/PlakarKorp/kloset/connectors/importer/importer.go:57:	Backends	100.0%
github.com/PlakarKorp/kloset/connectors/importer/importer.go:61:	NewImporter	84.6%
total:									(statements)							70.0%
```

## After

```
github.com/PlakarKorp/kloset/connectors/importer/importer.go:43:	Register	100.0%
github.com/PlakarKorp/kloset/connectors/importer/importer.go:50:	Unregister	100.0%
github.com/PlakarKorp/kloset/connectors/importer/importer.go:57:	Backends	100.0%
github.com/PlakarKorp/kloset/connectors/importer/importer.go:61:	NewImporter	100.0%
total:									(statements)							100.0%
```