### PR TITLE
Add tests coverage for connectors reader and SDK helpers

### DIFF
--- a/connectors/reader_test.go
+++ b/connectors/reader_test.go
@@ -1,6 +1,7 @@
 package connectors_test
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -40,5 +41,85 @@ func TestNewLazyReader(t *testing.T) {
 		})
 		require.NotNil(t, reader)
 		require.Equal(t, 0, openCalls)
+	})
+}
+
+func TestLazyReaderRead(t *testing.T) {
+	t.Run("OpenReaderOnFirstRead", func(t *testing.T) {
+		openCalls := 0
+
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			openCalls++
+			return &readerReadCloser{reader: strings.NewReader("hello")}, nil
+		})
+
+		buf := make([]byte, 5)
+		n, err := reader.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		require.Equal(t, "hello", string(buf))
+		require.Equal(t, 1, openCalls)
+	})
+
+	t.Run("ReuseOpenedReaderAcrossReads", func(t *testing.T) {
+		openCalls := 0
+
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			openCalls++
+			return &readerReadCloser{reader: strings.NewReader("hello")}, nil
+		})
+
+		first := make([]byte, 2)
+		n, err := reader.Read(first)
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+		require.Equal(t, "he", string(first))
+
+		second := make([]byte, 3)
+		n, err = reader.Read(second)
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		require.Equal(t, "llo", string(second))
+		require.Equal(t, 1, openCalls)
+	})
+
+	t.Run("PropagateOpenError", func(t *testing.T) {
+		expectedErr := errors.New("open failure")
+		openCalls := 0
+
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			openCalls++
+			return nil, expectedErr
+		})
+
+		buf := make([]byte, 1)
+		n, err := reader.Read(buf)
+		require.Equal(t, 0, n)
+		require.ErrorIs(t, err, expectedErr)
+
+		n, err = reader.Read(buf)
+		require.Equal(t, 0, n)
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, 1, openCalls)
+	})
+
+	t.Run("PropagatesReadError_NotReOpened", func(t *testing.T) {
+		expectedErr := errors.New("read failure")
+		openCalls := 0
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			openCalls++
+			return &readerReadCloser{reader: failingReader{err: expectedErr}}, nil
+		})
+
+		buf := make([]byte, 1)
+		n, err := reader.Read(buf)
+		require.Equal(t, 0, n)
+		require.ErrorIs(t, err, expectedErr)
+
+		n, err = reader.Read(buf)
+		require.Equal(t, 0, n)
+		require.ErrorIs(t, err, expectedErr)
+
+		require.Equal(t, 1, openCalls)
 	})
 }

--- a/connectors/reader_test.go
+++ b/connectors/reader_test.go
@@ -123,3 +123,63 @@ func TestLazyReaderRead(t *testing.T) {
 		require.Equal(t, 1, openCalls)
 	})
 }
+
+func TestLazyReaderClose(t *testing.T) {
+	t.Run("DoesNothingIfReaderWasNeverOpened", func(t *testing.T) {
+		openCalls := 0
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			openCalls++
+			return &readerReadCloser{reader: strings.NewReader("hello")}, nil
+		})
+
+		err := reader.Close()
+		require.NoError(t, err)
+		require.Equal(t, 0, openCalls)
+	})
+
+	t.Run("CloseOpenedReader", func(t *testing.T) {
+		underlying := &readerReadCloser{reader: strings.NewReader("hello")}
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			return underlying, nil
+		})
+
+		buf := make([]byte, 1)
+		_, err := reader.Read(buf)
+		require.NoError(t, err)
+
+		err = reader.Close()
+		require.NoError(t, err)
+		require.Equal(t, 1, underlying.closeCalls)
+	})
+
+	t.Run("ReturnStoredOpenError", func(t *testing.T) {
+		expectedErr := errors.New("open failure")
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			return nil, expectedErr
+		})
+
+		_, err := reader.Read(make([]byte, 1))
+		require.ErrorIs(t, err, expectedErr)
+
+		err = reader.Close()
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("PropagatesReaderCloseError", func(t *testing.T) {
+		expectedErr := errors.New("close failure")
+		underlying := &readerReadCloser{
+			reader:   strings.NewReader("hello"),
+			closeErr: expectedErr,
+		}
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			return underlying, nil
+		})
+
+		_, err := reader.Read(make([]byte, 1))
+		require.NoError(t, err)
+
+		err = reader.Close()
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, 1, underlying.closeCalls)
+	})
+}

