### PR TITLE
Strengthen `connectors/storage` tests and fix parsing edge cases

### DIFF
--- a/connectors/storage/serialization.go
+++ b/connectors/storage/serialization.go
@@ -100,6 +100,10 @@ func (s *deserializeReader) Read(p []byte) (int, error) {
 			s.leftOver = s.leftOver[nFlush:]
 		}
 
+		if s.eof && len(s.leftOver) < 32 {
+			return total, io.ErrUnexpectedEOF
+		}
+
 		if s.eof && len(s.leftOver) == 32 {
 			copy(s.hmac[:], s.leftOver)
 			if !bytes.Equal(s.hmac[:], s.hasher.Sum(nil)) {

--- a/connectors/storage/serialization.go
+++ b/connectors/storage/serialization.go
@@ -107,7 +107,7 @@ func (s *deserializeReader) Read(p []byte) (int, error) {
 		if s.eof && len(s.leftOver) == 32 {
 			copy(s.hmac[:], s.leftOver)
 			if !bytes.Equal(s.hmac[:], s.hasher.Sum(nil)) {
-				return 0, fmt.Errorf("hmac mismatch")
+				return total, fmt.Errorf("hmac mismatch")
 			}
 			return total, io.EOF
 		}

--- a/connectors/storage/serialization_test.go
+++ b/connectors/storage/serialization_test.go
@@ -1,0 +1,215 @@
+package storage_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+
+	storage "github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/resources"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/stretchr/testify/require"
+)
+
+var errReader = errors.New("forced read error")
+
+type errorReader struct {
+	data []byte
+	read bool
+}
+
+func (r *errorReader) Read(p []byte) (int, error) {
+	if !r.read {
+		r.read = true
+		n := copy(p, r.data)
+		return n, errReader
+	}
+
+	return 0, errReader
+}
+
+func TestSerialize(t *testing.T) {
+	expectedSerializedData := func(
+		t *testing.T,
+		resourceType resources.Type,
+		version versioning.Version,
+		payload []byte,
+	) []byte {
+		t.Helper()
+
+		header := make([]byte, storage.STORAGE_HEADER_SIZE)
+		copy(header[0:8], []byte("_KLOSET_"))
+		binary.LittleEndian.PutUint32(header[8:12], uint32(resourceType))
+		binary.LittleEndian.PutUint32(header[12:16], uint32(version))
+
+		hasher := sha256.New()
+		_, err := hasher.Write(header)
+		require.NoError(t, err)
+
+		_, err = hasher.Write(payload)
+		require.NoError(t, err)
+
+		footer := hasher.Sum(nil)
+
+		serialized := make([]byte, 0, len(header)+len(payload)+len(footer))
+		serialized = append(serialized, header...)
+		serialized = append(serialized, payload...)
+		serialized = append(serialized, footer...)
+
+		return serialized
+	}
+
+	readAllInChunks := func(t *testing.T, r io.Reader, chunkSize int) ([]byte, error) {
+		t.Helper()
+
+		var out bytes.Buffer
+		buf := make([]byte, chunkSize)
+
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				_, writeErr := out.Write(buf[:n])
+				require.NoError(t, writeErr)
+			}
+
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return out.Bytes(), nil
+				}
+				return out.Bytes(), err
+			}
+		}
+	}
+
+	t.Run("EmptyPayload", func(t *testing.T) {
+		resourceType := resources.RT_CONFIG
+		version := versioning.Version(42)
+		payload := []byte{}
+
+		reader, err := storage.Serialize(sha256.New(), resourceType, version, bytes.NewReader(payload))
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		serializedData, err := io.ReadAll(reader)
+		require.NoError(t, err)
+
+		expected := expectedSerializedData(t, resourceType, version, payload)
+		require.Equal(t, expected, serializedData)
+		require.Len(t, serializedData, int(storage.STORAGE_HEADER_SIZE+storage.STORAGE_FOOTER_SIZE))
+		require.Equal(t, []byte("_KLOSET_"), serializedData[:8])
+		require.Equal(t, uint32(resourceType), binary.LittleEndian.Uint32(serializedData[8:12]))
+		require.Equal(t, uint32(version), binary.LittleEndian.Uint32(serializedData[12:16]))
+	})
+
+	t.Run("ValidPayload", func(t *testing.T) {
+		resourceType := resources.RT_CONFIG
+		version := versioning.Version(7)
+		payload := []byte("hello serialized world")
+
+		reader, err := storage.Serialize(sha256.New(), resourceType, version, bytes.NewReader(payload))
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		serializedData, err := io.ReadAll(reader)
+		require.NoError(t, err)
+
+		expected := expectedSerializedData(t, resourceType, version, payload)
+		require.Equal(t, expected, serializedData)
+		require.Len(t, serializedData, int(storage.STORAGE_HEADER_SIZE)+len(payload)+int(storage.STORAGE_FOOTER_SIZE))
+		require.Equal(t, payload, serializedData[storage.STORAGE_HEADER_SIZE:len(serializedData)-int(storage.STORAGE_FOOTER_SIZE)])
+	})
+
+	t.Run("ReadInSmallChunks", func(t *testing.T) {
+		resourceType := resources.RT_CONFIG
+		version := versioning.Version(9)
+		payload := bytes.Repeat([]byte("abc123"), 128)
+
+		reader, err := storage.Serialize(sha256.New(), resourceType, version, bytes.NewReader(payload))
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		serializedData, err := readAllInChunks(t, reader, 3)
+		require.NoError(t, err)
+
+		expected := expectedSerializedData(t, resourceType, version, payload)
+		require.Equal(t, expected, serializedData)
+	})
+
+	t.Run("Fails_IfReaderFailed", func(t *testing.T) {
+		resourceType := resources.RT_CONFIG
+		version := versioning.Version(11)
+		payloadPrefix := []byte("partial payload")
+
+		reader, err := storage.Serialize(sha256.New(), resourceType, version, &errorReader{data: payloadPrefix})
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		serializedData, err := io.ReadAll(reader)
+		require.ErrorIs(t, err, errReader)
+		require.GreaterOrEqual(t, len(serializedData), int(storage.STORAGE_HEADER_SIZE))
+		require.Equal(t, []byte("_KLOSET_"), serializedData[:8])
+		require.Equal(t, uint32(resourceType), binary.LittleEndian.Uint32(serializedData[8:12]))
+		require.Equal(t, uint32(version), binary.LittleEndian.Uint32(serializedData[12:16]))
+
+		payloadPart := serializedData[storage.STORAGE_HEADER_SIZE:]
+		require.Equal(t, payloadPrefix, payloadPart)
+	})
+
+	t.Run("Fails_IfReaderHasAnEmptyBuffer", func(t *testing.T) {
+		reader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(1),
+			bytes.NewReader([]byte("payload")),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		n, err := reader.Read(make([]byte, 0))
+
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+	})
+
+	t.Run("HasherResetIfUsed", func(t *testing.T) {
+		resourceType := resources.RT_CONFIG
+		version := versioning.Version(13)
+		payload := []byte("payload")
+
+		hasher := sha256.New()
+		_, err := hasher.Write([]byte("dirty state"))
+		require.NoError(t, err)
+
+		reader, err := storage.Serialize(hasher, resourceType, version, bytes.NewReader(payload))
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		serializedData, err := io.ReadAll(reader)
+		require.NoError(t, err)
+
+		expected := expectedSerializedData(t, resourceType, version, payload)
+		require.Equal(t, expected, serializedData)
+	})
+
+	t.Run("LargePayload", func(t *testing.T) {
+		resourceType := resources.RT_CONFIG
+		version := versioning.Version(21)
+		payload := make([]byte, 2*1024*1024)
+		for i := range payload {
+			payload[i] = byte(i % 251)
+		}
+
+		reader, err := storage.Serialize(sha256.New(), resourceType, version, bytes.NewReader(payload))
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		serializedData, err := io.ReadAll(reader)
+		require.NoError(t, err)
+
+		expected := expectedSerializedData(t, resourceType, version, payload)
+		require.Equal(t, expected, serializedData)
+	})
+}

