### PR TITLE
btree last unitests:  improve btree test coverage

### DIFF
--- a/btree/cache_internal_test.go
+++ b/btree/cache_internal_test.go
@@ -1,0 +1,38 @@
+package btree
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Get(t *testing.T) {
+	t.Run("Fails_BecauseLRUFlushFails", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n1 := Node[rune, int, int]{
+			Keys:     []rune{'a'},
+			Pointers: []int{1},
+		}
+		n2 := Node[rune, int, int]{
+			Keys:     []rune{'b'},
+			Pointers: []int{2},
+		}
+		ptr1, err := st.Put(&n1)
+		require.NoError(t, err)
+		ptr2, err := st.Put(&n2)
+		require.NoError(t, err)
+
+		c := cachefor[rune, int, int](&st, 1)
+		n, err := st.Get(ptr1)
+		require.NoError(t, err)
+		require.NoError(t, c.Update(ptr1, n))
+
+		flushErr := errors.New("Store.Update() failed")
+		st.UpdateFn = func(ptr int, n *Node[rune, int, int]) error { return flushErr }
+
+		got, err := c.Get(ptr2)
+		require.ErrorIs(t, err, flushErr)
+		require.Nil(t, got)
+	})
+}

--- a/btree/iter_internal_test.go
+++ b/btree/iter_internal_test.go
@@ -1,0 +1,246 @@
+package btree
+
+import (
+	"cmp"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newIteratorFWD(
+	t *testing.T,
+	st *InMemoryStore_t[rune, int],
+	cacheSize int,
+	ptr int,
+	e error,
+) (*BTree[rune, int, int], *forwardIter[rune, int, int], *Node[rune, int, int]) {
+	t.Helper()
+
+	n, err := st.Get(ptr)
+	require.NoError(t, err)
+
+	b := &BTree[rune, int, int]{
+		Order:   3,
+		Root:    ptr,
+		cache:   cachefor[rune, int, int](st, cacheSize),
+		compare: cmp.Compare[rune],
+	}
+
+	it := &forwardIter[rune, int, int]{
+		b:       b,
+		ptr:     ptr,
+		current: n,
+		idx:     -1,
+		err:     e,
+	}
+	return b, it, n
+}
+
+func TestForwardIter(t *testing.T) {
+	/* -------------------------
+	   Err
+	-------------------------- */
+	t.Run("Err_InitiallyToAnError", func(t *testing.T) {
+		oops := errors.New("oops")
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, oops)
+		require.ErrorIs(t, it.Err(), oops)
+	})
+
+	t.Run("Err_InitiallyNil", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, nil)
+		require.NoError(t, it.Err())
+	})
+
+	/* -------------------------
+	   Next
+	-------------------------- */
+	t.Run("Next_ValidAccess", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, nil)
+		require.True(t, it.Next())
+	})
+
+	t.Run("NextFails_BecauseOfPreviousError", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		oops := errors.New("oops")
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, oops)
+
+		require.False(t, it.Next())
+		require.ErrorIs(t, it.Err(), oops)
+	})
+
+	t.Run("Next_AtEnd", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, nil)
+
+		require.True(t, it.Next())
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("NextInvalid_WhenCurrentInvalid", func(t *testing.T) {
+		it := forwardIter[rune, int, int]{current: nil}
+		require.Panics(t, func() { it.Next() })
+	})
+
+	t.Run("Next_SetsErrOnCacheMissError", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n2 := Node[rune, int, int]{
+			Keys:   []rune{'c'},
+			Values: []int{3},
+		}
+		ptr2, err := st.Put(&n2)
+		require.NoError(t, err)
+
+		n1 := Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+			Next:   &ptr2,
+		}
+		ptr1, err := st.Put(&n1)
+		require.NoError(t, err)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(ptr int) (*Node[rune, int, int], error) {
+			if ptr == ptr2 {
+				return nil, getErr
+			}
+			if ptr >= len(st.store) {
+				return nil, notfound
+			}
+			return &st.store[ptr], nil
+		}
+
+		// enforce a cache miss on ptr2
+		_, it, _ := newIteratorFWD(t, &st, 1, ptr1, nil)
+
+		n, err := st.Get(ptr1)
+		require.NoError(t, err)
+		require.NoError(t, it.b.cache.lru.Put(ptr1, &cacheitem[rune, int, int]{node: n}))
+
+		require.True(t, it.Next())
+		require.True(t, it.Next())
+		require.False(t, it.Next())
+		require.ErrorIs(t, it.Err(), getErr)
+	})
+
+	t.Run("Next_ValidCacheMiss", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n2 := Node[rune, int, int]{
+			Keys:   []rune{'c'},
+			Values: []int{3},
+		}
+		ptr2, err := st.Put(&n2)
+		require.NoError(t, err)
+
+		n1 := Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+			Next:   &ptr2,
+		}
+		ptr1, err := st.Put(&n1)
+		require.NoError(t, err)
+
+		// enforce a cache miss on ptr2
+		_, it, n := newIteratorFWD(t, &st, 1, ptr1, nil)
+		require.NoError(t, it.b.cache.lru.Put(ptr1, &cacheitem[rune, int, int]{node: n}))
+
+		require.True(t, it.Next())
+		require.True(t, it.Next())
+		// cache miss valid
+		require.True(t, it.Next())
+		require.Equal(t, ptr2, it.ptr)
+		require.NotNil(t, it.current)
+		require.Equal(t, 0, it.idx)
+		require.Equal(t, rune('c'), it.current.Keys[it.idx])
+		require.Equal(t, 3, it.current.Values[it.idx])
+		require.NoError(t, it.Err())
+	})
+
+	/* -------------------------
+	   Current
+	-------------------------- */
+	t.Run("CurrentInvalid", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, nil)
+		require.Panics(t, func() { _, _ = it.Current() })
+	})
+
+	t.Run("CurrentValid", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, nil)
+
+		require.True(t, it.Next())
+		k, v := it.Current()
+		require.Equal(t, rune('a'), k)
+		require.Equal(t, 1, v)
+	})
+
+	t.Run("CurrentInvalid_BecauseAtEnd", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it, _ := newIteratorFWD(t, &st, 2, ptr, nil)
+
+		require.True(t, it.Next())
+		require.False(t, it.Next())
+		require.Panics(t, func() { _, _ = it.Current() })
+	})
+}

--- a/btree/iter_internal_test.go
+++ b/btree/iter_internal_test.go
@@ -424,7 +424,7 @@ func TestBackwardIter(t *testing.T) {
 		require.NoError(t, it.Err())
 	})
 