--- a/connectors/reader_test.go
+++ b/connectors/reader_test.go
@@ -1,0 +1,44 @@
+package connectors_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	con "github.com/PlakarKorp/kloset/connectors"
+	"github.com/stretchr/testify/require"
+)
+
+type readerReadCloser struct {
+	reader     io.Reader
+	closeErr   error
+	closeCalls int
+}
+
+func (rrc *readerReadCloser) Read(p []byte) (int, error) { return rrc.reader.Read(p) }
+
+func (rrc *readerReadCloser) Close() error {
+	rrc.closeCalls++
+	return rrc.closeErr
+}
+
+type failingReader struct {
+	err error
+}
+
+func (fr failingReader) Read([]byte) (int, error) {
+	return 0, fr.err
+}
+
+func TestNewLazyReader(t *testing.T) {
+	t.Run("DoesNotOpenReaderImmediately", func(t *testing.T) {
+		openCalls := 0
+
+		reader := con.NewLazyReader(func() (io.ReadCloser, error) {
+			openCalls++
+			return &readerReadCloser{reader: strings.NewReader("hello")}, nil
+		})
+		require.NotNil(t, reader)
+		require.Equal(t, 0, openCalls)
+	})
+}

--- a/connectors/sdk_test.go
+++ b/connectors/sdk_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	con "github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/objects"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,5 +124,116 @@ func TestRecordError(t *testing.T) {
 		require.ErrorIs(t, result.Err, expectedErr)
 		require.Equal(t, record, result.Record)
 		require.Equal(t, 1, reader.closeCalls)
+	})
+}
+
+func TestNewRecord(t *testing.T) {
+	t.Run("InitializeWithMetadata", func(t *testing.T) {
+		var fileInfo objects.FileInfo
+		xattrs := []string{"user.mime_type", "user.owner"}
+		openCalls := 0
+
+		record := con.NewRecord(
+			"file.txt",
+			"target",
+			fileInfo,
+			xattrs,
+			func() (io.ReadCloser, error) {
+				openCalls++
+				return &sdkReadCloser{reader: strings.NewReader("payload")}, nil
+			},
+		)
+
+		require.NotNil(t, record)
+		require.Equal(t, "file.txt", record.Pathname)
+		require.Equal(t, "target", record.Target)
+		require.Equal(t, fileInfo, record.FileInfo)
+		require.Equal(t, xattrs, record.ExtendedAttributes)
+		require.NotNil(t, record.Reader)
+		require.False(t, record.IsXattr)
+		require.Equal(t, 0, openCalls)
+
+		n, err := record.Reader.Read(make([]byte, 2))
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+		require.Equal(t, 1, openCalls)
+	})
+
+	t.Run("DefaultUnsetFieldsToZeroValues", func(t *testing.T) {
+		var fileInfo objects.FileInfo
+		record := con.NewRecord(
+			"file.txt",
+			"target",
+			fileInfo,
+			[]string{"user.mime_type"},
+			func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("payload")), nil
+			},
+		)
+
+		require.NotNil(t, record)
+		require.NoError(t, record.Err)
+		require.Equal(t, fileInfo, record.FileInfo)
+		require.False(t, record.IsXattr)
+		require.Empty(t, record.XattrName)
+		require.Zero(t, record.XattrType)
+		require.Zero(t, record.FileAttributes)
+	})
+
+	t.Run("AcceptNilExtendedAttributes", func(t *testing.T) {
+		var fileInfo objects.FileInfo
+		record := con.NewRecord(
+			"file.txt",
+			"target",
+			fileInfo,
+			nil,
+			func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("payload")), nil
+			},
+		)
+
+		require.NotNil(t, record)
+		require.Equal(t, fileInfo, record.FileInfo)
+		require.Nil(t, record.ExtendedAttributes)
+		require.NotNil(t, record.Reader)
+	})
+
+	t.Run("AcceptEmptyStringFields", func(t *testing.T) {
+		var fileInfo objects.FileInfo
+		record := con.NewRecord(
+			"",
+			"",
+			fileInfo,
+			nil,
+			func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("payload")), nil
+			},
+		)
+
+		require.NotNil(t, record)
+		require.Empty(t, record.Pathname)
+		require.Empty(t, record.Target)
+		require.NoError(t, record.Err)
+		require.False(t, record.IsXattr)
+		require.Empty(t, record.XattrName)
+	})
+
+	t.Run("PanicWhenReadFuncIsNil", func(t *testing.T) {
+		var readFn func() (io.ReadCloser, error)
+		var fileInfo objects.FileInfo
+		record := con.NewRecord(
+			"file.txt",
+			"target",
+			fileInfo,
+			nil,
+			readFn,
+		)
+
+		require.NotNil(t, record)
+		require.NotNil(t, record.Reader)
+
+		require.Panics(t, func() {
+			_, _ = record.Reader.Read(make([]byte, 1))
+		})
 	})
 }