--- a/connectors/storage/serialization_test.go
+++ b/connectors/storage/serialization_test.go
@@ -31,59 +31,59 @@ func (r *errorReader) Read(p []byte) (int, error) {
 	return 0, errReader
 }
 
-func TestSerialize(t *testing.T) {
-	expectedSerializedData := func(
-		t *testing.T,
-		resourceType resources.Type,
-		version versioning.Version,
-		payload []byte,
-	) []byte {
-		t.Helper()
+func expectedSerializedData(
+	t *testing.T,
+	magic string,
+	resourceType resources.Type,
+	version versioning.Version,
+	payload []byte,
+) []byte {
+	t.Helper()
 
-		header := make([]byte, storage.STORAGE_HEADER_SIZE)
-		copy(header[0:8], []byte("_KLOSET_"))
-		binary.LittleEndian.PutUint32(header[8:12], uint32(resourceType))
-		binary.LittleEndian.PutUint32(header[12:16], uint32(version))
+	header := make([]byte, storage.STORAGE_HEADER_SIZE)
+	copy(header[0:8], []byte(magic))
+	binary.LittleEndian.PutUint32(header[8:12], uint32(resourceType))
+	binary.LittleEndian.PutUint32(header[12:16], uint32(version))
 
-		hasher := sha256.New()
-		_, err := hasher.Write(header)
-		require.NoError(t, err)
+	hasher := sha256.New()
+	_, err := hasher.Write(header)
+	require.NoError(t, err)
 
-		_, err = hasher.Write(payload)
-		require.NoError(t, err)
+	_, err = hasher.Write(payload)
+	require.NoError(t, err)
 
-		footer := hasher.Sum(nil)
+	footer := hasher.Sum(nil)
 
-		serialized := make([]byte, 0, len(header)+len(payload)+len(footer))
-		serialized = append(serialized, header...)
-		serialized = append(serialized, payload...)
-		serialized = append(serialized, footer...)
+	serialized := make([]byte, 0, len(header)+len(payload)+len(footer))
+	serialized = append(serialized, header...)
+	serialized = append(serialized, payload...)
+	serialized = append(serialized, footer...)
+	return serialized
+}
 
-		return serialized
-	}
+func readAllInChunks(t *testing.T, r io.Reader, chunkSize int) ([]byte, error) {
+	t.Helper()
 
-	readAllInChunks := func(t *testing.T, r io.Reader, chunkSize int) ([]byte, error) {
-		t.Helper()
+	var out bytes.Buffer
+	buf := make([]byte, chunkSize)
 
-		var out bytes.Buffer
-		buf := make([]byte, chunkSize)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			_, writeErr := out.Write(buf[:n])
+			require.NoError(t, writeErr)
+		}
 
-		for {
-			n, err := r.Read(buf)
-			if n > 0 {
-				_, writeErr := out.Write(buf[:n])
-				require.NoError(t, writeErr)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return out.Bytes(), nil
 			}
-
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					return out.Bytes(), nil
-				}
-				return out.Bytes(), err
-			}
+			return out.Bytes(), err
 		}
 	}
+}
 
