### PR TITLE
Revert "connectors/storage: fix unsafe parsing in NewConfigurationFro…

### DIFF
--- a/connectors/storage/storage.go
+++ b/connectors/storage/storage.go
@@ -17,8 +17,8 @@
 package storage
 
 import (
-	"bytes"
 	"context"
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"io"
@@ -91,27 +91,19 @@ func NewConfigurationFromBytes(version versioning.Version, data []byte) (*Config
 }
 
 func NewConfigurationFromWrappedBytes(data []byte) (*Configuration, error) {
-	hasher := hashing.GetHasher(DEFAULT_HASHING_ALGORITHM)
-	if hasher == nil {
-		return nil, fmt.Errorf("unsupported hashing algorithm: %s", DEFAULT_HASHING_ALGORITHM)
-	}
+	var configuration Configuration
 
-	version, reader, err := Deserialize(
-		hasher,
-		resources.RT_CONFIG,
-		io.NopCloser(bytes.NewReader(data)),
-	)
+	version := versioning.Version(binary.LittleEndian.Uint32(data[12:16]))
+
+	data = data[:len(data)-int(STORAGE_FOOTER_SIZE)]
+	data = data[STORAGE_HEADER_SIZE:]
+
+	err := msgpack.Unmarshal(data, &configuration)
 	if err != nil {
 		return nil, err
 	}
-	defer reader.Close()
-
-	payload, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewConfigurationFromBytes(version, payload)
+	configuration.Version = version
+	return &configuration, nil
 }
 
 func (c *Configuration) ToBytes() ([]byte, error) {


### PR DESCRIPTION
…mWrappedBytes"

This reverts commit 23c09bcdd18fc17c1b8d216fe687bd0e32c21677.

This is the way to go, but apparently this commit is borken