--- a/connectors/sdk_test.go
+++ b/connectors/sdk_test.go
@@ -1,0 +1,57 @@
+package connectors_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	con "github.com/PlakarKorp/kloset/connectors"
+	"github.com/stretchr/testify/require"
+)
+
+type sdkReadCloser struct {
+	reader     io.Reader
+	closeErr   error
+	closeCalls int
+}
+
+func (src *sdkReadCloser) Read(p []byte) (int, error) {
+	return src.reader.Read(p)
+}
+
+func (src *sdkReadCloser) Close() error {
+	src.closeCalls++
+	return src.closeErr
+}
+
+func TestRecordClose(t *testing.T) {
+	t.Run("FailsIfReaderIsMissing", func(t *testing.T) {
+		record := con.Record{}
+
+		err := record.Close()
+		require.ErrorIs(t, err, errors.ErrUnsupported)
+	})
+
+	t.Run("CloseReaderToo", func(t *testing.T) {
+		reader := sdkReadCloser{reader: strings.NewReader("hello")}
+		record := con.Record{Reader: &reader}
+
+		err := record.Close()
+		require.NoError(t, err)
+		require.Equal(t, 1, reader.closeCalls)
+	})
+
+	t.Run("PropagatesCloseError", func(t *testing.T) {
+		expectedErr := errors.New("close failure")
+		reader := sdkReadCloser{
+			reader:   strings.NewReader("hello"),
+			closeErr: expectedErr,
+		}
+		record := con.Record{Reader: &reader}
+
+		err := record.Close()
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, 1, reader.closeCalls)
+	})
+}

--- a/connectors/sdk_test.go
+++ b/connectors/sdk_test.go
@@ -237,3 +237,92 @@ func TestNewRecord(t *testing.T) {
 		})
 	})
 }