+func TestSerialize(t *testing.T) {
 	t.Run("EmptyPayload", func(t *testing.T) {
 		resourceType := resources.RT_CONFIG
 		version := versioning.Version(42)
@@ -96,7 +96,7 @@ func TestSerialize(t *testing.T) {
 		serializedData, err := io.ReadAll(reader)
 		require.NoError(t, err)
 
-		expected := expectedSerializedData(t, resourceType, version, payload)
+		expected := expectedSerializedData(t, "_KLOSET_", resourceType, version, payload)
 		require.Equal(t, expected, serializedData)
 		require.Len(t, serializedData, int(storage.STORAGE_HEADER_SIZE+storage.STORAGE_FOOTER_SIZE))
 		require.Equal(t, []byte("_KLOSET_"), serializedData[:8])
@@ -116,7 +116,7 @@ func TestSerialize(t *testing.T) {
 		serializedData, err := io.ReadAll(reader)
 		require.NoError(t, err)
 
-		expected := expectedSerializedData(t, resourceType, version, payload)
+		expected := expectedSerializedData(t, "_KLOSET_", resourceType, version, payload)
 		require.Equal(t, expected, serializedData)
 		require.Len(t, serializedData, int(storage.STORAGE_HEADER_SIZE)+len(payload)+int(storage.STORAGE_FOOTER_SIZE))
 		require.Equal(t, payload, serializedData[storage.STORAGE_HEADER_SIZE:len(serializedData)-int(storage.STORAGE_FOOTER_SIZE)])
@@ -134,7 +134,7 @@ func TestSerialize(t *testing.T) {
 		serializedData, err := readAllInChunks(t, reader, 3)
 		require.NoError(t, err)
 
-		expected := expectedSerializedData(t, resourceType, version, payload)
+		expected := expectedSerializedData(t, "_KLOSET_", resourceType, version, payload)
 		require.Equal(t, expected, serializedData)
 	})
 
@@ -190,7 +190,7 @@ func TestSerialize(t *testing.T) {
 		serializedData, err := io.ReadAll(reader)
 		require.NoError(t, err)
 
-		expected := expectedSerializedData(t, resourceType, version, payload)
+		expected := expectedSerializedData(t, "_KLOSET_", resourceType, version, payload)
 		require.Equal(t, expected, serializedData)
 	})
 
@@ -209,7 +209,345 @@ func TestSerialize(t *testing.T) {
 		serializedData, err := io.ReadAll(reader)
 		require.NoError(t, err)
 
-		expected := expectedSerializedData(t, resourceType, version, payload)
+		expected := expectedSerializedData(t, "_KLOSET_", resourceType, version, payload)
 		require.Equal(t, expected, serializedData)
+	})
+}
+
+type trackedReadCloser struct {
+	reader   io.Reader
+	closed   bool
+	closeErr error
+}
+
+func (r *trackedReadCloser) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *trackedReadCloser) Close() error {
+	r.closed = true
+	return r.closeErr
+}
+
+type delayedErrorReadCloser struct {
+	reader        *bytes.Reader
+	err           error
+	returnedError bool
+	closed        bool
+}
+
+func (r *delayedErrorReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err == io.EOF && !r.returnedError {
+		r.returnedError = true
+		return 0, r.err
+	}
+	return n, err
+}
+
+func (r *delayedErrorReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestDeserialize(t *testing.T) {
+	t.Run("Fails_IfHeaderIsTooShort", func(t *testing.T) {
+		version, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(bytes.NewReader([]byte("short"))),
+		)
+		require.Equal(t, versioning.Version(0), version)
+		require.Nil(t, reader)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("Fails_IfMagicIsInvalid", func(t *testing.T) {
+		serializedData := expectedSerializedData(
+			t,
+			"INVALID!",
+			resources.RT_CONFIG,
+			versioning.Version(1),
+			[]byte("payload"),
+		)
+
+		version, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(bytes.NewReader(serializedData)),
+		)
+		require.Equal(t, versioning.Version(0), version)
+		require.Nil(t, reader)
+		require.EqualError(t, err, "invalid plakar magic: INVALID!")
+	})
+
+	t.Run("Fails_IfResourceTypeIsInvalid", func(t *testing.T) {
+		serializedData := expectedSerializedData(
+			t,
+			"_KLOSET_",
+			resources.Type(9999),
+			versioning.Version(1),
+			[]byte("payload"),
+		)
+
+		version, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(bytes.NewReader(serializedData)),
+		)
+		require.Equal(t, versioning.Version(0), version)
+		require.Nil(t, reader)
+		require.EqualError(t, err, "invalid resource type")
+	})
+
+	t.Run("EmptyPayloadIsValid", func(t *testing.T) {
+		expectedVersion := versioning.Version(42)
+
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			expectedVersion,
+			bytes.NewReader([]byte{}),
+		)
+		require.NoError(t, err)
+
+		version, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(serializedReader),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.Equal(t, expectedVersion, version)
+
+		payload, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.Empty(t, payload)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("NonEmptyValidPayload", func(t *testing.T) {
+		expectedPayload := []byte("hello deserialize")
+		expectedVersion := versioning.Version(9)
+
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			expectedVersion,
+			bytes.NewReader(expectedPayload),
+		)
+		require.NoError(t, err)
+
+		version, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(serializedReader),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.Equal(t, expectedVersion, version)
+
+		payload, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.Equal(t, expectedPayload, payload)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("ReadInSmallChunks", func(t *testing.T) {
+		expectedPayload := bytes.Repeat([]byte("abc123"), 128)
+
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(11),
+			bytes.NewReader(expectedPayload),
+		)
+		require.NoError(t, err)
+
+		_, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(serializedReader),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		payload, err := readAllInChunks(t, reader, 3)
+		require.NoError(t, err)
+		require.Equal(t, expectedPayload, payload)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("Fails_WhenFooterTruncated", func(t *testing.T) {
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(13),
+			bytes.NewReader([]byte{}),
+		)
+		require.NoError(t, err)
+
+		serializedData, err := io.ReadAll(serializedReader)
+		require.NoError(t, err)
+
+		serializedData = serializedData[:len(serializedData)-1]
+		_, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(bytes.NewReader(serializedData)),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		payload, err := io.ReadAll(reader)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		require.Empty(t, payload)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("Fails_WhenHMACMismatched", func(t *testing.T) {
+		expectedPayload := []byte("payload")
+
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(15),
+			bytes.NewReader(expectedPayload),
+		)
+		require.NoError(t, err)
+
+		serializedData, err := io.ReadAll(serializedReader)
+		require.NoError(t, err)
+		serializedData[len(serializedData)-1] ^= 0xff
+
+		_, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(bytes.NewReader(serializedData)),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		payload, err := io.ReadAll(reader)
+		require.Equal(t, expectedPayload, payload)
+		require.EqualError(t, err, "hmac mismatch")
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("Fails_WhenReaderFailed", func(t *testing.T) {
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(17),
+			bytes.NewReader([]byte("payload")),
+		)
+		require.NoError(t, err)
+
+		serializedData, err := io.ReadAll(serializedReader)
+		require.NoError(t, err)
+
+		source := &delayedErrorReadCloser{
+			reader: bytes.NewReader(serializedData),
+			err:    errReader,
+		}
+
+		_, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			source,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		payload, err := io.ReadAll(reader)
+		require.ErrorIs(t, err, errReader)
+		require.Equal(t, []byte("payload"), payload)
+		require.NoError(t, reader.Close())
+		require.True(t, source.closed)
+	})
+
+	t.Run("HasherResetIfUsed", func(t *testing.T) {
+		expectedPayload := []byte("payload")
+		expectedVersion := versioning.Version(19)
+
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			expectedVersion,
+			bytes.NewReader(expectedPayload),
+		)
+		require.NoError(t, err)
+
+		hasher := sha256.New()
+		_, err = hasher.Write([]byte("dirty state"))
+		require.NoError(t, err)
+
+		_, reader, err := storage.Deserialize(
+			hasher,
+			resources.RT_CONFIG,
+			io.NopCloser(serializedReader),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		payload, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.Equal(t, expectedPayload, payload)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("AcceptsLegacyPlakarMagic", func(t *testing.T) {
+		expectedPayload := []byte("legacy payload")
+		expectedVersion := versioning.Version(21)
+		serializedData := expectedSerializedData(
+			t,
+			"_PLAKAR_",
+			resources.RT_CONFIG,
+			expectedVersion,
+			expectedPayload,
+		)
+
+		version, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			io.NopCloser(bytes.NewReader(serializedData)),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.Equal(t, expectedVersion, version)
+
+		payload, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.Equal(t, expectedPayload, payload)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("CloseDelegatedToInnerReader", func(t *testing.T) {
+		serializedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(23),
+			bytes.NewReader([]byte("payload")),
+		)
+		require.NoError(t, err)
+
+		serializedData, err := io.ReadAll(serializedReader)
+		require.NoError(t, err)
+
+		source := &trackedReadCloser{
+			reader: bytes.NewReader(serializedData),
+		}
+
+		_, reader, err := storage.Deserialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			source,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.False(t, source.closed)
+
+		require.NoError(t, reader.Close())
+		require.True(t, source.closed)
 	})
 }

--- a/connectors/storage/storage.go
+++ b/connectors/storage/storage.go
@@ -17,8 +17,8 @@
 package storage
 
 import (
+	"bytes"
 	"context"
-	"encoding/binary"
 	"flag"
 	"fmt"
 	"io"
@@ -91,19 +91,27 @@ func NewConfigurationFromBytes(version versioning.Version, data []byte) (*Config
 }
 
 func NewConfigurationFromWrappedBytes(data []byte) (*Configuration, error) {
-	var configuration Configuration
+	hasher := hashing.GetHasher(DEFAULT_HASHING_ALGORITHM)
+	if hasher == nil {
+		return nil, fmt.Errorf("unsupported hashing algorithm: %s", DEFAULT_HASHING_ALGORITHM)
+	}
 
-	version := versioning.Version(binary.LittleEndian.Uint32(data[12:16]))
-
-	data = data[:len(data)-int(STORAGE_FOOTER_SIZE)]
-	data = data[STORAGE_HEADER_SIZE:]
-
-	err := msgpack.Unmarshal(data, &configuration)
+	version, reader, err := Deserialize(
+		hasher,
+		resources.RT_CONFIG,
+		io.NopCloser(bytes.NewReader(data)),
+	)
 	if err != nil {
 		return nil, err
 	}
-	configuration.Version = version
-	return &configuration, nil
+	defer reader.Close()
+
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewConfigurationFromBytes(version, payload)
 }
 
 func (c *Configuration) ToBytes() ([]byte, error) {

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -13,6 +13,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStorageResourceString(t *testing.T) {
+	t.Run("StorageResourceUndefined", func(t *testing.T) {
+		require.Equal(t, "undefined", storage.StorageResourceUndefined.String())
+	})
+
+	t.Run("StorageResourcePackfile", func(t *testing.T) {
+		require.Equal(t, "packfile", storage.StorageResourcePackfile.String())
+	})
+
+	t.Run("StorageResourceState", func(t *testing.T) {
+		require.Equal(t, "state", storage.StorageResourceState.String())
+	})
+
+	t.Run("StorageResourceLock", func(t *testing.T) {
+		require.Equal(t, "lock", storage.StorageResourceLock.String())
+	})
+
+	t.Run("StorageResourceECCPackfile", func(t *testing.T) {
+		require.Equal(t, "ECC packfile", storage.StorageResourceECCPackfile.String())
+	})
+
+	t.Run("StorageResourceECCState", func(t *testing.T) {
+		require.Equal(t, "ECC state", storage.StorageResourceECCState.String())
+	})
+
+	t.Run("UnknownStorageResource", func(t *testing.T) {
+		require.Equal(t, "unknown", storage.StorageResource(999).String())
+	})
+}
+
 func TestNewStore(t *testing.T) {
 	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 func TestStorageResourceString(t *testing.T) {
@@ -95,6 +96,48 @@ func TestNewConfiguration(t *testing.T) {
 		require.NotEqual(t, uuid.Nil, cfg1.RepositoryID)
 		require.NotEqual(t, uuid.Nil, cfg2.RepositoryID)
 		require.NotEqual(t, cfg1.RepositoryID, cfg2.RepositoryID)
+	})
+}
+
+func TestConfigurationToBytes(t *testing.T) {
+	t.Run("ValidConfiguration", func(t *testing.T) {
+		cfg := storage.NewConfiguration()
+		cfg.Version = versioning.Version(42)
+
+		data, err := cfg.ToBytes()
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+
+		var decoded storage.Configuration
+		err = msgpack.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		require.True(t, cfg.Timestamp.Equal(decoded.Timestamp))
+		require.Equal(t, cfg.RepositoryID, decoded.RepositoryID)
+		require.Equal(t, cfg.Packfile, decoded.Packfile)
+		require.Equal(t, cfg.Chunking, decoded.Chunking)
+		require.Equal(t, cfg.Hashing, decoded.Hashing)
+		require.Equal(t, cfg.Compression, decoded.Compression)
+		require.Equal(t, cfg.Encryption, decoded.Encryption)
+		require.Equal(t, versioning.Version(0), decoded.Version)
+	})
+
+	t.Run("ConfigurationsWithoutCompressionAndEncryption", func(t *testing.T) {
+		cfg := storage.NewConfiguration()
+		require.NotNil(t, cfg)
+
+		cfg.Compression = nil
+		cfg.Encryption = nil
+		data, err := cfg.ToBytes()
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+
+		var decoded storage.Configuration
+		err = msgpack.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		require.Nil(t, decoded.Compression)
+		require.Nil(t, decoded.Encryption)
+		require.Equal(t, versioning.Version(0), decoded.Version)
 	})
 }
 

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -6,9 +6,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"io"
-	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -19,7 +17,6 @@ import (
 	"github.com/PlakarKorp/kloset/hashing"
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/location"
-	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/packfile"
 	"github.com/PlakarKorp/kloset/resources"
@@ -792,31 +789,75 @@ func TestOpen(t *testing.T) {
 	})
 }
 
-func TestCreateStore(t *testing.T) {
-	ctx := kcontext.NewKContext()
-	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
+func TestCreate(t *testing.T) {
+	registerBackend := func(
+		t *testing.T,
+		name string,
+		flags location.Flags,
+		backendFn storage.StoreFn,
+	) {
+		t.Helper()
 
-	config := storage.NewConfiguration()
-	serializedConfig, err := config.ToBytes()
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+		err := storage.Register(name, flags, backendFn)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = storage.Unregister(name) })
 	}
 
-	_, err = storage.Create(ctx, map[string]string{"location": "mock:///test/location"}, serializedConfig)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	t.Run("ValidCreation", func(t *testing.T) {
+		expectedConfig := []byte("serialized config")
+		expectedStore := mockStore{}
+		registerBackend(t, "test-create-success", 0, newMockBackend(&expectedStore, nil))
+		appCtx := kcontext.NewKContext()
 
-	// should return an error as the backend Create will return an error
-	_, err = storage.Create(ctx, map[string]string{"location": "mock:///test/location/musterror"}, serializedConfig)
-	if err.Error() != "creating error" {
-		t.Fatalf("Expected %s but got %v", "opening error", err)
-	}
+		store, err := storage.Create(appCtx, map[string]string{
+			"location": "test-create-success://some/path",
+		}, expectedConfig)
 
-	// should return an error as the backend does not exist
-	_, err = storage.Create(ctx, map[string]string{"location": "unknown://dummy"}, serializedConfig)
-	if err.Error() != "backend 'unknown' does not exist" {
-		t.Fatalf("Expected %s but got %v", "backend 'unknown' does not exist", err)
-	}
+		require.NoError(t, err)
+		require.Same(t, &expectedStore, store)
+		require.True(t, expectedStore.createCalled)
+		require.Equal(t, expectedConfig, expectedStore.createInput)
+	})
+
+	t.Run("NilConfigurationIsValid", func(t *testing.T) {
+		expectedStore := mockStore{}
+		registerBackend(t, "test-create-nil-config", 0, newMockBackend(&expectedStore, nil))
+		appCtx := kcontext.NewKContext()
+
+		store, err := storage.Create(appCtx, map[string]string{
+			"location": "test-create-nil-config://some/path",
+		}, nil)
+		require.NoError(t, err)
+		require.Same(t, &expectedStore, store)
+		require.True(t, expectedStore.createCalled)
+		require.Nil(t, expectedStore.createInput)
+	})
+
+	t.Run("PropagatesStoreCreateError", func(t *testing.T) {
+		expectedErr := errors.New("creating error")
+		expectedConfig := []byte("serialized config")
+		expectedStore := mockStore{
+			createErr: expectedErr,
+		}
+		registerBackend(t, "test-create-error", 0, newMockBackend(&expectedStore, nil))
+		appCtx := kcontext.NewKContext()
+
+		store, err := storage.Create(appCtx, map[string]string{
+			"location": "test-create-error://some/path",
+		}, expectedConfig)
+		require.Nil(t, store)
+		require.ErrorIs(t, err, expectedErr)
+		require.True(t, expectedStore.createCalled)
+		require.Equal(t, expectedConfig, expectedStore.createInput)
+	})
+
+	t.Run("FailsIfStoreCreationFails", func(t *testing.T) {
+		appCtx := kcontext.NewKContext()
+
+		store, err := storage.Create(appCtx, map[string]string{
+			"location": "unknown://some/path",
+		}, []byte("serialized config"))
+		require.Nil(t, store)
+		require.EqualError(t, err, "backend 'unknown' does not exist")
+	})
 }

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -380,6 +380,48 @@ func TestRegister(t *testing.T) {
 	})
 }
 
+func TestUnregister(t *testing.T) {
+	backendFn := func(
+		ctx context.Context,
+		proto string,
+		config map[string]string,
+	) (storage.Store, error) {
+		return nil, nil
+	}
+
+	t.Run("ValidBackendUnregistration", func(t *testing.T) {
+		backendName := "test-unregister-backend"
+
+		err := storage.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = storage.Unregister(backendName)
+		require.NoError(t, err)
+	})
+
+	t.Run("Fails_IfBackendNotRegistered", func(t *testing.T) {
+		backendName := "test-unregister-missing"
+
+		err := storage.Unregister(backendName)
+		require.EqualError(t, err, "storage backend 'test-unregister-missing' not registered")
+	})
+
+	t.Run("Register->Unregister->Register", func(t *testing.T) {
+		backendName := "test-unregister-reregister"
+
+		err := storage.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = storage.Unregister(backendName)
+		require.NoError(t, err)
+
+		err = storage.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = storage.Unregister(backendName) })
+	})
+}
+
 func TestNewStore(t *testing.T) {
 	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -464,25 +466,217 @@ func TestBackends(t *testing.T) {
 	})
 }
 
-func TestNewStore(t *testing.T) {
-	ctx := kcontext.NewKContext()
-	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
+func TestNew(t *testing.T) {
+	registerBackend := func(
+		t *testing.T,
+		name string,
+		flags location.Flags,
+		backendFn storage.StoreFn,
+	) {
+		t.Helper()
 
-	store, err := storage.New(ctx, map[string]string{"location": "mock:///test/location"})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+		err := storage.Register(name, flags, backendFn)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = storage.Unregister(name) })
 	}
 
-	if loc := store.Origin(); loc != "mock:///test/location" {
-		t.Errorf("expected location to be '/test/location', got %v", loc)
-	}
+	t.Run("Fails_IfLocationIsMissing", func(t *testing.T) {
+		appCtx := kcontext.NewKContext()
 
-	// should return an error as the backend does not exist
-	_, err = storage.New(ctx, map[string]string{"location": "unknown:///test/location"})
-	if err.Error() != "backend 'unknown' does not exist" {
-		t.Fatalf("Expected %s but got %v", "backend 'unknown' does not exist", err)
-	}
+		store, err := storage.New(appCtx, map[string]string{})
+		require.Nil(t, store)
+		require.EqualError(t, err, "missing location")
+	})
+
+	t.Run("Fails_IfBackendDoesNotExist", func(t *testing.T) {
+		appCtx := kcontext.NewKContext()
+
+		store, err := storage.New(appCtx, map[string]string{
+			"location": "unknown://some/path",
+		})
+		require.Nil(t, store)
+		require.EqualError(t, err, "backend 'unknown' does not exist")
+	})
+
+	t.Run("UseDefaultFSProtocolForRelativeLocalPath", func(t *testing.T) {
+		var (
+			called           bool
+			receivedCtx      context.Context
+			receivedProto    string
+			receivedLocation string
+			receivedConfig   map[string]string
+		)
+
+		backend := func(
+			ctx context.Context,
+			proto string,
+			storeConfig map[string]string,
+		) (storage.Store, error) {
+			called = true
+			receivedCtx = ctx
+			receivedProto = proto
+			receivedLocation = storeConfig["location"]
+			receivedConfig = storeConfig
+			return nil, nil
+		}
+
+		registerBackend(t, "fs", location.FLAG_LOCALFS, backend)
+
+		appCtx := kcontext.NewKContext()
+		appCtx.CWD = t.TempDir()
+		storeConfig := map[string]string{
+			"location": "relative/path",
+		}
+
+		store, err := storage.New(appCtx, storeConfig)
+		require.NoError(t, err)
+		require.Nil(t, store)
+		require.True(t, called)
+		require.Same(t, appCtx, receivedCtx)
+		require.Equal(t, "fs", receivedProto)
+		expectedLocation := "fs://" + filepath.Join(appCtx.CWD, "relative/path")
+		require.Equal(t, expectedLocation, receivedLocation)
+		require.Equal(t, expectedLocation, storeConfig["location"])
+		require.Equal(t, storeConfig, receivedConfig)
+	})
+
+	t.Run("KeepAbsoluteLocalPathUnchanged", func(t *testing.T) {
+		var (
+			receivedProto    string
+			receivedLocation string
+		)
+
+		backend := func(
+			ctx context.Context,
+			proto string,
+			storeConfig map[string]string,
+		) (storage.Store, error) {
+			receivedProto = proto
+			receivedLocation = storeConfig["location"]
+			return nil, nil
+		}
+
+		registerBackend(t, "fs", location.FLAG_LOCALFS, backend)
+
+		appCtx := kcontext.NewKContext()
+		absolutePath := filepath.Join(t.TempDir(), "some", "path")
+		storeConfig := map[string]string{
+			"location": "fs://" + absolutePath,
+		}
+
+		store, err := storage.New(appCtx, storeConfig)
+		require.NoError(t, err)
+		require.Nil(t, store)
+		require.Equal(t, "fs", receivedProto)
+		require.Equal(t, "fs://"+absolutePath, receivedLocation)
+		require.Equal(t, "fs://"+absolutePath, storeConfig["location"])
+	})
+
+	t.Run("DoNotRewriteNonLocalLocation", func(t *testing.T) {
+		var (
+			receivedProto    string
+			receivedLocation string
+		)
+
+		backend := func(
+			ctx context.Context,
+			proto string,
+			storeConfig map[string]string,
+		) (storage.Store, error) {
+			receivedProto = proto
+			receivedLocation = storeConfig["location"]
+			return nil, nil
+		}
+
+		registerBackend(t, "s3", 0, backend)
+
+		appCtx := kcontext.NewKContext()
+		storeConfig := map[string]string{
+			"location": "s3://bucket/path",
+		}
+
+		store, err := storage.New(appCtx, storeConfig)
+		require.NoError(t, err)
+		require.Nil(t, store)
+		require.Equal(t, "s3", receivedProto)
+		require.Equal(t, "s3://bucket/path", receivedLocation)
+		require.Equal(t, "s3://bucket/path", storeConfig["location"])
+	})
+
+	t.Run("RedirectFSArchiveToPTARBackend", func(t *testing.T) {
+		var (
+			fsCalled            bool
+			ptarCalled          bool
+			receivedProto       string
+			receivedLocation    string
+			receivedStoreConfig map[string]string
+		)
+
+		fsBackend := func(
+			ctx context.Context,
+			proto string,
+			storeConfig map[string]string,
+		) (storage.Store, error) {
+			fsCalled = true
+			return nil, nil
+		}
+
+		ptarBackend := func(
+			ctx context.Context,
+			proto string,
+			storeConfig map[string]string,
+		) (storage.Store, error) {
+			ptarCalled = true
+			receivedProto = proto
+			receivedLocation = storeConfig["location"]
+			receivedStoreConfig = storeConfig
+			return nil, nil
+		}
+
+		registerBackend(t, "fs", location.FLAG_LOCALFS, fsBackend)
+		registerBackend(t, "ptar", 0, ptarBackend)
+
+		appCtx := kcontext.NewKContext()
+		appCtx.CWD = t.TempDir()
+
+		storeConfig := map[string]string{
+			"location": "archive.ptar",
+		}
+
+		store, err := storage.New(appCtx, storeConfig)
+		require.NoError(t, err)
+		require.Nil(t, store)
+		require.False(t, fsCalled)
+		require.True(t, ptarCalled)
+		require.Equal(t, "ptar", receivedProto)
+		expectedLocation := "ptar://" + filepath.Join(appCtx.CWD, "archive.ptar")
+		require.Equal(t, expectedLocation, receivedLocation)
+		require.Equal(t, expectedLocation, storeConfig["location"])
+		require.Equal(t, storeConfig, receivedStoreConfig)
+	})
+
+	t.Run("PropagateBackendError", func(t *testing.T) {
+		expectedErr := errors.New("backend failure")
+
+		backend := func(
+			ctx context.Context,
+			proto string,
+			storeConfig map[string]string,
+		) (storage.Store, error) {
+			return nil, expectedErr
+		}
+
+		registerBackend(t, "s3", 0, backend)
+
+		appCtx := kcontext.NewKContext()
+		storeConfig := map[string]string{
+			"location": "s3://bucket/path",
+		}
+
+		store, err := storage.New(appCtx, storeConfig)
+		require.Nil(t, store)
+		require.ErrorIs(t, err, expectedErr)
+	})
 }
 
 func TestCreateStore(t *testing.T) {

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/packfile"
 	"github.com/PlakarKorp/kloset/resources"
 	"github.com/PlakarKorp/kloset/versioning"
@@ -27,6 +28,59 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vmihailenco/msgpack/v5"
 )
+
+type mockStore struct {
+	openData []byte
+	openErr  error
+
+	createCalled bool
+	createInput  []byte
+	createErr    error
+}
+
+func (m *mockStore) Create(_ context.Context, data []byte) error {
+	m.createCalled = true
+	m.createInput = append([]byte(nil), data...)
+	return m.createErr
+}
+
+func (m *mockStore) Open(context.Context) ([]byte, error) {
+	return m.openData, m.openErr
+}
+
+func (m *mockStore) Ping(context.Context) error                 { return nil }
+func (m *mockStore) Origin() string                             { return "" }
+func (m *mockStore) Type() string                               { return "" }
+func (m *mockStore) Root() string                               { return "" }
+func (m *mockStore) Flags() location.Flags                      { return 0 }
+func (m *mockStore) Mode(context.Context) (storage.Mode, error) { return 0, nil }
+func (m *mockStore) Size(context.Context) (int64, error)        { return 0, nil }
+
+func (m *mockStore) List(context.Context, storage.StorageResource) ([]objects.MAC, error) {
+	return nil, nil
+}
+
+func (m *mockStore) Put(context.Context, storage.StorageResource, objects.MAC, io.Reader) (int64, error) {
+	return 0, nil
+}
+
+func (m *mockStore) Get(context.Context, storage.StorageResource, objects.MAC, *storage.Range) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (m *mockStore) Delete(context.Context, storage.StorageResource, objects.MAC) error {
+	return nil
+}
+
+func (m *mockStore) Close(context.Context) error {
+	return nil
+}
+
+func newMockBackend(store storage.Store, err error) storage.StoreFn {
+	return func(context.Context, string, map[string]string) (storage.Store, error) {
+		return store, err
+	}
+}
 
 func TestStorageResourceString(t *testing.T) {
 	t.Run("StorageResourceUndefined", func(t *testing.T) {
@@ -679,6 +733,65 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestOpen(t *testing.T) {
+	registerBackend := func(
+		t *testing.T,
+		name string,
+		flags location.Flags,
+		backendFn storage.StoreFn,
+	) {
+		t.Helper()
+
+		err := storage.Register(name, flags, backendFn)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = storage.Unregister(name) })
+	}
+
+	t.Run("ReturnsValidStoreAndSerializedConfig", func(t *testing.T) {
+		expectedData := []byte("serialized config")
+		expectedStore := mockStore{
+			openData: expectedData,
+		}
+		registerBackend(t, "test-open-success", 0, newMockBackend(&expectedStore, nil))
+		appCtx := kcontext.NewKContext()
+
+		store, serializedConfig, err := storage.Open(appCtx, map[string]string{
+			"location": "test-open-success://some/path",
+		})
+		require.NoError(t, err)
+		require.Same(t, &expectedStore, store)
+		require.Equal(t, expectedData, serializedConfig)
+	})
+
+	t.Run("PropagatesStoreOpenError", func(t *testing.T) {
+		expectedErr := errors.New("opening error")
+		expectedStore := &mockStore{
+			openErr: expectedErr,
+		}
+
+		registerBackend(t, "test-open-error", 0, newMockBackend(expectedStore, nil))
+		appCtx := kcontext.NewKContext()
+
+		store, serializedConfig, err := storage.Open(appCtx, map[string]string{
+			"location": "test-open-error://some/path",
+		})
+		require.Nil(t, store)
+		require.Nil(t, serializedConfig)
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("Fails_IfStoreCreationFails", func(t *testing.T) {
+		appCtx := kcontext.NewKContext()
+
+		store, serializedConfig, err := storage.Open(appCtx, map[string]string{
+			"location": "unknown://some/path",
+		})
+		require.Nil(t, store)
+		require.Nil(t, serializedConfig)
+		require.EqualError(t, err, "backend 'unknown' does not exist")
+	})
+}
+
 func TestCreateStore(t *testing.T) {
 	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
@@ -703,33 +816,6 @@ func TestCreateStore(t *testing.T) {
 
 	// should return an error as the backend does not exist
 	_, err = storage.Create(ctx, map[string]string{"location": "unknown://dummy"}, serializedConfig)
-	if err.Error() != "backend 'unknown' does not exist" {
-		t.Fatalf("Expected %s but got %v", "backend 'unknown' does not exist", err)
-	}
-}
-
-func TestOpenStore(t *testing.T) {
-	ctx := kcontext.NewKContext()
-	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
-
-	store, _, err := storage.Open(ctx, map[string]string{"location": "mock:///test/location"})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	if loc := store.Origin(); loc != "mock:///test/location" {
-		t.Errorf("expected location to be '/test/location', got %v", loc)
-	}
-
-	// should return an error as the backend Open will return an error
-	_, _, err = storage.Open(ctx, map[string]string{"location": "mock:///test/location/musterror"})
-	if err.Error() != "opening error" {
-		t.Fatalf("Expected %s but got %v", "opening error", err)
-	}
-
-	// should return an error as the backend does not exist
-	_, _, err = storage.Open(ctx, map[string]string{"location": "unknown://dummy"})
 	if err.Error() != "backend 'unknown' does not exist" {
 		t.Fatalf("Expected %s but got %v", "backend 'unknown' does not exist", err)
 	}

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -1,7 +1,10 @@
 package storage_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"io"
 	"os"
 	"runtime"
 	"testing"
@@ -15,6 +18,7 @@ import (
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/packfile"
+	"github.com/PlakarKorp/kloset/resources"
 	ptesting "github.com/PlakarKorp/kloset/testing"
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/google/uuid"
@@ -181,6 +185,168 @@ func TestNewConfigurationFromBytes(t *testing.T) {
 		decoded, err := storage.NewConfigurationFromBytes(versioning.Version(1), []byte("not msgpack"))
 		require.Nil(t, decoded)
 		require.Error(t, err)
+	})
+}
+
+func TestNewConfigurationFromWrappedBytes(t *testing.T) {
+	t.Run("DeserializesWrappedConfiguration", func(t *testing.T) {
+		cfg := storage.NewConfiguration()
+		require.NotNil(t, cfg)
+
+		payload, err := cfg.ToBytes()
+		require.NoError(t, err)
+
+		hasher := hashing.GetHasher(storage.DEFAULT_HASHING_ALGORITHM)
+		require.NotNil(t, hasher)
+
+		wrappedReader, err := storage.Serialize(
+			hasher,
+			resources.RT_CONFIG,
+			versioning.Version(42),
+			bytes.NewReader(payload),
+		)
+		require.NoError(t, err)
+
+		wrappedData, err := io.ReadAll(wrappedReader)
+		require.NoError(t, err)
+
+		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
+		require.NoError(t, err)
+		require.NotNil(t, decoded)
+		require.Equal(t, versioning.Version(42), decoded.Version)
+		require.True(t, cfg.Timestamp.Equal(decoded.Timestamp))
+		require.Equal(t, cfg.RepositoryID, decoded.RepositoryID)
+		require.Equal(t, cfg.Packfile, decoded.Packfile)
+		require.Equal(t, cfg.Chunking, decoded.Chunking)
+		require.Equal(t, cfg.Hashing, decoded.Hashing)
+		require.Equal(t, cfg.Compression, decoded.Compression)
+		require.Equal(t, cfg.Encryption, decoded.Encryption)
+	})
+
+	t.Run("UsesVersionFromHeader", func(t *testing.T) {
+		cfg := storage.NewConfiguration()
+		require.NotNil(t, cfg)
+
+		cfg.Version = versioning.Version(999)
+		payload, err := cfg.ToBytes()
+		require.NoError(t, err)
+
+		hasher := hashing.GetHasher(storage.DEFAULT_HASHING_ALGORITHM)
+		require.NotNil(t, hasher)
+
+		wrappedReader, err := storage.Serialize(
+			hasher,
+			resources.RT_CONFIG,
+			versioning.Version(7),
+			bytes.NewReader(payload),
+		)
+		require.NoError(t, err)
+
+		wrappedData, err := io.ReadAll(wrappedReader)
+		require.NoError(t, err)
+
+		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
+		require.NoError(t, err)
+		require.NotNil(t, decoded)
+		require.Equal(t, versioning.Version(7), decoded.Version)
+	})
+
+	t.Run("Fails_IfPayloadIsInvalid", func(t *testing.T) {
+		wrappedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(1),
+			bytes.NewReader([]byte("not msgpack")),
+		)
+		require.NoError(t, err)
+
+		wrappedData, err := io.ReadAll(wrappedReader)
+		require.NoError(t, err)
+
+		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
+		require.Nil(t, decoded)
+		require.Error(t, err)
+	})
+
+	t.Run("Fails_IfDataIsTooShort", func(t *testing.T) {
+		decoded, err := storage.NewConfigurationFromWrappedBytes([]byte("short"))
+		require.Nil(t, decoded)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("Fails_IfMagicIsInvalid", func(t *testing.T) {
+		payload := []byte{0x80}
+		wrappedData := expectedSerializedData(
+			t,
+			"INVALID!",
+			resources.RT_CONFIG,
+			versioning.Version(1),
+			payload,
+		)
+
+		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
+		require.Nil(t, decoded)
+		require.EqualError(t, err, "invalid plakar magic: INVALID!")
+	})
+
+	t.Run("FailsIfWrappedResourceTypeIsInvalid", func(t *testing.T) {
+		payload := []byte{0x80}
+		wrappedData := expectedSerializedData(
+			t,
+			"_KLOSET_",
+			resources.Type(9999),
+			versioning.Version(1),
+			payload,
+		)
+
+		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
+		require.Nil(t, decoded)
+		require.EqualError(t, err, "invalid resource type")
+	})
+
+	t.Run("Fails_IfFooterIsTruncated", func(t *testing.T) {
+		hasher := hashing.GetHasher(storage.DEFAULT_HASHING_ALGORITHM)
+		require.NotNil(t, hasher)
+
+		wrappedReader, err := storage.Serialize(
+			hasher,
+			resources.RT_CONFIG,
+			versioning.Version(2),
+			bytes.NewReader([]byte{}),
+		)
+		require.NoError(t, err)
+
+		wrappedData, err := io.ReadAll(wrappedReader)
+		require.NoError(t, err)
+
+		wrappedData = wrappedData[:len(wrappedData)-1]
+		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
+		require.Nil(t, decoded)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("Fails_IfHMACIsInvalid", func(t *testing.T) {
+		cfg := storage.NewConfiguration()
+		require.NotNil(t, cfg)
+
+		payload, err := cfg.ToBytes()
+		require.NoError(t, err)
+
+		wrappedReader, err := storage.Serialize(
+			sha256.New(),
+			resources.RT_CONFIG,
+			versioning.Version(3),
+			bytes.NewReader(payload),
+		)
+		require.NoError(t, err)
+
+		wrappedData, err := io.ReadAll(wrappedReader)
+		require.NoError(t, err)
+
+		wrappedData[len(wrappedData)-1] ^= 0xff
+		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
+		require.Nil(t, decoded)
+		require.EqualError(t, err, "hmac mismatch")
 	})
 }
 

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -141,6 +141,49 @@ func TestConfigurationToBytes(t *testing.T) {
 	})
 }
 
+func TestNewConfigurationFromBytes(t *testing.T) {
+	t.Run("ValidConfiguration", func(t *testing.T) {
+		cfg := storage.NewConfiguration()
+
+		data, err := cfg.ToBytes()
+		require.NoError(t, err)
+
+		version := versioning.Version(42)
+		decoded, err := storage.NewConfigurationFromBytes(version, data)
+		require.NoError(t, err)
+		require.NotNil(t, decoded)
+
+		require.Equal(t, version, decoded.Version)
+		require.True(t, cfg.Timestamp.Equal(decoded.Timestamp))
+		require.Equal(t, cfg.RepositoryID, decoded.RepositoryID)
+		require.Equal(t, cfg.Packfile, decoded.Packfile)
+		require.Equal(t, cfg.Chunking, decoded.Chunking)
+		require.Equal(t, cfg.Hashing, decoded.Hashing)
+		require.Equal(t, cfg.Compression, decoded.Compression)
+		require.Equal(t, cfg.Encryption, decoded.Encryption)
+	})
+
+	t.Run("UsesVersionArgument", func(t *testing.T) {
+		cfg := storage.NewConfiguration()
+		require.NotNil(t, cfg)
+
+		cfg.Version = versioning.Version(999)
+		data, err := cfg.ToBytes()
+		require.NoError(t, err)
+
+		decoded, err := storage.NewConfigurationFromBytes(versioning.Version(7), data)
+		require.NoError(t, err)
+		require.NotNil(t, decoded)
+		require.Equal(t, versioning.Version(7), decoded.Version)
+	})
+
+	t.Run("Fails_IfDataInvalid", func(t *testing.T) {
+		decoded, err := storage.NewConfigurationFromBytes(versioning.Version(1), []byte("not msgpack"))
+		require.Nil(t, decoded)
+		require.Error(t, err)
+	})
+}
+
 func TestNewStore(t *testing.T) {
 	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -5,11 +5,19 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
+	"github.com/PlakarKorp/kloset/chunking"
+	"github.com/PlakarKorp/kloset/compression"
 	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/encryption"
+	"github.com/PlakarKorp/kloset/hashing"
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/kloset/packfile"
 	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +48,53 @@ func TestStorageResourceString(t *testing.T) {
 
 	t.Run("UnknownStorageResource", func(t *testing.T) {
 		require.Equal(t, "unknown", storage.StorageResource(999).String())
+	})
+}
+
+func TestNewConfiguration(t *testing.T) {
+	t.Run("ReturnsDefaultConfiguration", func(t *testing.T) {
+		before := time.Now()
+		cfg := storage.NewConfiguration()
+		after := time.Now()
+
+		require.NotNil(t, cfg)
+		require.Equal(t, versioning.FromString(storage.VERSION), cfg.Version)
+
+		require.False(t, cfg.Timestamp.IsZero())
+		require.False(t, cfg.Timestamp.Before(before))
+		require.False(t, cfg.Timestamp.After(after))
+
+		require.NotEqual(t, uuid.Nil, cfg.RepositoryID)
+
+		require.Equal(t, *packfile.NewDefaultConfiguration(), cfg.Packfile)
+		require.Equal(t, *chunking.NewDefaultConfiguration(), cfg.Chunking)
+		require.Equal(t, *hashing.NewDefaultConfiguration(), cfg.Hashing)
+
+		require.NotNil(t, cfg.Compression)
+		require.Equal(t, *compression.NewDefaultConfiguration(), *cfg.Compression)
+
+		expectedEncryption := encryption.NewDefaultConfiguration()
+		require.NotNil(t, cfg.Encryption)
+		require.Equal(t, expectedEncryption.SubKeyAlgorithm, cfg.Encryption.SubKeyAlgorithm)
+		require.Equal(t, expectedEncryption.DataAlgorithm, cfg.Encryption.DataAlgorithm)
+		require.Equal(t, expectedEncryption.ChunkSize, cfg.Encryption.ChunkSize)
+		require.Equal(t, expectedEncryption.KDFParams.KDF, cfg.Encryption.KDFParams.KDF)
+		require.Len(t, cfg.Encryption.KDFParams.Salt, len(expectedEncryption.KDFParams.Salt))
+		require.NotNil(t, cfg.Encryption.KDFParams.Argon2idParams)
+		require.Nil(t, cfg.Encryption.KDFParams.ScryptParams)
+		require.Nil(t, cfg.Encryption.KDFParams.Pbkdf2Params)
+		require.Equal(t, expectedEncryption.Canary, cfg.Encryption.Canary)
+	})
+
+	t.Run("TwoNewConfigurations_DistinctRepositoryIDs", func(t *testing.T) {
+		cfg1 := storage.NewConfiguration()
+		cfg2 := storage.NewConfiguration()
+
+		require.NotNil(t, cfg1)
+		require.NotNil(t, cfg2)
+		require.NotEqual(t, uuid.Nil, cfg1.RepositoryID)
+		require.NotEqual(t, uuid.Nil, cfg2.RepositoryID)
+		require.NotEqual(t, cfg1.RepositoryID, cfg2.RepositoryID)
 	})
 }
 

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/packfile"
 	"github.com/PlakarKorp/kloset/resources"
-	ptesting "github.com/PlakarKorp/kloset/testing"
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -422,6 +421,49 @@ func TestUnregister(t *testing.T) {
 	})
 }
 
+func TestBackends(t *testing.T) {
+	backendFn := func(
+		ctx context.Context,
+		proto string,
+		config map[string]string,
+	) (storage.Store, error) {
+		return nil, nil
+	}
+
+	t.Run("GetRegisteredBackends", func(t *testing.T) {
+		backendName1 := "test-backends-first"
+		backendName2 := "test-backends-second"
+
+		err := storage.Register(backendName1, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = storage.Register(backendName2, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_ = storage.Unregister(backendName1)
+			_ = storage.Unregister(backendName2)
+		})
+
+		backends := storage.Backends()
+		require.Contains(t, backends, backendName1)
+		require.Contains(t, backends, backendName2)
+	})
+
+	t.Run("DoNotGetUnregisteredBackends", func(t *testing.T) {
+		backendName := "test-backends-removed"
+
+		err := storage.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+
+		err = storage.Unregister(backendName)
+		require.NoError(t, err)
+
+		backends := storage.Backends()
+		require.NotContains(t, backends, backendName)
+	})
+}
+
 func TestNewStore(t *testing.T) {
 	ctx := kcontext.NewKContext()
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
@@ -497,73 +539,4 @@ func TestOpenStore(t *testing.T) {
 	if err.Error() != "backend 'unknown' does not exist" {
 		t.Fatalf("Expected %s but got %v", "backend 'unknown' does not exist", err)
 	}
-}
-
-func TestBackends(t *testing.T) {
-	ctx := kcontext.NewKContext()
-	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
-
-	storage.Register("test", 0, func(ctx context.Context, proto string, storeConfig map[string]string) (storage.Store, error) {
-		return &ptesting.MockBackend{}, nil
-	})
-
-	expected := []string{"mock", "test"}
-	actual := storage.Backends()
-	require.Equal(t, expected, actual)
-}
-
-func TestNew(t *testing.T) {
-	locations := []string{
-		"foo",
-		"bar",
-		"baz",
-		"quux",
-	}
-
-	for _, name := range locations {
-		t.Run(name, func(t *testing.T) {
-			ctx := kcontext.NewKContext()
-			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
-
-			storage.Register(name, 0, func(ctx context.Context, proto string, storeConfig map[string]string) (storage.Store, error) {
-				return ptesting.NewMockBackend(storeConfig), nil
-			})
-
-			location := name + ":///test/location"
-
-			store, err := storage.New(ctx, map[string]string{"location": location})
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if loc := store.Origin(); loc != location {
-				t.Errorf("expected location to be '%s', got %v", location, loc)
-			}
-		})
-	}
-
-	t.Run("unknown backend", func(t *testing.T) {
-		ctx := kcontext.NewKContext()
-		ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-		ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
-
-		// storage.Register("unknown", func(location string) storage.Store { return ptesting.NewMockBackend(location) })
-		_, err := storage.New(ctx, map[string]string{"location": "unknown://dummy"})
-		if err.Error() != "backend 'unknown' does not exist" {
-			t.Fatalf("Expected %s but got %v", "backend 'unknown' does not exist", err)
-		}
-	})
-
-	t.Run("absolute fs path", func(t *testing.T) {
-		ctx := kcontext.NewKContext()
-		ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-		ctx.MaxConcurrency = runtime.NumCPU()*8 + 1
-
-		// storage.Register("unknown", func(location string) storage.Store { return ptesting.NewMockBackend(location) })
-		store, err := storage.New(ctx, map[string]string{"location": "dummy"})
-		require.Nil(t, store)
-		require.ErrorContains(t, err, "backend 'fs' does not exist")
-	})
 }

--- a/connectors/storage/storage_test.go
+++ b/connectors/storage/storage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/PlakarKorp/kloset/encryption"
 	"github.com/PlakarKorp/kloset/hashing"
 	"github.com/PlakarKorp/kloset/kcontext"
+	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/packfile"
 	"github.com/PlakarKorp/kloset/resources"
@@ -347,6 +348,35 @@ func TestNewConfigurationFromWrappedBytes(t *testing.T) {
 		decoded, err := storage.NewConfigurationFromWrappedBytes(wrappedData)
 		require.Nil(t, decoded)
 		require.EqualError(t, err, "hmac mismatch")
+	})
+}
+
+func TestRegister(t *testing.T) {
+	backendFn := func(
+		ctx context.Context,
+		proto string,
+		config map[string]string,
+	) (storage.Store, error) {
+		return nil, nil
+	}
+
+	t.Run("ValidBackendRegistration", func(t *testing.T) {
+		backendName := "test-register-backend"
+
+		err := storage.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		t.Cleanup(func() { _ = storage.Unregister(backendName) })
+		require.NoError(t, err)
+	})
+
+	t.Run("FailsIfBackendAlreadyRegistered", func(t *testing.T) {
+		backendName := "test-register-duplicate"
+
+		err := storage.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = storage.Unregister(backendName) })
+
+		err = storage.Register(backendName, location.FLAG_LOCALFS, backendFn)
+		require.EqualError(t, err, "storage backend 'test-register-duplicate' already registered")
 	})
 }
 


### PR DESCRIPTION
This PR strengthens the test suite for `connectors/storage` with more focused black-box coverage.

It also fixes a few edge cases uncovered while expanding the tests.

## Changes

- add focused tests for:
  - `Serialize`
  - `Deserialize`
  - `NewConfiguration`
  - `(*Configuration).ToBytes`
  - `NewConfigurationFromBytes`
  - `NewConfigurationFromWrappedBytes`
  - `Register`
  - `Unregister`
  - `Backends`
  - `New`
  - `Open`
  - `Create`
 
## Bug fixes

This PR also fixes a few issues uncovered by the new tests:

- handle truncated footers correctly in `deserializeReader.Read()`
- return the correct byte count on HMAC mismatch in `deserializeReader.Read()`
- make `NewConfigurationFromWrappedBytes()` parse wrapped data safely instead of assuming the input is long enough and well-formed

## Results

### Before 


```
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:37:	newDeserializeReader				0.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:65:	Read								0.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:123:	Close								0.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:127:	Deserialize							0.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:144:	newSerializeReader					0.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:162:	Read								0.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:225:	Serialize							0.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:46:			init								100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:68:			NewConfiguration					100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:83:			NewConfigurationFromBytes			0.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:93:			NewConfigurationFromWrappedBytes	0.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:109:			ToBytes								100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:131:			String								0.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:179:			Register							66.7%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:186:			Unregister							0.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:193:			Backends							100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:197:			New									57.1%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:223:			Open								100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:238:			Create								100.0%
total:									(statements)														19.2%
```

### After

```
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:37:	newDeserializeReader				100.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:65:	Read								100.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:127:	Close								100.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:131:	Deserialize							100.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:148:	newSerializeReader					100.0%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:166:	Read								96.8%
github.com/PlakarKorp/kloset/connectors/storage/serialization.go:229:	Serialize							100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:46:			init								100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:68:			NewConfiguration					100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:83:			NewConfigurationFromBytes			100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:93:			NewConfigurationFromWrappedBytes	90.9%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:117:			ToBytes								100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:139:			String								100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:187:			Register							100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:194:			Unregister							100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:201:			Backends							100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:205:			New									100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:231:			Open								100.0%
github.com/PlakarKorp/kloset/connectors/storage/storage.go:246:			Create								100.0%
total:									(statements)														98.7%
```