### PR TITLE
locate: Rework time flag tests as black-box coverage

### DIFF
--- a/locate/time.go
+++ b/locate/time.go
@@ -18,6 +18,7 @@ package locate
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/PlakarKorp/go-human2duration"
@@ -49,6 +50,10 @@ func (t *TimeFlag) Set(s string) error {
 }
 
 func ParseTimeFlag(input string) (time.Time, error) {
+	if strings.TrimSpace(input) != input {
+		return time.Time{}, fmt.Errorf("invalid time format: %q", input)
+	}
+
 	if input == "" {
 		return time.Time{}, nil
 	}

--- a/locate/time_test.go
+++ b/locate/time_test.go
@@ -1,7 +1,6 @@
 package locate_test
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -128,50 +127,106 @@ func TestParseTimeFlag(t *testing.T) {
 	})
 }
 
-// helper: compare times exactly (in UTC) for absolute parses
-func mustUTC(t *testing.T, y int, m time.Month, d, hh, mm, ss int) time.Time {
-	t.Helper()
-	return time.Date(y, m, d, hh, mm, ss, 0, time.UTC)
-}
+// TimeFlag is tested as a single block because its public pieces are tightly coupled:
+// NewTimeFlag only becomes observable through String and Set, and Set itself delegates
+// parsing to ParseTimeFlag. Testing them together avoids an artificial ordering between
+// APIs that do not have meaningful standalone black-box behavior.
+func TestTimeFlag(t *testing.T) {
+	t.Run("StringReturnsEmptyStringWhenDestinationIsNil", func(t *testing.T) {
+		flag := loc.NewTimeFlag(nil)
+		got := flag.String()
 
-func TestTimeFlag_SetAndString(t *testing.T) {
-	var dest time.Time
-	tf := loc.NewTimeFlag(&dest)
+		require.Equal(t, "", got)
+	})
 
-	// Zero value should stringify to empty
-	if s := tf.String(); s != "" {
-		t.Fatalf("String on zero dest: got %q want ''", s)
-	}
+	t.Run("StringReturnsEmptyStringWhenDestinationIsZero", func(t *testing.T) {
+		var dest time.Time
 
-	// Set an RFC3339 value
-	in := "2025-08-28T00:00:00Z"
-	if err := tf.Set(in); err != nil {
-		t.Fatalf("Set(%q) error: %v", in, err)
-	}
-	want := mustUTC(t, 2025, time.August, 28, 0, 0, 0)
-	if !dest.Equal(want) {
-		t.Fatalf("dest: got %v want %v", dest, want)
-	}
+		flag := loc.NewTimeFlag(&dest)
+		got := flag.String()
 
-	// After setting, String() should be non-empty and contain the date
-	if s := tf.String(); !strings.Contains(s, "2025-08-28") {
-		t.Fatalf("String after Set: got %q; expected it to include 2025-08-28", s)
-	}
-}
+		require.Equal(t, "", got)
+	})
 
-func TestTimeFlag_Set_Duration(t *testing.T) {
-	var dest time.Time
-	tf := loc.NewTimeFlag(&dest)
+	t.Run("StringReturnsNonEmptyStringWhenDestinationIsSet", func(t *testing.T) {
+		dest := time.Date(2025, time.August, 28, 12, 34, 56, 0, time.UTC)
 
-	before := time.Now()
-	if err := tf.Set("30min"); err != nil { // IMPORTANT: use "min", not "m"
-		t.Fatalf("Set duration error: %v", err)
-	}
-	after := time.Now()
+		flag := loc.NewTimeFlag(&dest)
+		got := flag.String()
 
-	lower := before.Add(-30 * time.Minute).Add(-250 * time.Millisecond)
-	upper := after.Add(-30 * time.Minute).Add(250 * time.Millisecond)
-	if dest.Before(lower) || dest.After(upper) {
-		t.Fatalf("Set(30min): got %v, want in [%v, %v]", dest, lower, upper)
-	}
+		require.NotEmpty(t, got)
+		require.Contains(t, got, "2025-08-28")
+	})
+
+	t.Run("SetFailsWhenInputIsInvalid", func(t *testing.T) {
+		var dest time.Time
+
+		flag := loc.NewTimeFlag(&dest)
+		err := flag.Set("not-a-time")
+
+		require.Error(t, err)
+		require.True(t, dest.IsZero())
+	})
+
+	t.Run("SetStoresParsedTimeWhenInputIsValid", func(t *testing.T) {
+		var dest time.Time
+
+		flag := loc.NewTimeFlag(&dest)
+		err := flag.Set("2025-08-28T12:34:56Z")
+
+		require.NoError(t, err)
+		require.Equal(t, time.Date(2025, time.August, 28, 12, 34, 56, 0, time.UTC), dest)
+	})
+
+	t.Run("SetStoresRelativeDurationWhenInputIsValid", func(t *testing.T) {
+		var dest time.Time
+
+		flag := loc.NewTimeFlag(&dest)
+		before := time.Now()
+		err := flag.Set("2h")
+		after := time.Now()
+		require.NoError(t, err)
+
+		lower := before.Add(-2 * time.Hour).Add(-250 * time.Millisecond)
+		upper := after.Add(-2 * time.Hour).Add(250 * time.Millisecond)
+		require.False(t, dest.Before(lower), "got %v, want >= %v", dest, lower)
+		require.False(t, dest.After(upper), "got %v, want <= %v", dest, upper)
+	})
+
+	t.Run("SetDoesNotOverwriteExistingValueWhenInputIsInvalid", func(t *testing.T) {
+		dest := time.Date(2025, time.August, 28, 12, 34, 56, 0, time.UTC)
+		flag := loc.NewTimeFlag(&dest)
+
+		err := flag.Set("not-a-time")
+		require.Error(t, err)
+		require.Equal(t, time.Date(2025, time.August, 28, 12, 34, 56, 0, time.UTC), dest)
+	})
+
+	t.Run("SetOverwritesExistingValueWhenInputIsValid", func(t *testing.T) {
+		dest := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+		flag := loc.NewTimeFlag(&dest)
+
+		err := flag.Set("2025-08-28T12:34:56Z")
+		require.NoError(t, err)
+		require.Equal(t, time.Date(2025, time.August, 28, 12, 34, 56, 0, time.UTC), dest)
+	})
+
+	t.Run("StringReflectsUpdatedDestinationAfterSet", func(t *testing.T) {
+		var dest time.Time
+		flag := loc.NewTimeFlag(&dest)
+
+		err := flag.Set("2025-08-28T12:34:56Z")
+		require.NoError(t, err)
+
+		got := flag.String()
+		require.NotEmpty(t, got)
+		require.Contains(t, got, "2025-08-28")
+	})
+
+	t.Run("SetPanicsWhenDestinationIsNil", func(t *testing.T) {
+		flag := loc.NewTimeFlag(nil)
+		require.Panics(t, func() {
+			flag.Set("2025-08-28T12:34:56Z")
+		})
+	})
 }

--- a/locate/time_test.go
+++ b/locate/time_test.go
@@ -6,108 +6,132 @@ import (
 	"time"
 
 	loc "github.com/PlakarKorp/kloset/locate"
+	"github.com/stretchr/testify/require"
 )
+
+func TestParseTimeFlag(t *testing.T) {
+	t.Run("EmptyTimeFlagReturnsZeroTime", func(t *testing.T) {
+		got, err := loc.ParseTimeFlag("")
+		require.NoError(t, err)
+		require.True(t, got.IsZero())
+	})
+
+	t.Run("AbsoluteFormats", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input string
+			want  time.Time
+		}{
+			{
+				name:  "RFC3339",
+				input: "2025-08-28T12:34:56Z",
+				want:  time.Date(2025, time.August, 28, 12, 34, 56, 0, time.UTC),
+			},
+			{
+				name:  "date and minute",
+				input: "2025-08-28 09:10",
+				want:  time.Date(2025, time.August, 28, 9, 10, 0, 0, time.UTC),
+			},
+			{
+				name:  "date and second",
+				input: "2025-08-28 09:10:11",
+				want:  time.Date(2025, time.August, 28, 9, 10, 11, 0, time.UTC),
+			},
+			{
+				name:  "dash date only",
+				input: "2025-08-28",
+				want:  time.Date(2025, time.August, 28, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				name:  "slash date only",
+				input: "2025/08/28",
+				want:  time.Date(2025, time.August, 28, 0, 0, 0, 0, time.UTC),
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := loc.ParseTimeFlag(tt.input)
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			})
+		}
+	})
+
+	t.Run("RFC3339TimeFlagWithTimezoneOffset", func(t *testing.T) {
+		got, err := loc.ParseTimeFlag("2025-08-28T12:34:56+02:00")
+		require.NoError(t, err)
+
+		want := time.Date(2025, time.August, 28, 10, 34, 56, 0, time.UTC)
+		require.True(t, got.Equal(want), "got %v, want same instant as %v", got, want)
+	})
+
+	t.Run("RelativeDuration", func(t *testing.T) {
+		before := time.Now()
+		got, err := loc.ParseTimeFlag("2h")
+		after := time.Now()
+		require.NoError(t, err)
+
+		lower := before.Add(-2 * time.Hour).Add(-250 * time.Millisecond)
+		upper := after.Add(-2 * time.Hour).Add(250 * time.Millisecond)
+
+		require.False(t, got.Before(lower), "got %v, want >= %v", got, lower)
+		require.False(t, got.After(upper), "got %v, want <= %v", got, upper)
+	})
+
+	t.Run("ZeroRelativeDuration", func(t *testing.T) {
+		before := time.Now()
+		got, err := loc.ParseTimeFlag("0s")
+		after := time.Now()
+		require.NoError(t, err)
+
+		require.False(t, got.Before(before.Add(-250*time.Millisecond)))
+		require.False(t, got.After(after.Add(250*time.Millisecond)))
+	})
+
+	t.Run("Check_m_Interpretation", func(t *testing.T) {
+		before := time.Now()
+		got, err := loc.ParseTimeFlag("1m")
+		require.NoError(t, err)
+
+		minAgo := before.Add(-31 * 24 * time.Hour)
+		maxAgo := before.Add(-28 * 24 * time.Hour)
+		require.False(t, got.Before(minAgo), "got %v, want about one month ago", got)
+		require.False(t, got.After(maxAgo), "got %v, want about one month ago", got)
+	})
+
+	t.Run("FailsIfTimeFlagHasWhitespaces", func(t *testing.T) {
+		got, err := loc.ParseTimeFlag(" 2025-08-28 ")
+		require.Error(t, err)
+		require.True(t, got.IsZero())
+	})
+
+	t.Run("FailsIfInvalidTimeFlag", func(t *testing.T) {
+		tests := []string{
+			"not-a-time",
+			"2025-13-01",
+			"2025-02-30",
+			"99wibbly",
+			"2025/99/01 25:61",
+		}
+
+		for _, input := range tests {
+			input := input
+			t.Run(input, func(t *testing.T) {
+				got, err := loc.ParseTimeFlag(input)
+				require.Error(t, err)
+				require.True(t, got.IsZero())
+				require.Contains(t, err.Error(), "invalid time format")
+			})
+		}
+	})
+}
 
 // helper: compare times exactly (in UTC) for absolute parses
 func mustUTC(t *testing.T, y int, m time.Month, d, hh, mm, ss int) time.Time {
 	t.Helper()
 	return time.Date(y, m, d, hh, mm, ss, 0, time.UTC)
-}
-
-func TestParseTimeFlag_Empty(t *testing.T) {
-	got, err := loc.ParseTimeFlag("")
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-	if !got.IsZero() {
-		t.Fatalf("expected zero time, got %v", got)
-	}
-}
-
-func TestParseTimeFlag_AbsoluteFormats(t *testing.T) {
-	tcs := []struct {
-		in   string
-		want time.Time
-	}{
-		// RFC3339
-		{"2025-08-28T12:34:56Z", mustUTC(t, 2025, time.August, 28, 12, 34, 56)},
-
-		// "2006-01-02 15:04"
-		{"2025-08-28 09:10", mustUTC(t, 2025, time.August, 28, 9, 10, 0)},
-
-		// "2006-01-02 15:04:05"
-		{"2025-08-28 09:10:11", mustUTC(t, 2025, time.August, 28, 9, 10, 11)},
-
-		// "2006-01-02"
-		{"2025-08-28", mustUTC(t, 2025, time.August, 28, 0, 0, 0)},
-
-		// "2006/01/02"
-		{"2025/08/28", mustUTC(t, 2025, time.August, 28, 0, 0, 0)},
-	}
-
-	for _, tc := range tcs {
-		got, err := loc.ParseTimeFlag(tc.in)
-		if err != nil {
-			t.Fatalf("ParseTimeFlag(%q) error: %v", tc.in, err)
-		}
-		if !got.Equal(tc.want) {
-			t.Fatalf("ParseTimeFlag(%q): got %v want %v", tc.in, got, tc.want)
-		}
-		if got.Location() != time.UTC {
-			t.Fatalf("ParseTimeFlag(%q): want UTC location, got %v", tc.in, got.Location())
-		}
-	}
-}
-func TestParseTimeFlag_DurationRelativeNow(t *testing.T) {
-	// Because ParseTimeFlag uses time.Now().Add(-d),
-	// we measure before/after to assert the result falls in a small window.
-	type durCase struct {
-		in      string
-		approxD time.Duration
-	}
-	tcs := []durCase{
-		{"2h", 2 * time.Hour},
-		{"1h30min", 90 * time.Minute}, // IMPORTANT: use "min", not "m"
-		{"45min", 45 * time.Minute},   // IMPORTANT: use "min", not "m"
-		{"10s", 10 * time.Second},
-	}
-
-	const slack = 250 * time.Millisecond // tolerate small runtime jitter
-
-	for _, tc := range tcs {
-		before := time.Now()
-		got, err := loc.ParseTimeFlag(tc.in)
-		after := time.Now()
-		if err != nil {
-			t.Fatalf("ParseTimeFlag(%q) error: %v", tc.in, err)
-		}
-		// Expected window is (before - d) .. (after - d)
-		lower := before.Add(-tc.approxD).Add(-slack)
-		upper := after.Add(-tc.approxD).Add(slack)
-
-		if got.Before(lower) || got.After(upper) {
-			t.Fatalf("ParseTimeFlag(%q): got %v, want in [%v, %v]", tc.in, got, lower, upper)
-		}
-	}
-}
-
-func TestParseTimeFlag_Invalid(t *testing.T) {
-	bad := []string{
-		"not-a-time",
-		"2025-13-01",       // invalid month
-		"2025-02-30",       // invalid day
-		"99wibbly",         // bogus duration
-		"2025/99/01 25:61", // broken format & values
-	}
-	for _, in := range bad {
-		_, err := loc.ParseTimeFlag(in)
-		if err == nil {
-			t.Fatalf("expected error for %q, got nil", in)
-		}
-		if !strings.Contains(err.Error(), "invalid time format") {
-			t.Fatalf("unexpected error for %q: %v", in, err)
-		}
-	}
 }
 
 func TestTimeFlag_SetAndString(t *testing.T) {
@@ -149,19 +173,5 @@ func TestTimeFlag_Set_Duration(t *testing.T) {
 	upper := after.Add(-30 * time.Minute).Add(250 * time.Millisecond)
 	if dest.Before(lower) || dest.After(upper) {
 		t.Fatalf("Set(30min): got %v, want in [%v, %v]", dest, lower, upper)
-	}
-}
-
-func TestParseTimeFlag_MMeansMonths(t *testing.T) {
-	before := time.Now()
-	got, err := loc.ParseTimeFlag("1m") // in this lib, "m" == month
-	if err != nil {
-		t.Fatalf("ParseTimeFlag(1m) error: %v", err)
-	}
-	// Expect roughly 1 month ago (we'll use ~28..31 day window).
-	minAgo := before.Add(-31 * 24 * time.Hour)
-	maxAgo := before.Add(-28 * 24 * time.Hour)
-	if got.Before(minAgo) || got.After(maxAgo) {
-		t.Fatalf(`"1m" should be ~1 month ago, got %v (expected between %v and %v)`, got, minAgo, maxAgo)
 	}
 }

--- a/locate/time_test.go
+++ b/locate/time_test.go
@@ -1,9 +1,11 @@
-package locate
+package locate_test
 
 import (
 	"strings"
 	"testing"
 	"time"
+
+	loc "github.com/PlakarKorp/kloset/locate"
 )
 
 // helper: compare times exactly (in UTC) for absolute parses
@@ -13,7 +15,7 @@ func mustUTC(t *testing.T, y int, m time.Month, d, hh, mm, ss int) time.Time {
 }
 
 func TestParseTimeFlag_Empty(t *testing.T) {
-	got, err := ParseTimeFlag("")
+	got, err := loc.ParseTimeFlag("")
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -44,7 +46,7 @@ func TestParseTimeFlag_AbsoluteFormats(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		got, err := ParseTimeFlag(tc.in)
+		got, err := loc.ParseTimeFlag(tc.in)
 		if err != nil {
 			t.Fatalf("ParseTimeFlag(%q) error: %v", tc.in, err)
 		}
@@ -74,7 +76,7 @@ func TestParseTimeFlag_DurationRelativeNow(t *testing.T) {
 
 	for _, tc := range tcs {
 		before := time.Now()
-		got, err := ParseTimeFlag(tc.in)
+		got, err := loc.ParseTimeFlag(tc.in)
 		after := time.Now()
 		if err != nil {
 			t.Fatalf("ParseTimeFlag(%q) error: %v", tc.in, err)
@@ -98,7 +100,7 @@ func TestParseTimeFlag_Invalid(t *testing.T) {
 		"2025/99/01 25:61", // broken format & values
 	}
 	for _, in := range bad {
-		_, err := ParseTimeFlag(in)
+		_, err := loc.ParseTimeFlag(in)
 		if err == nil {
 			t.Fatalf("expected error for %q, got nil", in)
 		}
@@ -110,7 +112,7 @@ func TestParseTimeFlag_Invalid(t *testing.T) {
 
 func TestTimeFlag_SetAndString(t *testing.T) {
 	var dest time.Time
-	tf := NewTimeFlag(&dest)
+	tf := loc.NewTimeFlag(&dest)
 
 	// Zero value should stringify to empty
 	if s := tf.String(); s != "" {
@@ -135,7 +137,7 @@ func TestTimeFlag_SetAndString(t *testing.T) {
 
 func TestTimeFlag_Set_Duration(t *testing.T) {
 	var dest time.Time
-	tf := NewTimeFlag(&dest)
+	tf := loc.NewTimeFlag(&dest)
 
 	before := time.Now()
 	if err := tf.Set("30min"); err != nil { // IMPORTANT: use "min", not "m"
@@ -152,7 +154,7 @@ func TestTimeFlag_Set_Duration(t *testing.T) {
 
 func TestParseTimeFlag_MMeansMonths(t *testing.T) {
 	before := time.Now()
-	got, err := ParseTimeFlag("1m") // in this lib, "m" == month
+	got, err := loc.ParseTimeFlag("1m") // in this lib, "m" == month
 	if err != nil {
 		t.Fatalf("ParseTimeFlag(1m) error: %v", err)
 	}


### PR DESCRIPTION
This PR rewrites the `locate` time parsing and time-flag tests as black-box tests exercised through the public package API. It also adds targeted coverage for `ParseTimeFlag` edge cases and documents the current `TimeFlag` nil-destination panic behavior.

## Changes

- update `ParseTimeFlag` to reject inputs with surrounding whitespace

- switch `locate/time_test.go` from `package locate` to `package locate_test`
- rewrite `ParseTimeFlag` tests into a single structured black-box suite with subtests
- add `ParseTimeFlag` coverage for:
  - empty input
  - supported absolute formats
  - RFC3339 timestamps with timezone offsets
  - relative durations
  - invalid inputs
  - month-based duration parsing (`1m`)
  - surrounding whitespace rejection
- group `NewTimeFlag`, `TimeFlag.String`, and `TimeFlag.Set` into a single test block because their public behavior is tightly coupled
- add `TimeFlag` coverage for:
  - empty string when destination is nil
  - empty string when destination is zero
  - non-empty string when destination is set
  - valid absolute input
  - valid relative duration input
  - invalid input
  - preserving an existing value on invalid input
  - overwriting an existing value on valid input
  - reflecting updated state through `String`
  - panic behavior when `Set` is called with a nil destination

## Results

### Before

```
github.com/PlakarKorp/kloset/locate/time.go:31:		NewTimeFlag			100.0%
github.com/PlakarKorp/kloset/locate/time.go:35:		String				100.0%
github.com/PlakarKorp/kloset/locate/time.go:42:		Set				80.0%
github.com/PlakarKorp/kloset/locate/time.go:51:		ParseTimeFlag			100.0%
```

### After

```
github.com/PlakarKorp/kloset/locate/time.go:32:		NewTimeFlag			100.0%
github.com/PlakarKorp/kloset/locate/time.go:36:		String				100.0%
github.com/PlakarKorp/kloset/locate/time.go:43:		Set				100.0%
github.com/PlakarKorp/kloset/locate/time.go:52:		ParseTimeFlag			100.0%
```