+
+func TestNewXattr(t *testing.T) {
+	t.Run("InitializeWithMetadata", func(t *testing.T) {
+		var kind objects.Attribute
+		openCalls := 0
+
+		record := con.NewXattr(
+			"file.txt",
+			"user.mime_type",
+			kind,
+			func() (io.ReadCloser, error) {
+				openCalls++
+				return &sdkReadCloser{reader: strings.NewReader("payload")}, nil
+			},
+		)
+
+		require.NotNil(t, record)
+		require.Equal(t, "file.txt", record.Pathname)
+		require.True(t, record.IsXattr)
+		require.Equal(t, "user.mime_type", record.XattrName)
+		require.Equal(t, kind, record.XattrType)
+		require.NotNil(t, record.Reader)
+		require.Equal(t, 0, openCalls)
+
+		buf := make([]byte, 7)
+		n, err := record.Reader.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, 7, n)
+		require.Equal(t, "payload", string(buf))
+		require.Equal(t, 1, openCalls)
+	})
+
+	t.Run("DefaultUnsetFieldsToZeroValues", func(t *testing.T) {
+		var kind objects.Attribute
+		record := con.NewXattr(
+			"file.txt",
+			"user.mime_type",
+			kind,
+			func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("payload")), nil
+			},
+		)
+
+		require.NotNil(t, record)
+		require.NoError(t, record.Err)
+		require.Empty(t, record.Target)
+		require.Nil(t, record.ExtendedAttributes)
+		require.Zero(t, record.FileAttributes)
+		require.Empty(t, record.FileInfo)
+	})
+
+	t.Run("AcceptEmptyStringFields", func(t *testing.T) {
+		var kind objects.Attribute
+		record := con.NewXattr(
+			"",
+			"",
+			kind,
+			func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("payload")), nil
+			},
+		)
+
+		require.NotNil(t, record)
+		require.Empty(t, record.Pathname)
+		require.True(t, record.IsXattr)
+		require.Empty(t, record.XattrName)
+		require.Equal(t, kind, record.XattrType)
+		require.Empty(t, record.FileInfo)
+	})
+
+	t.Run("PanicWhenReadFuncIsNil", func(t *testing.T) {
+		var readFn func() (io.ReadCloser, error)
+		var kind objects.Attribute
+
+		record := con.NewXattr(
+			"file.txt",
+			"user.mime_type",
+			kind,
+			readFn,
+		)
+
+		require.NotNil(t, record)
+		require.NotNil(t, record.Reader)
+
+		require.Panics(t, func() {
+			_, _ = record.Reader.Read(make([]byte, 1))
+		})
+	})
+}

--- a/connectors/sdk_test.go
+++ b/connectors/sdk_test.go
@@ -326,3 +326,38 @@ func TestNewXattr(t *testing.T) {
 		})
 	})
 }
+
+func TestNewError(t *testing.T) {
+	t.Run("Initialize", func(t *testing.T) {
+		expectedErr := errors.New("record failure")
+		record := con.NewError("file.txt", expectedErr)
+
+		require.NotNil(t, record)
+		require.Equal(t, "file.txt", record.Pathname)
+		require.ErrorIs(t, record.Err, expectedErr)
+		require.Nil(t, record.Reader)
+		require.Empty(t, record.Target)
+		require.False(t, record.IsXattr)
+		require.Empty(t, record.XattrName)
+		require.Zero(t, record.XattrType)
+		require.Empty(t, record.FileInfo)
+		require.Nil(t, record.ExtendedAttributes)
+		require.Zero(t, record.FileAttributes)
+	})
+
+	t.Run("AcceptEmptyPathnameAndNilError", func(t *testing.T) {
+		record := con.NewError("", nil)
+
+		require.NotNil(t, record)
+		require.Empty(t, record.Pathname)
+		require.NoError(t, record.Err)
+		require.Nil(t, record.Reader)
+		require.Empty(t, record.Target)
+		require.False(t, record.IsXattr)
+		require.Empty(t, record.XattrName)
+		require.Zero(t, record.XattrType)
+		require.Empty(t, record.FileInfo)
+		require.Nil(t, record.ExtendedAttributes)
+		require.Zero(t, record.FileAttributes)
+	})
+}

--- a/connectors/sdk_test.go
+++ b/connectors/sdk_test.go
@@ -89,3 +89,39 @@ func TestRecordOk(t *testing.T) {
 		require.Equal(t, 1, reader.closeCalls)
 	})
 }
