### PR TITLE
Rework and expand tests for location package

### DIFF
--- a/location/location_test.go
+++ b/location/location_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 
 	"github.com/PlakarKorp/kloset/location"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
-	fallback := "default"
-	loc := location.New[string](fallback)
-	if loc == nil {
-		t.Fatal("New returned nil")
-	}
+	t.Run("InitializeEmptyLocation", func(t *testing.T) {
+		loc := location.New[string]("default")
+		require.NotNil(t, loc)
+		require.Empty(t, loc.Names())
+	})
 }
 
 func TestRegister(t *testing.T) {

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -115,24 +115,34 @@ func TestUnregister(t *testing.T) {
 }
 
 func TestNames(t *testing.T) {
-	loc := location.New[string]("default")
-	expected := []string{"a", "b", "c"}
+	t.Run("EmptySliceWhenNoItemsAreRegistered", func(t *testing.T) {
+		loc := location.New[string]("default")
 
-	// Register items in reverse order to test sorting
-	loc.Register("c", "value3", 0)
-	loc.Register("b", "value2", 0)
-	loc.Register("a", "value1", 0)
+		names := loc.Names()
+		require.Empty(t, names)
+	})
 
-	names := loc.Names()
-	if len(names) != len(expected) {
-		t.Errorf("Names() returned %d items, want %d", len(names), len(expected))
-	}
+	t.Run("ReturnSortedRegisteredNames", func(t *testing.T) {
+		loc := location.New[string]("default")
 
-	for i, name := range names {
-		if name != expected[i] {
-			t.Errorf("Names()[%d] = %q, want %q", i, name, expected[i])
-		}
-	}
+		require.True(t, loc.Register("c", "value-c", 0))
+		require.True(t, loc.Register("a", "value-a", 0))
+		require.True(t, loc.Register("b", "value-b", 0))
+
+		names := loc.Names()
+		require.Equal(t, []string{"a", "b", "c"}, names)
+	})
+
+	t.Run("DoNotReturnUnregisteredNames", func(t *testing.T) {
+		loc := location.New[string]("default")
+
+		require.True(t, loc.Register("a", "value-a", 0))
+		require.True(t, loc.Register("b", "value-b", 0))
+		require.True(t, loc.Unregister("a"))
+
+		names := loc.Names()
+		require.Equal(t, []string{"b"}, names)
+	})
 }
 
 func TestLookup(t *testing.T) {

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -15,6 +15,54 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestParseFlag(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantFlag location.Flags
+		wantErr  error
+	}{
+		{
+			input:    "localfs",
+			wantFlag: location.FLAG_LOCALFS,
+		},
+		{
+			input:    "file",
+			wantFlag: location.FLAG_FILE,
+		},
+		{
+			input:    "stream",
+			wantFlag: location.FLAG_STREAM,
+		},
+		{
+			input:    "needack",
+			wantFlag: location.FLAG_NEEDACK,
+		},
+		{
+			input:    "nomerge",
+			wantFlag: location.FLAG_NOMERGE,
+		},
+		{
+			input:    "unknown",
+			wantFlag: 0,
+			wantErr:  location.ErrUnknownFlag,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("_"+tt.input, func(t *testing.T) {
+			flag, err := location.ParseFlag(tt.input)
+
+			if tt.input == "unknown" {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Zero(t, flag)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantFlag, flag)
+		})
+	}
+}
+
 func TestRegister(t *testing.T) {
 	loc := location.New[string]("default")
 

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -248,3 +248,71 @@ func TestLookup(t *testing.T) {
 		require.True(t, found)
 	})
 }
+
+func TestLocationLifecycle(t *testing.T) {
+	t.Run("Register->Lookup", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("http", "http-value", location.FLAG_LOCALFS|location.FLAG_FILE)
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("http://example.com")
+		require.Equal(t, "http", proto)
+		require.Equal(t, "example.com", locationValue)
+		require.Equal(t, "http-value", item)
+		require.Equal(t, location.FLAG_LOCALFS|location.FLAG_FILE, flags)
+		require.True(t, found)
+	})
+
+	t.Run("Register->Unregister->Lookup", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("http", "http-value", location.FLAG_LOCALFS)
+		require.True(t, ok)
+
+		ok = loc.Unregister("http")
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("http://example.com")
+		require.Equal(t, "http", proto)
+		require.Equal(t, "example.com", locationValue)
+		require.Empty(t, item)
+		require.Zero(t, flags)
+		require.False(t, found)
+	})
+
+	t.Run("FullLifecycle", func(t *testing.T) {
+		loc := location.New[string]("default")
+		require.True(t, loc.Register("fs", "first-value", location.FLAG_LOCALFS))
+		require.True(t, loc.Register("s3", "s3-value", location.FLAG_STREAM))
+
+		names := loc.Names()
+		require.Equal(t, []string{"fs", "s3"}, names)
+
+		proto, locationValue, item, flags, found := loc.Lookup("fs:///tmp/file")
+		require.Equal(t, "fs", proto)
+		require.Equal(t, "/tmp/file", locationValue)
+		require.Equal(t, "first-value", item)
+		require.Equal(t, location.FLAG_LOCALFS, flags)
+		require.True(t, found)
+
+		require.True(t, loc.Unregister("fs"))
+
+		proto, locationValue, item, flags, found = loc.Lookup("fs:///tmp/file")
+		require.Equal(t, "fs", proto)
+		require.Equal(t, "/tmp/file", locationValue)
+		require.Empty(t, item)
+		require.Zero(t, flags)
+		require.False(t, found)
+
+		require.True(t, loc.Register("fs", "second-value", location.FLAG_FILE))
+
+		proto, locationValue, item, flags, found = loc.Lookup("fs:///tmp/file")
+		require.Equal(t, "fs", proto)
+		require.Equal(t, "/tmp/file", locationValue)
+		require.Equal(t, "second-value", item)
+		require.Equal(t, location.FLAG_FILE, flags)
+		require.True(t, found)
+
+		names = loc.Names()
+		require.Equal(t, []string{"fs", "s3"}, names)
+	})
+}

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -1,25 +1,21 @@
-package location
+package location_test
 
 import (
 	"testing"
+
+	"github.com/PlakarKorp/kloset/location"
 )
 
 func TestNew(t *testing.T) {
 	fallback := "default"
-	loc := New[string](fallback)
+	loc := location.New[string](fallback)
 	if loc == nil {
 		t.Fatal("New returned nil")
-	}
-	if loc.fallback != fallback {
-		t.Errorf("fallback = %q, want %q", loc.fallback, fallback)
-	}
-	if loc.items == nil {
-		t.Error("items map is nil")
 	}
 }
 
 func TestRegister(t *testing.T) {
-	loc := New[string]("default")
+	loc := location.New[string]("default")
 
 	// Test successful registration
 	if !loc.Register("test", "value", 0) {
@@ -30,15 +26,10 @@ func TestRegister(t *testing.T) {
 	if loc.Register("test", "value2", 0) {
 		t.Error("Register succeeded when it should have failed for duplicate")
 	}
-
-	// Verify the value wasn't changed
-	if v, ok := loc.items["test"]; !ok || v.item != "value" {
-		t.Errorf("Duplicate registration changed value: got %v, want %v", v, "value")
-	}
 }
 
 func TestNames(t *testing.T) {
-	loc := New[string]("default")
+	loc := location.New[string]("default")
 	expected := []string{"a", "b", "c"}
 
 	// Register items in reverse order to test sorting
@@ -59,7 +50,7 @@ func TestNames(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	loc := New[string]("default")
+	loc := location.New[string]("default")
 	loc.Register("http", "http-value", 0)
 	loc.Register("https", "https-value", 0)
 

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -146,83 +146,105 @@ func TestNames(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	loc := location.New[string]("default")
-	loc.Register("http", "http-value", 0)
-	loc.Register("https", "https-value", 0)
+	t.Run("LookupRegisteredProtocolWithDoubleSlash", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("http", "http-value", location.FLAG_LOCALFS)
+		require.True(t, ok)
 
-	tests := []struct {
-		name         string
-		uri          string
-		wantProto    string
-		wantLocation string
-		wantValue    string
-		wantFound    bool
-	}{
-		{
-			name:         "simple http",
-			uri:          "http://example.com",
-			wantProto:    "http",
-			wantLocation: "example.com",
-			wantValue:    "http-value",
-			wantFound:    true,
-		},
-		{
-			name:         "simple https",
-			uri:          "https://example.com",
-			wantProto:    "https",
-			wantLocation: "example.com",
-			wantValue:    "https-value",
-			wantFound:    true,
-		},
-		{
-			name:         "unknown protocol",
-			uri:          "ftp://example.com",
-			wantProto:    "ftp",
-			wantLocation: "example.com",
-			wantValue:    "",
-			wantFound:    false,
-		},
-		{
-			name:         "no protocol",
-			uri:          "example.com",
-			wantProto:    "default",
-			wantLocation: "example.com",
-			wantValue:    "",
-			wantFound:    false,
-		},
-		{
-			name:         "windows absolute path",
-			uri:          "C:\\Users\\Plakup",
-			wantProto:    "default",
-			wantLocation: "C:\\Users\\Plakup",
-			wantValue:    "",
-			wantFound:    false,
-		},
-		{
-			name:         "empty string",
-			uri:          "",
-			wantProto:    "default",
-			wantLocation: "",
-			wantValue:    "",
-			wantFound:    false,
-		},
-	}
+		proto, locationValue, item, flags, found := loc.Lookup("http://example.com")
+		require.Equal(t, "http", proto)
+		require.Equal(t, "example.com", locationValue)
+		require.Equal(t, "http-value", item)
+		require.Equal(t, location.FLAG_LOCALFS, flags)
+		require.True(t, found)
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			proto, location, value, _, found := loc.Lookup(tt.uri)
-			if proto != tt.wantProto {
-				t.Errorf("Lookup() proto = %v, want %v", proto, tt.wantProto)
-			}
-			if location != tt.wantLocation {
-				t.Errorf("Lookup() location = %v, want %v", location, tt.wantLocation)
-			}
-			if value != tt.wantValue {
-				t.Errorf("Lookup() value = %v, want %v", value, tt.wantValue)
-			}
-			if found != tt.wantFound {
-				t.Errorf("Lookup() found = %v, want %v", found, tt.wantFound)
-			}
-		})
-	}
+	t.Run("ReturnUnknownProtocolWhenProtocolIsNotRegistered", func(t *testing.T) {
+		loc := location.New[string]("default")
+
+		proto, locationValue, item, flags, found := loc.Lookup("ftp://example.com")
+		require.Equal(t, "ftp", proto)
+		require.Equal(t, "example.com", locationValue)
+		require.Empty(t, item)
+		require.Zero(t, flags)
+		require.False(t, found)
+	})
+
+	t.Run("UseFallbackWhenProtocolIsMissing", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("default", "default-value", location.FLAG_FILE)
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("example.com")
+		require.Equal(t, "default", proto)
+		require.Equal(t, "example.com", locationValue)
+		require.Equal(t, "default-value", item)
+		require.Equal(t, location.FLAG_FILE, flags)
+		require.True(t, found)
+	})
+
+	t.Run("UseFallbackForWindowsAbsolutePath", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("default", "default-value", location.FLAG_LOCALFS)
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("C:\\Users\\Plakup")
+		require.Equal(t, "default", proto)
+		require.Equal(t, "C:\\Users\\Plakup", locationValue)
+		require.Equal(t, "default-value", item)
+		require.Equal(t, location.FLAG_LOCALFS, flags)
+		require.True(t, found)
+	})
+
+	t.Run("LookupRegisteredProtocolWithoutDoubleSlash", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("http", "http-value", location.FLAG_STREAM)
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("http:example.com")
+		require.Equal(t, "http", proto)
+		require.Equal(t, "example.com", locationValue)
+		require.Equal(t, "http-value", item)
+		require.Equal(t, location.FLAG_STREAM, flags)
+		require.True(t, found)
+	})
+
+	t.Run("UseFallbackForEmptyString", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("default", "default-value", location.FLAG_FILE)
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("")
+		require.Equal(t, "default", proto)
+		require.Equal(t, "", locationValue)
+		require.Equal(t, "default-value", item)
+		require.Equal(t, location.FLAG_FILE, flags)
+		require.True(t, found)
+	})
+
+	t.Run("DoNotTreatOneCharacterPrefixAsProtocol", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("default", "default-value", location.FLAG_LOCALFS)
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("a:/tmp/file")
+		require.Equal(t, "default", proto)
+		require.Equal(t, "a:/tmp/file", locationValue)
+		require.Equal(t, "default-value", item)
+		require.Equal(t, location.FLAG_LOCALFS, flags)
+		require.True(t, found)
+	})
+
+	t.Run("TrimLeadingDoubleSlashFromLocation", func(t *testing.T) {
+		loc := location.New[string]("default")
+		ok := loc.Register("fs", "fs-value", location.FLAG_LOCALFS)
+		require.True(t, ok)
+
+		proto, locationValue, item, flags, found := loc.Lookup("fs:///tmp/file")
+		require.Equal(t, "fs", proto)
+		require.Equal(t, "/tmp/file", locationValue)
+		require.Equal(t, "fs-value", item)
+		require.Equal(t, location.FLAG_LOCALFS, flags)
+		require.True(t, found)
+	})
 }

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -82,6 +82,38 @@ func TestRegister(t *testing.T) {
 	})
 }
 
