### PR TITLE
Decoder: Plug a leak.

### DIFF
--- a/compression/compression.go
+++ b/compression/compression.go
@@ -94,13 +94,29 @@ func DeflateLZ4Stream(r io.Reader) (io.Reader, error) {
 	return pr, nil
 }
 
+type readCloserInternal struct {
+	input  io.Closer
+	reader io.ReadCloser
+}
+
+func (c *readCloserInternal) Read(p []byte) (int, error) { return c.reader.Read(p) }
+func (c *readCloserInternal) Close() error               { c.reader.Close(); return c.input.Close() }
+
 func InflateStream(name string, r io.ReadCloser) (io.ReadCloser, error) {
 	m := map[string]func(io.ReadCloser) (io.ReadCloser, error){
 		"GZIP": InflateGzipStream,
 		"LZ4":  InflateLZ4Stream,
 	}
 	if fn, exists := m[name]; exists {
-		return fn(r)
+		or, err := fn(r)
+		if err != nil {
+			return nil, err
+		}
+
+		return &readCloserInternal{
+			input:  r,
+			reader: or,
+		}, nil
 	}
 	return nil, fmt.Errorf("unsupported compression method %q", name)
 }
@@ -131,12 +147,9 @@ var lz4ReaderPool = sync.Pool{
 
 func InflateLZ4Stream(r io.ReadCloser) (io.ReadCloser, error) {
 	pr, pw := io.Pipe()
+	lz := lz4.NewReader(r)
 	go func() {
-		lz := lz4ReaderPool.Get().(*lz4.Reader)
-		lz.Reset(r)
-
 		defer pw.Close()
-		defer lz4ReaderPool.Put(lz)
 
 		_, err := io.Copy(pw, lz)
 		if err != nil {

--- a/encryption/symmetric.go
+++ b/encryption/symmetric.go
@@ -330,6 +330,14 @@ func EncryptStream(config *Configuration, key []byte, r io.Reader) (io.Reader, e
 	return pr, nil
 }
 
+type readCloserInternal struct {
+	input  io.Closer
+	reader io.ReadCloser
+}
+
+func (c *readCloserInternal) Read(p []byte) (int, error) { return c.reader.Read(p) }
+func (c *readCloserInternal) Close() error               { c.reader.Close(); return c.input.Close() }
+
 // DecryptStream decrypts a stream using AES-GCM with a random session-specific subkey
 func DecryptStream(config *Configuration, key []byte, r io.ReadCloser) (io.ReadCloser, error) {
 	if config.DataAlgorithm != "AES256-GCM-SIV" {
@@ -380,5 +388,5 @@ func DecryptStream(config *Configuration, key []byte, r io.ReadCloser) (io.ReadC
 		}
 	}()
 
-	return pr, nil
+	return &readCloserInternal{input: r, reader: pr}, nil
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -581,14 +581,6 @@ func (r *Repository) Close() error {
 	return nil
 }
 
-type closerWrapper struct {
-	reader io.Reader
-	closer io.Closer
-}
-
-func (c *closerWrapper) Read(p []byte) (int, error) { return c.reader.Read(p) }
-func (c *closerWrapper) Close() error               { return c.closer.Close() }
-
 func (r *Repository) decode(input io.ReadCloser) (io.ReadCloser, error) {
 	t0 := time.Now()
 	defer func() {
@@ -612,10 +604,7 @@ func (r *Repository) decode(input io.ReadCloser) (io.ReadCloser, error) {
 		stream = tmp
 	}
 
-	return &closerWrapper{
-		reader: stream,
-		closer: input,
-	}, nil
+	return stream, nil
 }
 
 func (r *Repository) encode(input io.Reader) (io.Reader, error) {


### PR DESCRIPTION
* When we end up wrapping the input stream (for decompression/decryption), we wrapped the stream to close the original input on a Close(), but that left the inner stream (the piperead part). While on most cases we hit EOF and this is fine (the pipe closes on EOF), when doing the TopoSort we just read the first few bytes and Close() early leading to a leak.

* Fix this by just wrapping all stream in a Closer that closes the input and the reader on a Close().