-	t.Run("Next_RewindsAndDivesLef_tWhenRighDone", func(t *testing.T) {
+	t.Run("Next_RewindsAndDivesLeft_WhenRighDone", func(t *testing.T) {
 		st := InMemoryStore_t[rune, int]{}
 
 		leafL := Node[rune, int, int]{

--- a/btree/iter_internal_test.go
+++ b/btree/iter_internal_test.go
@@ -244,3 +244,466 @@ func TestForwardIter(t *testing.T) {
 		require.Panics(t, func() { _, _ = it.Current() })
 	})
 }
+
+func newIteratorBWD(
+	t *testing.T,
+	st *InMemoryStore_t[rune, int],
+	cacheSize int,
+	ptr int,
+	e error,
+) (*BTree[rune, int, int], *backwardIter[rune, int, int]) {
+	t.Helper()
+
+	b := &BTree[rune, int, int]{
+		Order:   3,
+		Root:    ptr,
+		cache:   cachefor[rune, int, int](st, cacheSize),
+		compare: cmp.Compare[rune],
+	}
+
+	it := &backwardIter[rune, int, int]{
+		b:   b,
+		err: e,
+	}
+	return b, it
+}
+
+func TestBackwardIter(t *testing.T) {
+	/* -------------------------
+	   Err
+	-------------------------- */
+	t.Run("Err_InitiallyToAnError", func(t *testing.T) {
+		oops := errors.New("oops")
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 2, ptr, oops)
+		require.ErrorIs(t, it.Err(), oops)
+	})
+
+	t.Run("Err_InitiallyNil", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 2, ptr, nil)
+		require.NoError(t, it.Err())
+	})
+
+	/* -------------------------
+	   dive
+	-------------------------- */
+
+	t.Run("Dive_Initialization", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+
+		leafL := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+
+		leafR := Node[rune, int, int]{
+			Keys:   []rune{'b', 'c'},
+			Values: []int{2, 3},
+		}
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := Node[rune, int, int]{
+			Keys:     []rune{'b'},
+			Pointers: []int{ptrL, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 4, rootPtr, nil)
+
+		require.NoError(t, it.dive(rootPtr))
+		require.NotEmpty(t, it.steps)
+		require.NotNil(t, it.cur)
+		require.Equal(t, leafR.Keys, it.cur.Keys)
+		require.Equal(t, len(leafR.Keys), it.steps[len(it.steps)-1].idx)
+	})
+
+	t.Run("DiveFails_BecauseStoreGetFails", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 2, ptr, nil)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(_ int) (*Node[rune, int, int], error) { return nil, getErr }
+
+		require.ErrorIs(t, it.dive(ptr), getErr)
+	})
+
+	/* -------------------------
+	   Next
+	-------------------------- */
+	t.Run("NextFails_BecauseOfPreviousError", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		oops := errors.New("oops")
+		_, it := newIteratorBWD(t, &st, 2, ptr, oops)
+
+		require.False(t, it.Next())
+		require.ErrorIs(t, it.Err(), oops)
+	})
+
+	t.Run("NoNext_WhenNoSteps", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 2, ptr, nil)
+
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("Next_CheckLeafIdx_WhenIdxGreaterThanZero", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 2, ptr, nil)
+		require.NoError(t, it.dive(ptr))
+
+		before := it.steps[len(it.steps)-1].idx
+		require.True(t, it.Next())
+		after := it.steps[len(it.steps)-1].idx
+
+		require.Equal(t, before-1, after)
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("Next_AtEnd", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 2, ptr, nil)
+		require.NoError(t, it.dive(ptr))
+
+		require.True(t, it.Next())
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("Next_RewindsAndDivesLef_tWhenRighDone", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+
+		leafL := Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+
+		leafR := Node[rune, int, int]{
+			Keys:   []rune{'c', 'd'},
+			Values: []int{3, 4},
+		}
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := Node[rune, int, int]{
+			Keys:     []rune{'c'},
+			Pointers: []int{ptrL, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 4, rootPtr, nil)
+		require.NoError(t, it.dive(rootPtr))
+
+		// Dive right to the end
+		require.True(t, it.Next())
+		require.True(t, it.Next())
+
+		// Now Next rewinds
+		require.True(t, it.Next())
+		require.NoError(t, it.Err())
+		require.Equal(t, leafL.Keys, it.cur.Keys)
+		require.Equal(t, leafL.Values, it.cur.Values)
+		require.Equal(t, len(leafL.Keys)-1, it.steps[len(it.steps)-1].idx)
+	})
+
+	t.Run("NextFails_BecauseStoreGetFailsDuringRewind", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+
+		leafL := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+
+		leafR := Node[rune, int, int]{
+			Keys:   []rune{'b'},
+			Values: []int{2},
+		}
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := Node[rune, int, int]{
+			Keys:     []rune{'b'},
+			Pointers: []int{ptrL, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 1, rootPtr, nil)
+		require.NoError(t, it.dive(rootPtr))
+
+		// Go right once
+		require.True(t, it.Next())
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(ptr int) (*Node[rune, int, int], error) {
+			if ptr == rootPtr {
+				return nil, getErr
+			}
+			if ptr >= len(st.store) {
+				return nil, notfound
+			}
+			return &st.store[ptr], nil
+		}
+
+		require.False(t, it.Next())
+		require.ErrorIs(t, it.Err(), getErr)
+	})
+
+	t.Run("Next_RewindLoopBubblesUp", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+
+		leafA := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptrA, err := st.Put(&leafA)
+		require.NoError(t, err)
+
+		leafB := Node[rune, int, int]{
+			Keys:   []rune{'b'},
+			Values: []int{2},
+		}
+		ptrB, err := st.Put(&leafB)
+		require.NoError(t, err)
+
+		leafC := Node[rune, int, int]{
+			Keys:   []rune{'c'},
+			Values: []int{3},
+		}
+		ptrC, err := st.Put(&leafC)
+		require.NoError(t, err)
+
+		internalR := Node[rune, int, int]{
+			Keys:     []rune{'c'},
+			Pointers: []int{ptrB, ptrC},
+		}
+		internalPtr, err := st.Put(&internalR)
+		require.NoError(t, err)
+
+		root := Node[rune, int, int]{
+			Keys:     []rune{'b'},
+			Pointers: []int{ptrA, internalPtr},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 8, rootPtr, nil)
+		require.NoError(t, it.dive(rootPtr))
+
+		// Sanity check
+		require.NotNil(t, it.cur)
+		require.Equal(t, leafC.Keys, it.cur.Keys)
+		require.Equal(t, 1, it.steps[len(it.steps)-1].idx)
+		require.NoError(t, it.Err())
+
+		// Consume C
+		require.True(t, it.Next())
+		require.NoError(t, it.Err())
+		require.Equal(t, 0, it.steps[len(it.steps)-1].idx, "precondition: last.idx must be 0 before triggering rewind")
+
+		// Rewind to B
+		require.True(t, it.Next())
+		require.NoError(t, it.Err())
+		require.Equal(t, leafB.Keys, it.cur.Keys)
+		require.Equal(t, 0, it.steps[len(it.steps)-1].idx)
+
+		// Rewind to A
+		require.True(t, it.Next())
+		require.NoError(t, it.Err())
+
+		// Check position on A
+		require.Equal(t, leafA.Keys, it.cur.Keys)
+		require.Equal(t, 0, it.steps[len(it.steps)-1].idx)
+
+		// Check if Internal node popped out of the stack
+		require.Equal(t, 2, len(it.steps))
+		require.Equal(t, rootPtr, it.steps[0].ptr)
+		require.Equal(t, ptrA, it.steps[1].ptr)
+
+		// End of tree
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
+
+	/* -------------------------
+	   Current
+	-------------------------- */
+	t.Run("Current_InvalidAccess", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 4, ptr, nil)
+		require.NoError(t, it.dive(ptr))
+
+		require.Panics(t, func() { _, _ = it.Current() })
+	})
+
+	t.Run("Current_ValidAccess", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 4, ptr, nil)
+		require.NoError(t, it.dive(ptr))
+
+		require.True(t, it.Next())
+		require.NoError(t, it.Err())
+
+		k, v := it.Current()
+		require.Equal(t, rune('b'), k)
+		require.Equal(t, 2, v)
+	})
+
+	t.Run("Current_ValidAccess_GoUpOnParent", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 4, ptr, nil)
+		require.NoError(t, it.dive(ptr))
+
+		require.True(t, it.Next()) // now at 'b'
+		require.True(t, it.Next()) // now at 'a'
+		require.NoError(t, it.Err())
+
+		k, v := it.Current()
+		require.Equal(t, rune('a'), k)
+		require.Equal(t, 1, v)
+	})
+
+	t.Run("Current_ValidAccess_AfterRewind", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+
+		leafL := Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+
+		leafR := Node[rune, int, int]{
+			Keys:   []rune{'c'},
+			Values: []int{3},
+		}
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := Node[rune, int, int]{
+			Keys:     []rune{'c'},
+			Pointers: []int{ptrL, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 8, rootPtr, nil)
+		require.NoError(t, it.dive(rootPtr))
+
+		// Consume leaf right
+		require.True(t, it.Next())
+
+		// Rewind on B
+		require.True(t, it.Next())
+		require.NoError(t, it.Err())
+
+		k, v := it.Current()
+		require.Equal(t, rune('b'), k)
+		require.Equal(t, 2, v)
+	})
+
+	t.Run("Current_ValidAccessAtEnd", func(t *testing.T) {
+		st := InMemoryStore_t[rune, int]{}
+
+		n := Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		ptr, err := st.Put(&n)
+		require.NoError(t, err)
+
+		_, it := newIteratorBWD(t, &st, 4, ptr, nil)
+		require.NoError(t, it.dive(ptr))
+
+		// on A
+		require.True(t, it.Next())
+		// End of tree
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+
+		k, v := it.Current()
+		require.Equal(t, rune('a'), k)
+		require.Equal(t, 1, v)
+	})
+}