+func TestUnregister(t *testing.T) {
+	t.Run("ExistingItem", func(t *testing.T) {
+		loc := location.New[string]("default")
+
+		ok := loc.Register("test", "value", 0)
+		require.True(t, ok)
+
+		ok = loc.Unregister("test")
+		require.True(t, ok)
+	})
+
+	t.Run("FailsIfItemDoesNotExist", func(t *testing.T) {
+		loc := location.New[string]("default")
+
+		ok := loc.Unregister("missing")
+		require.False(t, ok)
+	})
+
+	t.Run("Register ->Unregister->Register", func(t *testing.T) {
+		loc := location.New[string]("default")
+
+		ok := loc.Register("test", "value", 0)
+		require.True(t, ok)
+
+		ok = loc.Unregister("test")
+		require.True(t, ok)
+
+		ok = loc.Register("test", "other-value", 0)
+		require.True(t, ok)
+	})
+}
+
 func TestNames(t *testing.T) {
 	loc := location.New[string]("default")
 	expected := []string{"a", "b", "c"}

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -64,17 +64,22 @@ func TestParseFlag(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	loc := location.New[string]("default")
+	t.Run("NewItem", func(t *testing.T) {
+		loc := location.New[string]("default")
 
-	// Test successful registration
-	if !loc.Register("test", "value", 0) {
-		t.Error("Register failed to register new item")
-	}
+		ok := loc.Register("test", "value", location.FLAG_LOCALFS)
+		require.True(t, ok)
+	})
 
-	// Test duplicate registration
-	if loc.Register("test", "value2", 0) {
-		t.Error("Register succeeded when it should have failed for duplicate")
-	}
+	t.Run("FailsIfDuplicateName", func(t *testing.T) {
+		loc := location.New[string]("default")
+
+		ok := loc.Register("test", "value", location.FLAG_LOCALFS)
+		require.True(t, ok)
+
+		ok = loc.Register("test", "other-value", location.FLAG_FILE)
+		require.False(t, ok)
+	})
 }
 
 func TestNames(t *testing.T) {


### PR DESCRIPTION
This PR rewrites the existing `location` tests to stop relying on package internals and to align them with the public API only. It also adds missing coverage for `ParseFlag`, `Unregister`, richer `Lookup` cases, and cross-API lifecycle flows.

## Changes

- switch `location/location_test.go` from `package location` to `package location_test`
- add `testify/require` assertions and restructure tests with `t.Run(...)`
- rework `TestNew` as a black-box test
- add dedicated coverage for `ParseFlag`, including:
  - all known flags
  - unknown flag handling with `ErrUnknownFlag`
- rework `TestRegister` to cover:
  - successful registration
  - duplicate name rejection
- add `TestUnregister` to cover:
  - unregistering an existing item
  - rejecting missing items
  - registering again after unregistering
- rework `TestNames` to cover:
  - empty locations
  - sorted registered names
  - exclusion of unregistered names
- expand `TestLookup` to cover:
  - registered protocols with `://`
  - registered protocols with `:`
  - unknown protocols
  - fallback resolution when no protocol is provided
  - fallback resolution for empty strings
  - fallback resolution for Windows-style absolute paths
  - one-character prefixes that must not be treated as protocols
  - trimming of leading `//` from resolved locations
- add `TestLocationLifecycle` integration-style coverage for:
  - `Register -> Lookup`
  - `Register -> Unregister -> Lookup`
  - a fuller lifecycle combining `Register`, `Lookup`, `Names`, and `Unregister`

## Results

### Before

```
github.com/PlakarKorp/kloset/location/location.go:33:	New		100.0%
github.com/PlakarKorp/kloset/location/location.go:40:	Register	100.0%
github.com/PlakarKorp/kloset/location/location.go:53:	Unregister	0.0%
github.com/PlakarKorp/kloset/location/location.go:63:	Names		100.0%
github.com/PlakarKorp/kloset/location/location.go:75:	allowedInUri	100.0%
github.com/PlakarKorp/kloset/location/location.go:80:	Lookup		100.0%
github.com/PlakarKorp/kloset/location/location.go:115:	ParseFlag	0.0%
total:							(statements)	71.7%
```

### After

```
github.com/PlakarKorp/kloset/location/location.go:33:	New		100.0%
github.com/PlakarKorp/kloset/location/location.go:40:	Register	100.0%
github.com/PlakarKorp/kloset/location/location.go:53:	Unregister	100.0%
github.com/PlakarKorp/kloset/location/location.go:63:	Names		100.0%
github.com/PlakarKorp/kloset/location/location.go:75:	allowedInUri	100.0%
github.com/PlakarKorp/kloset/location/location.go:80:	Lookup		100.0%
github.com/PlakarKorp/kloset/location/location.go:115:	ParseFlag	100.0%
total:							(statements)	100.0%
```