+
+func TestRecordError(t *testing.T) {
+	t.Run("ReturnFailedResultAndCloseReader", func(t *testing.T) {
+		expectedErr := errors.New("record failure")
+		reader := sdkReadCloser{reader: strings.NewReader("hello")}
+		record := con.Record{
+			Reader:   &reader,
+			Pathname: "file.txt",
+			Target:   "target",
+		}
+
+		result := record.Error(expectedErr)
+		require.NotNil(t, result)
+		require.ErrorIs(t, result.Err, expectedErr)
+		require.Equal(t, record, result.Record)
+		require.Equal(t, 1, reader.closeCalls)
+	})
+
+	t.Run("IgnoreCloseError", func(t *testing.T) {
+		expectedErr := errors.New("record failure")
+		reader := sdkReadCloser{
+			reader:   strings.NewReader("hello"),
+			closeErr: errors.New("close failure"),
+		}
+		record := con.Record{
+			Reader:   &reader,
+			Pathname: "file.txt",
+		}
+
+		result := record.Error(expectedErr)
+		require.NotNil(t, result)
+		require.ErrorIs(t, result.Err, expectedErr)
+		require.Equal(t, record, result.Record)
+		require.Equal(t, 1, reader.closeCalls)
+	})
+}

--- a/connectors/sdk_test.go
+++ b/connectors/sdk_test.go
@@ -55,3 +55,37 @@ func TestRecordClose(t *testing.T) {
 		require.Equal(t, 1, reader.closeCalls)
 	})
 }
+
+func TestRecordOk(t *testing.T) {
+	t.Run("ReturnSuccessfulResultAndCloseReader", func(t *testing.T) {
+		reader := sdkReadCloser{reader: strings.NewReader("hello")}
+		record := con.Record{
+			Reader:   &reader,
+			Pathname: "file.txt",
+			Target:   "target",
+		}
+
+		result := record.Ok()
+		require.NotNil(t, result)
+		require.NoError(t, result.Err)
+		require.Equal(t, record, result.Record)
+		require.Equal(t, 1, reader.closeCalls)
+	})
+
+	t.Run("IgnoreCloseError", func(t *testing.T) {
+		reader := sdkReadCloser{
+			reader:   strings.NewReader("hello"),
+			closeErr: errors.New("close failure"),
+		}
+		record := con.Record{
+			Reader:   &reader,
+			Pathname: "file.txt",
+		}
+
+		result := record.Ok()
+		require.NotNil(t, result)
+		require.NoError(t, result.Err)
+		require.Equal(t, record, result.Record)
+		require.Equal(t, 1, reader.closeCalls)
+	})
+}


### PR DESCRIPTION
Adds dedicated tests for the lazy reader and record helper APIs. The new suite covers both nominal behavior and edge cases such as open/read/close failures, zero-value fields, and nil read functions.

## Changes

- add `connectors/reader_test.go`
- add `connectors/sdk_test.go`
- cover `LazyReader` behavior for:
  - lazy initialization through `NewLazyReader`
  - first-read opening
  - reader reuse across reads
  - propagation of open, read, and close errors
  - no-op close before the reader is opened
- cover `Record` helper methods for:
  - `Close`
  - `Ok`
  - `Error`
- cover record constructors for:
  - `NewRecord`
  - `NewXattr`
  - `NewError`
- validate:
  - metadata initialization
  - default zero values for unset fields
  - acceptance of empty strings and nil optional fields where applicable
  - current panic behavior when a nil read function is wrapped in a lazy reader

## Results

### Before

```
github.com/PlakarKorp/kloset/connectors/reader.go:12:	NewLazyReader	0.0%
github.com/PlakarKorp/kloset/connectors/reader.go:16:	Read		0.0%
github.com/PlakarKorp/kloset/connectors/reader.go:28:	Close		0.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:41:	Close		0.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:48:	Ok		0.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:56:	Error		0.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:70:	NewRecord	0.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:80:	NewXattr	0.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:90:	NewError	0.0%
total:							(statements)	0.0%
```

### After

```
github.com/PlakarKorp/kloset/connectors/reader.go:12:	NewLazyReader	100.0%
github.com/PlakarKorp/kloset/connectors/reader.go:16:	Read		100.0%
github.com/PlakarKorp/kloset/connectors/reader.go:28:	Close		100.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:41:	Close		100.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:48:	Ok		100.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:56:	Error		100.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:70:	NewRecord	100.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:80:	NewXattr	100.0%
github.com/PlakarKorp/kloset/connectors/sdk.go:90:	NewError	100.0%
total:							(statements)	100.0%
```