--- a/btree/iter_test.go
+++ b/btree/iter_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTreeRunes(
+func BuildTreeRunes(
 	t *testing.T,
 	st *btree.InMemoryStore_t[rune, int],
 	order int,
@@ -31,7 +31,7 @@ func TestScanAll(t *testing.T) {
 	t.Run("IteratesInOrder", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 3, keys)
+		tree := BuildTreeRunes(t, &st, 3, keys)
 
 		it, err := tree.ScanAll()
 		require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestScanAll(t *testing.T) {
 	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 3, keys)
+		tree := BuildTreeRunes(t, &st, 3, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("StartsExactlyAtKeyIfKeyExists", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 8, keys)
+		tree := BuildTreeRunes(t, &st, 8, keys)
 
 		it, err := tree.ScanFrom('e')
 		require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("StartsAtFirstGreaterIfKeyMissing_inSameNode", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune{'a', 'c', 'e', 'g', 'i'}
-		tree := buildTreeRunes(t, &st, 8, keys)
+		tree := BuildTreeRunes(t, &st, 8, keys)
 
 		it, err := tree.ScanFrom('d')
 		require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("StartsAtFirstGreaterIfKeyMissing_inAnotherNode", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 3, keys)
+		tree := BuildTreeRunes(t, &st, 3, keys)
 
 		it, err := tree.ScanFrom('c')
 		require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestScanFrom(t *testing.T) {
 
 	t.Run("EmptyIteratorIfKeyGreaterThanMax", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
-		tree := buildTreeRunes(t, &st, 8, []rune("abc"))
+		tree := BuildTreeRunes(t, &st, 8, []rune("abc"))
 
 		it, err := tree.ScanFrom('z')
 		require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("ScanFrom_ReturnsError_WhenFindLeafFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 8, keys)
+		tree := BuildTreeRunes(t, &st, 8, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestScanAllReverse(t *testing.T) {
 	t.Run("IteratesInReverseOrder", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 3, keys)
+		tree := BuildTreeRunes(t, &st, 3, keys)
 
 		it, err := tree.ScanAllReverse()
 		require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestScanAllReverse(t *testing.T) {
 	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 3, keys)
+		tree := BuildTreeRunes(t, &st, 3, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestIterDFS(t *testing.T) {
 	t.Run("VisitsAllLeafKeysInOrder", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 3, keys)
+		tree := BuildTreeRunes(t, &st, 3, keys)
 
 		it := tree.IterDFS()
 
@@ -260,7 +260,7 @@ func TestIterDFS(t *testing.T) {
 	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := buildTreeRunes(t, &st, 3, keys)
+		tree := BuildTreeRunes(t, &st, 3, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)

--- a/btree/iter_test.go
+++ b/btree/iter_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BuildTreeRunes(
+func buildTreeRunes(
 	t *testing.T,
 	st *btree.InMemoryStore_t[rune, int],
 	order int,
@@ -31,7 +31,7 @@ func TestScanAll(t *testing.T) {
 	t.Run("IteratesInOrder", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 3, keys)
+		tree := buildTreeRunes(t, &st, 3, keys)
 
 		it, err := tree.ScanAll()
 		require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestScanAll(t *testing.T) {
 	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 3, keys)
+		tree := buildTreeRunes(t, &st, 3, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("StartsExactlyAtKeyIfKeyExists", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 8, keys)
+		tree := buildTreeRunes(t, &st, 8, keys)
 
 		it, err := tree.ScanFrom('e')
 		require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("StartsAtFirstGreaterIfKeyMissing_inSameNode", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune{'a', 'c', 'e', 'g', 'i'}
-		tree := BuildTreeRunes(t, &st, 8, keys)
+		tree := buildTreeRunes(t, &st, 8, keys)
 
 		it, err := tree.ScanFrom('d')
 		require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("StartsAtFirstGreaterIfKeyMissing_inAnotherNode", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 3, keys)
+		tree := buildTreeRunes(t, &st, 3, keys)
 
 		it, err := tree.ScanFrom('c')
 		require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestScanFrom(t *testing.T) {
 
 	t.Run("EmptyIteratorIfKeyGreaterThanMax", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
-		tree := BuildTreeRunes(t, &st, 8, []rune("abc"))
+		tree := buildTreeRunes(t, &st, 8, []rune("abc"))
 
 		it, err := tree.ScanFrom('z')
 		require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestScanFrom(t *testing.T) {
 	t.Run("ScanFrom_ReturnsError_WhenFindLeafFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 8, keys)
+		tree := buildTreeRunes(t, &st, 8, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestScanAllReverse(t *testing.T) {
 	t.Run("IteratesInReverseOrder", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 3, keys)
+		tree := buildTreeRunes(t, &st, 3, keys)
 
 		it, err := tree.ScanAllReverse()
 		require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestScanAllReverse(t *testing.T) {
 	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 3, keys)
+		tree := buildTreeRunes(t, &st, 3, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestIterDFS(t *testing.T) {
 	t.Run("VisitsAllLeafKeysInOrder", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 3, keys)
+		tree := buildTreeRunes(t, &st, 3, keys)
 
 		it := tree.IterDFS()
 
@@ -260,7 +260,7 @@ func TestIterDFS(t *testing.T) {
 	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &st, 3, keys)
+		tree := buildTreeRunes(t, &st, 3, keys)
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)

--- a/btree/iter_test.go
+++ b/btree/iter_test.go
@@ -10,24 +10,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestScanAll(t *testing.T) {
-	buildTreeRunes := func(
-		t *testing.T,
-		st *btree.InMemoryStore_t[rune, int],
-		order int,
-		keys []rune,
-	) *btree.BTree[rune, int, int] {
-		t.Helper()
+func buildTreeRunes(
+	t *testing.T,
+	st *btree.InMemoryStore_t[rune, int],
+	order int,
+	keys []rune,
+) *btree.BTree[rune, int, int] {
+	t.Helper()
 
-		tree, err := btree.New[rune, int, int](st, cmp.Compare, order)
-		require.NoError(t, err)
+	tree, err := btree.New[rune, int, int](st, cmp.Compare, order)
+	require.NoError(t, err)
 
-		for i, k := range keys {
-			require.NoError(t, tree.Insert(k, i))
-		}
-		return tree
+	for i, k := range keys {
+		require.NoError(t, tree.Insert(k, i))
 	}
+	return tree
+}
 
+func TestScanAll(t *testing.T) {
 	t.Run("IteratesInOrder", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
@@ -66,28 +66,138 @@ func TestScanAll(t *testing.T) {
 }
 
 func TestScanFrom(t *testing.T) {
-	store := btree.InMemoryStore_t[rune, int]{}
-	tree, err := btree.New(&store, cmp.Compare, 8)
-	require.NoError(t, err)
+	t.Run("StartsExactlyAtKeyIfKeyExists", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 8, keys)
 
-	alphabet := []rune("abcdefghijklmnopqrstuvwxyz")
-	for i, r := range alphabet {
-		err := tree.Insert(r, i)
+		it, err := tree.ScanFrom('e')
 		require.NoError(t, err)
-	}
+		require.NoError(t, it.Err())
 
-	iter, err := tree.ScanFrom(rune('e'))
-	require.NoError(t, err)
+		for i := 4; i < len(keys); i++ {
+			require.True(t, it.Next())
+			gotK, gotV := it.Current()
+			require.Equal(t, keys[i], gotK)
+			require.Equal(t, i, gotV)
+		}
 
-	for i := 4; i < len(alphabet); i++ {
-		r := alphabet[i]
-		require.True(t, iter.Next())
-		k, v := iter.Current()
-		require.Equal(t, k, r)
-		require.Equal(t, v, i)
-	}
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
 
-	require.False(t, iter.Next())
+	t.Run("StartsAtFirstGreaterIfKeyMissing_inSameNode", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune{'a', 'c', 'e', 'g', 'i'}
+		tree := buildTreeRunes(t, &st, 8, keys)
+
+		it, err := tree.ScanFrom('d')
+		require.NoError(t, err)
+		require.NoError(t, it.Err())
+
+		require.True(t, it.Next())
+		gotK, gotV := it.Current()
+		require.Equal(t, rune('e'), gotK)
+		require.Equal(t, 2, gotV)
+
+		require.True(t, it.Next())
+		gotK, gotV = it.Current()
+		require.Equal(t, rune('g'), gotK)
+		require.Equal(t, 3, gotV)
+	})
+
+	t.Run("StartsAtFirstGreaterIfKeyMissing_inAnotherNode", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 3, keys)
+
+		it, err := tree.ScanFrom('c')
+		require.NoError(t, err)
+		require.NoError(t, it.Err())
+
+		require.True(t, it.Next())
+		gotK, _ := it.Current()
+		require.Equal(t, rune('d'), gotK)
+	})
+
+	t.Run("EmptyIteratorIfKeyGreaterThanMax", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		tree := buildTreeRunes(t, &st, 8, []rune("abc"))
+
+		it, err := tree.ScanFrom('z')
+		require.NoError(t, err)
+		require.NoError(t, it.Err())
+
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("ScanFrom_ReturnsError_WhenFindLeafFails", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 8, keys)
+
+		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+		require.NotNil(t, fresh)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(ptr int) (*btree.Node[rune, int, int], error) {
+			return nil, getErr
+		}
+
+		_, err = fresh.ScanFrom('m')
+		require.ErrorIs(t, err, getErr)
+	})
+
+	t.Run("Fails_BecauseKeyMissing_AndCacheGetOnNextLeafFails", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leaf1 := btree.Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		ptr1, err := st.Put(&leaf1)
+		require.NoError(t, err)
+
+		leaf2 := btree.Node[rune, int, int]{
+			Keys:   []rune{'d', 'e'},
+			Values: []int{4, 5},
+		}
+		ptr2, err := st.Put(&leaf2)
+		require.NoError(t, err)
+
+		n1, err := st.Get(ptr1)
+		require.NoError(t, err)
+		n1.Next = &ptr2
+		require.NoError(t, st.Update(ptr1, n1))
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'d'},
+			Pointers: []int{ptr1, ptr2},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		b, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(ptr int) (*btree.Node[rune, int, int], error) {
+			if ptr == ptr2 {
+				return nil, getErr
+			}
+			prev := st.GetFn
+			st.GetFn = nil
+			n, err := st.Get(ptr)
+			st.GetFn = prev
+			return n, err
+		}
+
+		_, err = b.ScanFrom('c')
+		require.ErrorIs(t, err, getErr)
+	})
 }
 
 func TestScanAllReverse(t *testing.T) {

--- a/btree/iter_test.go
+++ b/btree/iter_test.go
@@ -238,27 +238,38 @@ func TestScanAllReverse(t *testing.T) {
 	})
 }
 
-func TestVisitDFS(t *testing.T) {
-	store := btree.InMemoryStore_t[rune, int]{}
-	tree, err := btree.New(&store, cmp.Compare, 3)
-	require.NoError(t, err)
+func TestIterDFS(t *testing.T) {
+	t.Run("VisitsAllLeafKeysInOrder", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 3, keys)
 
-	alphabet := []rune("abcdefghijklmnopqrstuvwxyz")
-	for i, r := range alphabet {
-		err := tree.Insert(r, i)
-		require.NoError(t, err)
-	}
+		it := tree.IterDFS()
 
-	keySaw := []rune{}
-	it := tree.IterDFS()
-	for it.Next() {
-		_, node := it.Current()
-		if len(node.Pointers) == 0 {
-			for i := range node.Keys {
-				keySaw = append(keySaw, node.Keys[i])
+		var keysSaw []rune
+		for it.Next() {
+			_, node := it.Current()
+			if len(node.Pointers) == 0 {
+				keysSaw = append(keysSaw, node.Keys...)
 			}
 		}
-	}
-	require.NoError(t, it.Err())
-	require.Zero(t, slices.Compare(alphabet, keySaw))
+		require.NoError(t, it.Err())
+		require.Zero(t, slices.Compare(keys, keysSaw))
+	})
+
+	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 3, keys)
+
+		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(_ int) (*btree.Node[rune, int, int], error) { return nil, getErr }
+
+		it := fresh.IterDFS()
+		require.False(t, it.Next())
+		require.ErrorIs(t, it.Err(), getErr)
+	})
 }

--- a/btree/iter_test.go
+++ b/btree/iter_test.go
@@ -201,28 +201,41 @@ func TestScanFrom(t *testing.T) {
 }
 
 func TestScanAllReverse(t *testing.T) {
-	store := btree.InMemoryStore_t[rune, int]{}
-	tree, err := btree.New(&store, cmp.Compare, 3)
-	require.NoError(t, err)
+	t.Run("IteratesInReverseOrder", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 3, keys)
 
-	alphabet := []rune("abcdefghijklmnopqrstuvwxyz")
-	for i, r := range alphabet {
-		err := tree.Insert(r, i)
+		it, err := tree.ScanAllReverse()
 		require.NoError(t, err)
-	}
+		require.NoError(t, it.Err())
 
-	iter, err := tree.ScanAllReverse()
-	require.NoError(t, err)
+		// Expect reverse order
+		for i := len(keys) - 1; i >= 0; i-- {
+			require.True(t, it.Next())
+			gotK, gotV := it.Current()
+			require.Equal(t, keys[i], gotK)
+			require.Equal(t, i, gotV)
+		}
 
-	for i := len(alphabet) - 1; i >= 0; i-- {
-		r := alphabet[i]
-		require.True(t, iter.Next())
-		k, v := iter.Current()
-		require.Equal(t, k, r)
-		require.Equal(t, v, i)
-	}
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
 
-	require.False(t, iter.Next())
+	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 3, keys)
+
+		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(_ int) (*btree.Node[rune, int, int], error) { return nil, getErr }
+
+		_, err = fresh.ScanAllReverse()
+		require.ErrorIs(t, err, getErr)
+	})
 }
 
 func TestVisitDFS(t *testing.T) {

--- a/btree/iter_test.go
+++ b/btree/iter_test.go
@@ -2,6 +2,7 @@ package btree_test
 
 import (
 	"cmp"
+	"errors"
 	"slices"
 	"testing"
 
@@ -10,27 +11,58 @@ import (
 )
 
 func TestScanAll(t *testing.T) {
-	store := btree.InMemoryStore_t[rune, int]{}
-	tree, err := btree.New(&store, cmp.Compare, 3)
-	require.NoError(t, err)
+	buildTreeRunes := func(
+		t *testing.T,
+		st *btree.InMemoryStore_t[rune, int],
+		order int,
+		keys []rune,
+	) *btree.BTree[rune, int, int] {
+		t.Helper()
 
-	alphabet := []rune("abcdefghijklmnopqrstuvwxyz")
-	for i, r := range alphabet {
-		err := tree.Insert(r, i)
+		tree, err := btree.New[rune, int, int](st, cmp.Compare, order)
 		require.NoError(t, err)
+
+		for i, k := range keys {
+			require.NoError(t, tree.Insert(k, i))
+		}
+		return tree
 	}
 
-	iter, err := tree.ScanAll()
-	require.NoError(t, err)
+	t.Run("IteratesInOrder", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 3, keys)
 
-	for i, r := range alphabet {
-		require.True(t, iter.Next())
-		k, v := iter.Current()
-		require.Equal(t, k, r)
-		require.Equal(t, v, i)
-	}
+		it, err := tree.ScanAll()
+		require.NoError(t, err)
+		require.NoError(t, it.Err())
 
-	require.False(t, iter.Next())
+		for i, k := range keys {
+			require.True(t, it.Next())
+			gotK, gotV := it.Current()
+			require.Equal(t, k, gotK)
+			require.Equal(t, i, gotV)
+		}
+
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := buildTreeRunes(t, &st, 3, keys)
+
+		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+		require.NotNil(t, fresh)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(ptr int) (*btree.Node[rune, int, int], error) { return nil, getErr }
+
+		_, err = fresh.ScanAll()
+		require.ErrorIs(t, err, getErr)
+	})
 }
 
 func TestScanFrom(t *testing.T) {

--- a/btree/persist_test.go
+++ b/btree/persist_test.go
@@ -2,52 +2,92 @@ package btree_test
 
 import (
 	"cmp"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/PlakarKorp/kloset/btree"
 	"github.com/stretchr/testify/require"
 )
 
+type countingStore[K comparable, V any] struct {
+	inner *btree.InMemoryStore_t[K, V]
+
+	putCalls    int
+	getCalls    int
+	updateCalls int
+	closeCalls  int
+}
+
+func (s *countingStore[K, V]) Get(ptr int) (*btree.Node[K, int, V], error) {
+	s.getCalls++
+	return s.inner.Get(ptr)
+}
+
+func (s *countingStore[K, V]) Put(n *btree.Node[K, int, V]) (int, error) {
+	s.putCalls++
+	return s.inner.Put(n)
+}
+
+func (s *countingStore[K, V]) Update(ptr int, n *btree.Node[K, int, V]) error {
+	s.updateCalls++
+	return s.inner.Update(ptr, n)
+}
+
+func (s *countingStore[K, V]) Close() error {
+	s.closeCalls++
+	return s.inner.Close()
+}
+
 func TestPersist(t *testing.T) {
-	order := 3
-	store := btree.InMemoryStore_t[rune, int]{}
-	tree1, err := btree.New(&store, cmp.Compare, order)
-	require.NoError(t, err)
+	t.Run("CopiesAllKeysValues_AndDoesNotReadDestination", func(t *testing.T) {
+		src := btree.InMemoryStore_t[rune, int]{}
+		dstInner := btree.InMemoryStore_t[rune, string]{}
+		dst := &countingStore[rune, string]{inner: &dstInner}
 
-	alphabet := []rune("abcdefghijklmnopqrstuvwxyz")
-	for i, r := range alphabet {
-		err := tree1.Insert(r, i)
+		keys := []rune("abcdefghijklmnopqrstuvwxyz")
+		tree := BuildTreeRunes(t, &src, 3, keys)
+
+		conv := func(v int) (string, error) { return fmt.Sprintf("v=%d", v), nil }
+
+		rootPtr, err := btree.Persist[rune, int, int, int, string](tree, dst, conv)
 		require.NoError(t, err)
-	}
 
-	store2 := btree.InMemoryStore_t[rune, int]{}
-	root, err := btree.Persist(tree1, &store2, func(e int) (int, error) { return e, nil })
-	require.NoError(t, err)
+		require.Greater(t, dst.putCalls, 0)
+		require.Equal(t, 0, dst.getCalls)
+		require.Equal(t, 0, dst.updateCalls)
+		require.Equal(t, 0, dst.closeCalls)
 
-	tree2, err := btree.FromStorage(root, &store2, cmp.Compare, order)
-	require.NoError(t, err)
-	require.NotNil(t, tree2)
-	for i, r := range alphabet {
-		v, found, err := tree2.Find(r)
+		out, err := btree.FromStorage[rune, int, string](rootPtr, &dstInner, cmp.Compare, 3)
 		require.NoError(t, err)
-		require.True(t, found)
-		require.Equal(t, v, i)
-	}
+		it, err := out.ScanAll()
+		require.NoError(t, err)
 
-	nonexist := 'A'
-	_, found, err := tree2.Find(nonexist)
-	require.NoError(t, err)
-	require.False(t, found)
+		for i, k := range keys {
+			require.True(t, it.Next())
+			gotK, gotV := it.Current()
+			require.Equal(t, k, gotK)
+			require.Equal(t, fmt.Sprintf("v=%d", i), gotV)
+		}
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+	})
 
-	iter, err := tree2.ScanAll()
-	require.NoError(t, err)
+	t.Run("Fails_BecauseConversionFails", func(t *testing.T) {
+		src := btree.InMemoryStore_t[rune, int]{}
+		dst := btree.InMemoryStore_t[rune, string]{}
 
-	for i, r := range alphabet {
-		require.True(t, iter.Next())
-		k, v := iter.Current()
-		require.Equal(t, k, r)
-		require.Equal(t, v, i)
-	}
+		tree := BuildTreeRunes(t, &src, 3, []rune{'a', 'b', 'c'})
 
-	require.False(t, iter.Next())
+		boom := errors.New("conversion failed")
+		conv := func(v int) (string, error) {
+			if v == 1 {
+				return "", boom
+			}
+			return fmt.Sprintf("%d", v), nil
+		}
+
+		_, err := btree.Persist[rune, int, int, int, string](tree, &dst, conv)
+		require.ErrorIs(t, err, boom)
+	})
 }

--- a/btree/persist_test.go
+++ b/btree/persist_test.go
@@ -46,7 +46,7 @@ func TestPersist(t *testing.T) {
 		dst := &countingStore[rune, string]{inner: &dstInner}
 
 		keys := []rune("abcdefghijklmnopqrstuvwxyz")
-		tree := BuildTreeRunes(t, &src, 3, keys)
+		tree := buildTreeRunes(t, &src, 3, keys)
 
 		conv := func(v int) (string, error) { return fmt.Sprintf("v=%d", v), nil }
 
@@ -77,7 +77,7 @@ func TestPersist(t *testing.T) {
 		src := btree.InMemoryStore_t[rune, int]{}
 		dst := btree.InMemoryStore_t[rune, string]{}
 
-		tree := BuildTreeRunes(t, &src, 3, []rune{'a', 'b', 'c'})
+		tree := buildTreeRunes(t, &src, 3, []rune{'a', 'b', 'c'})
 
 		boom := errors.New("conversion failed")
 		conv := func(v int) (string, error) {

--- a/btree/verify.go
+++ b/btree/verify.go
@@ -88,7 +88,7 @@ func (b *BTree[K, P, V]) verifyNode(cur, parent *Node[K, P, V], ptrIdx int, stat
 
 	// Now check the order of keys.
 	for i := 1; i < len(cur.Keys); i++ {
-		if b.compare(cur.Keys[i-1], cur.Keys[1]) >= 0 {
+		if b.compare(cur.Keys[i-1], cur.Keys[i]) >= 0 {
 			return fmt.Errorf("Node: broken ordering of keys %v", cur.Keys)
 		}
 	}

--- a/btree/verify.go
+++ b/btree/verify.go
@@ -113,33 +113,6 @@ func (b *BTree[K, P, V]) verifyNode(cur, parent *Node[K, P, V], ptrIdx int, stat
 		}
 	}
 
-	// Now check the order of keys.
-	for i := 1; i < len(cur.Keys); i++ {
-		if b.compare(cur.Keys[i-1], cur.Keys[1]) >= 0 {
-			return fmt.Errorf("Node: broken ordering of keys %v", cur.Keys)
-		}
-	}
-
-	// Check ordering between parent and us
-	if parent != nil {
-		if ptrIdx == 0 {
-			// left-most value we just check the upper bound. No need to check
-			// the siblings, it's done by checking the bounds in parent.
-			if b.compare(cur.Keys[len(cur.Keys)-1], parent.Keys[ptrIdx]) > 0 {
-				return fmt.Errorf("InternalNode: broken invariant: Parent/Child ordering is wrong Parent ('-inf' / '%v') -> Child('%v')", parent.Keys[ptrIdx], cur.Keys[len(cur.Keys)-1])
-			}
-		} else if ptrIdx == len(parent.Pointers)-1 {
-			// right-most value. ditto.
-			if b.compare(cur.Keys[0], parent.Keys[ptrIdx-1]) < 0 {
-				return fmt.Errorf("InternalNode: broken invariant: Parent/Child ordering is wrong Parent ('%v' / '+inf') -> Child('%v')", parent.Keys[ptrIdx-1], cur.Keys[0])
-			}
-		} else {
-			if b.compare(cur.Keys[0], parent.Keys[ptrIdx-1]) < 0 || b.compare(cur.Keys[len(cur.Keys)-1], parent.Keys[ptrIdx]) > 0 {
-				return fmt.Errorf("InternalNode: broken invariant: Parent/Child ordering is wrong Parent ('%v' / '%v') -> Child('%v')", parent.Keys[ptrIdx-1], parent.Keys[ptrIdx], cur.Keys[0])
-			}
-		}
-	}
-
 	state.CurrDepth++
 	for i, child := range cur.Pointers {
 		childNode, err := b.cache.Get(child)

--- a/btree/verify_test.go
+++ b/btree/verify_test.go
@@ -56,7 +56,7 @@ func TestVerify(t *testing.T) {
 
 	t.Run("Filled tree", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
-		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+		tree := buildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
 
 		out := stdOutCapture(t, func() { require.NoError(t, tree.Verify()) })
 		require.Contains(t, out, "Verify ended, visited")
@@ -64,7 +64,7 @@ func TestVerify(t *testing.T) {
 
 	t.Run("Fails_WhenRootCannotBeLoaded", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
-		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+		tree := buildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
 
 		// empty cache => Verify must call store.Get(root)
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
@@ -94,7 +94,7 @@ func TestVerify(t *testing.T) {
 
 	t.Run("Fails_WhenChildCannotBeLoaded_DuringTraversal", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
-		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+		tree := buildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
 
 		// empty cache => Verify must call store.Get(internal node)
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
@@ -522,7 +522,7 @@ func TestDot(t *testing.T) {
 	t.Run("ValidGraph", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 
-		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+		tree := buildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
 
 		var buf bytes.Buffer
 		err := tree.Dot(&buf, false)
@@ -537,7 +537,7 @@ func TestDot(t *testing.T) {
 	t.Run("ShowNextPtr", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 
-		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+		tree := buildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
 
 		var bufNo, bufYes bytes.Buffer
 		err := tree.Dot(&bufNo, false)
@@ -560,7 +560,7 @@ func TestDot(t *testing.T) {
 	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
 		st := btree.InMemoryStore_t[rune, int]{}
 
-		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+		tree := buildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
 
 		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
 		require.NoError(t, err)

--- a/btree/verify_test.go
+++ b/btree/verify_test.go
@@ -1,0 +1,518 @@
+package btree_test
+
+import (
+	"bytes"
+	"cmp"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/btree"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerify(t *testing.T) {
+	var stdOutMutex sync.Mutex
+
+	stdOutCapture := func(t *testing.T, fn func()) string {
+		t.Helper()
+
+		stdOutMutex.Lock()
+		defer stdOutMutex.Unlock()
+
+		old := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer r.Close()
+
+		os.Stdout = w
+
+		done := make(chan string, 1)
+		go func() {
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r)
+			done <- buf.String()
+		}()
+
+		fn()
+
+		_ = w.Close()
+		os.Stdout = old
+
+		return <-done
+	}
+
+	t.Run("Root is a leaf", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		tree, err := btree.New[rune, int, int](&st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		out := stdOutCapture(t, func() { require.NoError(t, tree.Verify()) })
+		require.NotContains(t, out, "Verify ended")
+	})
+
+	t.Run("Filled tree", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+
+		out := stdOutCapture(t, func() { require.NoError(t, tree.Verify()) })
+		require.Contains(t, out, "Verify ended, visited")
+	})
+
+	t.Run("Fails_WhenRootCannotBeLoaded", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+
+		// empty cache => Verify must call store.Get(root)
+		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		getErr := errors.New("Store.Get() failed")
+		rootPtr := tree.Root
+
+		st.GetFn = func(ptr int) (*btree.Node[rune, int, int], error) {
+			if ptr == rootPtr {
+				return nil, getErr
+			}
+			prev := st.GetFn
+			st.GetFn = nil
+			defer func() { st.GetFn = prev }()
+			return st.Get(ptr)
+		}
+
+		out := stdOutCapture(t, func() {
+			err := fresh.Verify()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "failed to get root node")
+			require.ErrorIs(t, err, getErr)
+		})
+		require.NotContains(t, out, "Verify ended, visited")
+	})
+
+	t.Run("Fails_WhenChildCannotBeLoaded_DuringTraversal", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+
+		// empty cache => Verify must call store.Get(internal node)
+		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		boom := errors.New("boom: child get failed")
+		rootPtr := tree.Root
+		getCalls := 0
+
+		st.GetFn = func(ptr int) (*btree.Node[rune, int, int], error) {
+			getCalls++
+			if getCalls >= 2 {
+				return nil, boom
+			}
+
+			prev := st.GetFn
+			st.GetFn = nil
+			defer func() { st.GetFn = prev }()
+
+			if ptr != rootPtr {
+				return nil, errors.New("unexpected first Get() pointer (expected root)")
+			}
+			return st.Get(ptr)
+		}
+
+		out := stdOutCapture(t, func() {
+			err := fresh.Verify()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Failed to fetch node")
+		})
+		require.Contains(t, out, "Verify ended, visited")
+	})
+
+	t.Run("LeafDepthMismatch", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		leafL := btree.Node[rune, int, int]{
+			Keys:   []rune{'n'},
+			Values: []int{2},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'z'},
+			Values: []int{3},
+		}
+		ptr, err := st.Put(&leaf)
+		require.NoError(t, err)
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		internalNode := btree.Node[rune, int, int]{
+			Keys:     []rune{'z'},
+			Pointers: []int{ptrL, ptrR},
+		}
+		internalPtr, err := st.Put(&internalNode)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m'},
+			Pointers: []int{ptr, internalPtr},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Leaf: broken invariant: Left-most leaf depth")
+	})
+
+	t.Run("LeafKeysOccupancyTooSmall", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		badLeaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		leafM := btree.Node[rune, int, int]{
+			Keys:   []rune{'n', 'o'},
+			Values: []int{2, 3},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'u', 'v'},
+			Values: []int{4, 5},
+		}
+		ptrBad, err := st.Put(&badLeaf)
+		require.NoError(t, err)
+		ptrM, err := st.Put(&leafM)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m', 't'},
+			Pointers: []int{ptrBad, ptrM, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 4)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Leaf: broken invariant: Keys occupancy")
+	})
+
+	t.Run("LeafValuesOccupancyTooSmall", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		badLeaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1},
+		}
+		leafM := btree.Node[rune, int, int]{
+			Keys:   []rune{'n', 'o'},
+			Values: []int{2, 3},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'u', 'v'},
+			Values: []int{4, 5},
+		}
+		ptrBad, err := st.Put(&badLeaf)
+		require.NoError(t, err)
+		ptrM, err := st.Put(&leafM)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m', 't'},
+			Pointers: []int{ptrBad, ptrM, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 4)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Leaf: broken invariant: Values occupancy")
+	})
+
+	t.Run("InternalKeysOccupancyTooSmall", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leafL := btree.Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'y', 'z'},
+			Values: []int{3, 4},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m'},
+			Pointers: []int{ptrL, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 4)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "InternalNode: broken invariant: Keys occupancy")
+	})
+
+	t.Run("InternalValuesNotEmpty", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leafL := btree.Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'y', 'z'},
+			Values: []int{3, 4},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m'},
+			Pointers: []int{ptrL, ptrR},
+			Values:   []int{999},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "InteralNode: broken invariant: Values is not empty")
+	})
+
+	t.Run("InternalPointersOccupancyTooSmall", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'a', 'b'},
+			Values: []int{1, 2},
+		}
+		ptr, err := st.Put(&leaf)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m', 't'},
+			Pointers: []int{ptr},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 4)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "InternalNode: broken invariant: Pointers occupancy")
+	})
+
+	t.Run("NodeKeysOrderingBroken_InternalNode", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leafL := btree.Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'b'},
+			Values: []int{2},
+		}
+		leafM := btree.Node[rune, int, int]{
+			Keys:   []rune{'c'},
+			Values: []int{3},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+		ptrM, err := st.Put(&leafM)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'t', 'n'},
+			Pointers: []int{ptrL, ptrM, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Node: broken ordering of keys")
+	})
+
+	t.Run("NodeKeysOrderingBroken_Leaf", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		badLeaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'a', 'b', 'b'},
+			Values: []int{1, 2, 3},
+		}
+		leafM := btree.Node[rune, int, int]{
+			Keys:   []rune{'n', 'o'},
+			Values: []int{4, 5},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'u', 'v'},
+			Values: []int{6, 7},
+		}
+		ptrBad, err := st.Put(&badLeaf)
+		require.NoError(t, err)
+		ptrM, err := st.Put(&leafM)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		rootPtr, err := st.Put(&btree.Node[rune, int, int]{
+			Keys:     []rune{'m', 't'},
+			Pointers: []int{ptrBad, ptrM, ptrR},
+		})
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 4)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Node: broken ordering of keys")
+	})
+
+	t.Run("ParentChildOrdering_LeftMostChild", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		badLeaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'x', 'z'},
+			Values: []int{1, 2},
+		}
+		leafM := btree.Node[rune, int, int]{
+			Keys:   []rune{'n', 'o'},
+			Values: []int{3, 4},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'u', 'v'},
+			Values: []int{5, 6},
+		}
+		ptrBad, err := st.Put(&badLeaf)
+		require.NoError(t, err)
+		ptrM, err := st.Put(&leafM)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m', 't'},
+			Pointers: []int{ptrBad, ptrM, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 4)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Parent/Child ordering is wrong Parent (")
+		require.Contains(t, err.Error(), "('-inf' /")
+		require.Contains(t, err.Error(), " / '109')")
+	})
+
+	t.Run("ParentChildOrdering_RightMostChild", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		badLeaf := btree.Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{2},
+		}
+		ptrLeaf, err := st.Put(&leaf)
+		require.NoError(t, err)
+		ptrBad, err := st.Put(&badLeaf)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m'},
+			Pointers: []int{ptrLeaf, ptrBad},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Parent/Child ordering is wrong Parent (")
+		require.Contains(t, err.Error(), "/ '+inf')")
+	})
+
+	t.Run("ParentChildOrdering_MiddleChild", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		leafL := btree.Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{1},
+		}
+		leafMidBad := btree.Node[rune, int, int]{
+			Keys:   []rune{'a'},
+			Values: []int{2},
+		}
+		leafR := btree.Node[rune, int, int]{
+			Keys:   []rune{'z'},
+			Values: []int{3},
+		}
+		ptrL, err := st.Put(&leafL)
+		require.NoError(t, err)
+		ptrMidBad, err := st.Put(&leafMidBad)
+		require.NoError(t, err)
+		ptrR, err := st.Put(&leafR)
+		require.NoError(t, err)
+
+		root := btree.Node[rune, int, int]{
+			Keys:     []rune{'m', 't'},
+			Pointers: []int{ptrL, ptrMidBad, ptrR},
+		}
+		rootPtr, err := st.Put(&root)
+		require.NoError(t, err)
+
+		tree, err := btree.FromStorage[rune, int, int](rootPtr, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		stdOutCapture(t, func() { err = tree.Verify() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Parent/Child ordering is wrong Parent (")
+		require.Contains(t, err.Error(), "('109' / '116')")
+	})
+}

--- a/btree/verify_test.go
+++ b/btree/verify_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -514,5 +515,61 @@ func TestVerify(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Parent/Child ordering is wrong Parent (")
 		require.Contains(t, err.Error(), "('109' / '116')")
+	})
+}
+
+func TestDot(t *testing.T) {
+	t.Run("ValidGraph", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+
+		var buf bytes.Buffer
+		err := tree.Dot(&buf, false)
+		require.NoError(t, err)
+
+		out := buf.String()
+		require.True(t, strings.HasPrefix(out, "digraph G {"))
+		require.True(t, strings.HasSuffix(strings.TrimSpace(out), "}"))
+		require.Contains(t, out, "->")
+	})
+
+	t.Run("ShowNextPtr", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+
+		var bufNo, bufYes bytes.Buffer
+		err := tree.Dot(&bufNo, false)
+		require.NoError(t, err)
+
+		err = tree.Dot(&bufYes, true)
+		require.NoError(t, err)
+
+		outNo := bufNo.String()
+		outYes := bufYes.String()
+
+		require.True(t, strings.HasPrefix(outNo, "digraph G {"))
+		require.True(t, strings.HasSuffix(strings.TrimSpace(outNo), "}"))
+		require.True(t, strings.HasPrefix(outYes, "digraph G {"))
+		require.True(t, strings.HasSuffix(strings.TrimSpace(outYes), "}"))
+
+		require.GreaterOrEqual(t, len(outYes), len(outNo))
+	})
+
+	t.Run("Fails_BecauseStoreGetFails", func(t *testing.T) {
+		st := btree.InMemoryStore_t[rune, int]{}
+
+		tree := BuildTreeRunes(t, &st, 3, []rune("abcdefghijklmnopqrstuvwxyz"))
+
+		fresh, err := btree.FromStorage[rune, int, int](tree.Root, &st, cmp.Compare, 3)
+		require.NoError(t, err)
+
+		getErr := errors.New("Store.Get() failed")
+		st.GetFn = func(_ int) (*btree.Node[rune, int, int], error) { return nil, getErr }
+
+		var buf bytes.Buffer
+		err = fresh.Dot(&buf, false)
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
This PR expands the `btree` test suite with focused coverage for cache behavior, iterators, tree scans, persistence, verification, and DOT output generation.

It also simplifies and fixes part of the tree verification logic.

## Changes

- add a test for cache flush failure handling
- add tests for forward iterator basic behavior
- add tests for backward iterator basic behavior
- add tests for:
  - `ScanAll`
  - `ScanFrom`
  - `ScanAllReverse`
  - `IterDFS`
  - `Persist`
  - `Verify`
  - `Dot`
- remove duplicated key/order checks in `verifyNode`
- fix key ordering validation in `verify`
- iterator initialization and error propagation

## Results

### Before

```
github.com/PlakarKorp/kloset/btree/btree.go:21:			init			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:68:			New				85.7%
github.com/PlakarKorp/kloset/btree/btree.go:91:			FromStorage		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:101:		Deserialize		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:109:		Close			0.0%
github.com/PlakarKorp/kloset/btree/btree.go:113:		newNodeFrom		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:126:		isleaf			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:130:		findleaf		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:156:		Find			85.7%
github.com/PlakarKorp/kloset/btree/btree.go:169:		find			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:177:		insertAt		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:182:		insertInternal	66.7%
github.com/PlakarKorp/kloset/btree/btree.go:196:		findsplit		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:200:		split			90.0%
github.com/PlakarKorp/kloset/btree/btree.go:217:		insert			80.0%
github.com/PlakarKorp/kloset/btree/btree.go:257:		Insert			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:264:		Update			0.0%
github.com/PlakarKorp/kloset/btree/btree.go:271:		insertUpwards	79.2%
github.com/PlakarKorp/kloset/btree/btree.go:314:		Stats			0.0%
github.com/PlakarKorp/kloset/btree/cache.go:17:			cachefor		100.0%
github.com/PlakarKorp/kloset/btree/cache.go:29:			Get				88.9%
github.com/PlakarKorp/kloset/btree/cache.go:46:			Update			100.0%
github.com/PlakarKorp/kloset/btree/cache.go:50:			Put				100.0%
github.com/PlakarKorp/kloset/btree/cache.go:54:			Close			0.0%
github.com/PlakarKorp/kloset/btree/iter.go:13:			Next			81.2%
github.com/PlakarKorp/kloset/btree/iter.go:40:			Current			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:44:			Err				0.0%
github.com/PlakarKorp/kloset/btree/iter.go:50:			ScanAll			90.9%
github.com/PlakarKorp/kloset/btree/iter.go:78:			ScanFrom		57.9%
github.com/PlakarKorp/kloset/btree/iter.go:130:			dive			88.9%
github.com/PlakarKorp/kloset/btree/iter.go:150:			Next			81.0%
github.com/PlakarKorp/kloset/btree/iter.go:190:			Current			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:195:			Err				0.0%
github.com/PlakarKorp/kloset/btree/iter.go:199:			ScanAllReverse	75.0%
github.com/PlakarKorp/kloset/btree/iter.go:219:			Next			93.3%
github.com/PlakarKorp/kloset/btree/iter.go:243:			Current			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:247:			Err				100.0%
github.com/PlakarKorp/kloset/btree/iter.go:251:			IterDFS			100.0%
github.com/PlakarKorp/kloset/btree/memorystore.go:16:	cloneNode		66.7%
github.com/PlakarKorp/kloset/btree/memorystore.go:31:	Get				66.7%
github.com/PlakarKorp/kloset/btree/memorystore.go:38:	Update			85.7%
github.com/PlakarKorp/kloset/btree/memorystore.go:50:	Put				100.0%
github.com/PlakarKorp/kloset/btree/memorystore.go:57:	Close			0.0%
github.com/PlakarKorp/kloset/btree/persist.go:3:		persist			88.5%
github.com/PlakarKorp/kloset/btree/persist.go:55:		Persist			80.0%
github.com/PlakarKorp/kloset/btree/verify.go:8:			depth			0.0%
github.com/PlakarKorp/kloset/btree/verify.go:35:		Verify			0.0%
github.com/PlakarKorp/kloset/btree/verify.go:54:		verifyNode		0.0%
github.com/PlakarKorp/kloset/btree/verify.go:161:		Dot				0.0%
total:							(statements)							64.0%
```

### After

```
github.com/PlakarKorp/kloset/btree/btree.go:25:			init			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:72:			New				100.0%
github.com/PlakarKorp/kloset/btree/btree.go:98:			FromStorage		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:114:		Deserialize		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:122:		Close			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:126:		newNodeFrom		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:139:		isleaf			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:143:		findleaf		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:169:		Find			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:182:		find			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:190:		insertAt		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:195:		insertInternal	100.0%
github.com/PlakarKorp/kloset/btree/btree.go:209:		findsplit		100.0%
github.com/PlakarKorp/kloset/btree/btree.go:213:		split			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:230:		insert			96.0%
github.com/PlakarKorp/kloset/btree/btree.go:270:		Insert			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:277:		Update			100.0%
github.com/PlakarKorp/kloset/btree/btree.go:284:		insertUpwards	95.8%
github.com/PlakarKorp/kloset/btree/btree.go:327:		Stats			100.0%
github.com/PlakarKorp/kloset/btree/cache.go:17:			cachefor		100.0%
github.com/PlakarKorp/kloset/btree/cache.go:29:			Get				100.0%
github.com/PlakarKorp/kloset/btree/cache.go:46:			Update			100.0%
github.com/PlakarKorp/kloset/btree/cache.go:50:			Put				100.0%
github.com/PlakarKorp/kloset/btree/cache.go:54:			Close			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:13:			Next			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:40:			Current			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:44:			Err				100.0%
github.com/PlakarKorp/kloset/btree/iter.go:50:			ScanAll			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:78:			ScanFrom		100.0%
github.com/PlakarKorp/kloset/btree/iter.go:130:			dive			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:150:			Next			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:190:			Current			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:195:			Err				100.0%
github.com/PlakarKorp/kloset/btree/iter.go:199:			ScanAllReverse	100.0%
github.com/PlakarKorp/kloset/btree/iter.go:219:			Next			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:243:			Current			100.0%
github.com/PlakarKorp/kloset/btree/iter.go:247:			Err				100.0%
github.com/PlakarKorp/kloset/btree/iter.go:251:			IterDFS			100.0%
github.com/PlakarKorp/kloset/btree/memorystore.go:16:	cloneNode		66.7%
github.com/PlakarKorp/kloset/btree/memorystore.go:31:	Get				66.7%
github.com/PlakarKorp/kloset/btree/memorystore.go:38:	Update			85.7%
github.com/PlakarKorp/kloset/btree/memorystore.go:50:	Put				100.0%
github.com/PlakarKorp/kloset/btree/memorystore.go:57:	Close			0.0%
github.com/PlakarKorp/kloset/btree/persist.go:3:		persist			96.2%
github.com/PlakarKorp/kloset/btree/persist.go:55:		Persist			80.0%
github.com/PlakarKorp/kloset/btree/verify.go:8:			depth			100.0%
github.com/PlakarKorp/kloset/btree/verify.go:35:		Verify			100.0%
github.com/PlakarKorp/kloset/btree/verify.go:54:		verifyNode		97.4%
github.com/PlakarKorp/kloset/btree/verify.go:134:		Dot				100.0%
total:							(statements)							97.6%
```

