### PR TITLE
packer_seq: Reintroduce Last blob padding on packfiles.

### DIFF
--- a/repository/packer/packer_seq.go
+++ b/repository/packer/packer_seq.go
@@ -145,6 +145,10 @@ func (mgr *seqPackerManager) Run() error {
 					}
 
 					if pfile.Size() > mgr.storageConf.Packfile.MaxSize {
+						if err := mgr.AddPadding(pfile, int(mgr.storageConf.Chunking.MinSize)); err != nil {
+							return err
+						}
+
 						packerResultChan <- pfile
 						pfile = nil
 					}


### PR DESCRIPTION
* In commit 3094bd4394ae to make the code more readable I moved the end padding addition to the packfile construction loop (as opposed to the flushing), sadly I put it only in one case (the teardown phase) and forgot the packfile full case. Add back the padding.

Fixes: 3094bd4394ae ("packer: Bubble up the error from underlying i/o error.")