### PR TITLE
builder: Do not wait on context cancellation in flusher.

### DIFF
--- a/snapshot/builder.go
+++ b/snapshot/builder.go
@@ -327,8 +327,6 @@ func (snap *Builder) Unlock() {
 func (snap *Builder) flushDeltaState() {
 	for {
 		select {
-		case <-snap.appContext.Done():
-			return
 		case <-snap.flushEnd:
 			// End of backup we push the last and final State.
 			err := snap.repository.CommitTransaction(snap.stateId)


### PR DESCRIPTION
* Doing so leads to a hang with a well timed SIGTERM, because then Commit() waits on a channel that'll never be written to.