### PR TITLE
Compact tail packfiles

### DIFF
--- a/packfile/packfile_disk.go
+++ b/packfile/packfile_disk.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"hash"
 	"io"
+	"iter"
 	"os"
 	"time"
 
@@ -95,7 +96,6 @@ func (w *PackfileOnDisk) Serialize(encoder EncodingFn) (io.Reader, objects.MAC, 
 	_ = binary.Write(&rawFooter, binary.LittleEndian, w.curOff)
 	_ = binary.Write(&rawFooter, binary.LittleEndian, w.indexMAC)
 	_ = binary.Write(&rawFooter, binary.LittleEndian, w.footerFlags)
-
 	encFooter, err := encoder(bytes.NewReader(rawFooter.Bytes()))
 	if err != nil {
 		return nil, objects.NilMac, err
@@ -123,4 +123,27 @@ func (w *PackfileOnDisk) Serialize(encoder EncodingFn) (io.Reader, objects.MAC, 
 	}
 
 	return w.f, objects.MAC(w.totalHash.Sum(nil)), nil
+}
+
+func (p *PackfileOnDisk) Iterate() iter.Seq2[*BlobData, error] {
+	return func(yield func(*BlobData, error) bool) {
+		if err := p.bufferedWriter.Flush(); err != nil {
+			if !yield(nil, err) {
+				return
+			}
+		}
+
+		for _, b := range p.records {
+			out := make([]byte, b.Length)
+			if _, err := p.f.ReadAt(out, int64(b.Offset)); err != nil {
+				if !yield(nil, err) {
+					return
+				}
+			}
+
+			if !yield(&BlobData{b, out}, nil) {
+				return
+			}
+		}
+	}
 }

--- a/packfile/packfile_int.go
+++ b/packfile/packfile_int.go
@@ -3,6 +3,7 @@ package packfile
 import (
 	"hash"
 	"io"
+	"iter"
 
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/resources"
@@ -18,6 +19,11 @@ type Blob struct {
 	Offset  uint64
 	Length  uint32
 	Flags   uint32
+}
+
+type BlobData struct {
+	Blob
+	Data []byte
 }
 
 const BLOB_RECORD_SIZE = 56
@@ -38,6 +44,7 @@ type Packfile interface {
 	Size() uint64
 	Entries() []Blob
 	Serialize(EncodingFn) (io.Reader, objects.MAC, error)
+	Iterate() iter.Seq2[*BlobData, error]
 	Cleanup() error
 }
 

--- a/packfile/packfile_mem.go
+++ b/packfile/packfile_mem.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"iter"
 	"time"
 
 	"github.com/PlakarKorp/kloset/objects"
@@ -338,6 +339,19 @@ func (p *PackfileInMemory) AddBlob(resourceType resources.Type, version versioni
 	p.Footer.IndexOffset = uint64(len(p.Blobs))
 
 	return nil
+}
+
+func (p *PackfileInMemory) Iterate() iter.Seq2[*BlobData, error] {
+	return func(yield func(*BlobData, error) bool) {
+		for _, b := range p.Index {
+			out := make([]byte, b.Length)
+			copy(out, p.Blobs[b.Offset:b.Offset+uint64(b.Length)])
+
+			if !yield(&BlobData{b, out}, nil) {
+				return
+			}
+		}
+	}
 }
 
 func (p *PackfileInMemory) Entries() []Blob {

--- a/repository/packer/packer_seq.go
+++ b/repository/packer/packer_seq.go
@@ -69,6 +69,7 @@ func NewSeqPackerManager(ctx *kcontext.KContext, storageConfiguration *storage.C
 
 func (mgr *seqPackerManager) Run() error {
 	packerResultChan := make(chan packfile.Packfile, mgr.nChan)
+	partialPackfilesChan := make(chan packfile.Packfile, mgr.nChan)
 
 	flusherGroup, _ := errgroup.WithContext(context.TODO())
 	for range mgr.nChan {
@@ -119,11 +120,7 @@ func (mgr *seqPackerManager) Run() error {
 				case pm, ok := <-mgr.packerChan[i]:
 					if !ok {
 						if pfile != nil && pfile.Size() > 0 {
-							if err := mgr.AddPadding(pfile, int(mgr.storageConf.Chunking.MinSize)); err != nil {
-								return err
-							}
-
-							packerResultChan <- pfile
+							partialPackfilesChan <- pfile
 						}
 						return nil
 					}
@@ -165,6 +162,17 @@ func (mgr *seqPackerManager) Run() error {
 		inError = true
 	}
 
+	// No one is sending blobs we can attempt to merge the tail packfiles
+	close(partialPackfilesChan)
+
+	if !inError {
+		if err := mgr.mergeTailPackfiles(partialPackfilesChan, packerResultChan); err != nil {
+			mgr.appCtx.GetLogger().Error("Failed to merge partial packfiles: %s", err)
+			mgr.appCtx.Cancel(err)
+			inError = true
+		}
+	}
+
 	// Close the result channel and wait for the flusher to finish.
 	close(packerResultChan)
 	if err := flusherGroup.Wait(); err != nil {
@@ -191,6 +199,10 @@ func (mgr *seqPackerManager) Run() error {
 		}
 
 		drainingGroup.Wait()
+
+		for p := range partialPackfilesChan {
+			p.Cleanup()
+		}
 	}
 
 	// Signal completion.
@@ -275,4 +287,84 @@ func (mgr *seqPackerManager) AddPadding(packfile packfile.Packfile, maxSize int)
 	}
 
 	return packfile.AddBlob(resources.RT_RANDOM, versioning.GetCurrentVersion(resources.RT_RANDOM), mac, buffer, 0)
+}
+
+func (mgr *seqPackerManager) mergeTailPackfiles(partialPackfilesChan <-chan packfile.Packfile, packerResultChan chan<- packfile.Packfile) error {
+	var cur packfile.Packfile
+
+	cleanup := func(p packfile.Packfile) {
+		if cur != nil {
+			cur.Cleanup()
+		}
+
+		p.Cleanup()
+
+		for x := range partialPackfilesChan {
+			x.Cleanup()
+		}
+	}
+
+	for p := range partialPackfilesChan {
+		// First ever, let's use it to avoid allocating a new one.
+		if cur == nil {
+			cur = p
+			continue
+		}
+
+		for b, err := range p.Iterate() {
+			if err != nil {
+				cleanup(p)
+				return err
+			}
+
+			if b.Type == resources.RT_RANDOM {
+				continue
+			}
+
+			if cur == nil {
+				var err error
+				cur, err = mgr.packfileFactory(mgr.hashFactory)
+				if err != nil {
+					cleanup(p)
+					return err
+				}
+
+				if err := mgr.AddPadding(cur, int(mgr.storageConf.Chunking.MinSize)); err != nil {
+					cleanup(p)
+					return err
+				}
+			}
+
+			if err := cur.AddBlob(b.Type, b.Version, b.MAC, b.Data, b.Flags); err != nil {
+				cleanup(p)
+				return err
+			}
+
+			if cur.Size() > mgr.storageConf.Packfile.MaxSize {
+				if err := mgr.AddPadding(cur, int(mgr.storageConf.Chunking.MinSize)); err != nil {
+					cleanup(p)
+					return err
+				}
+
+				packerResultChan <- cur
+
+				// Next iteration will allocate a new one.
+				cur = nil
+			}
+		}
+
+		// p was fully ingested, clean it up
+		p.Cleanup()
+	}
+
+	if cur != nil {
+		if err := mgr.AddPadding(cur, int(mgr.storageConf.Chunking.MinSize)); err != nil {
+			cur.Cleanup()
+			return err
+		}
+
+		packerResultChan <- cur
+	}
+
+	return nil
 }


### PR DESCRIPTION
This adds compaction of tail packfiles in order to minimize the number of non-full packfiles we create

Still a draft as I want to measure performance with high concurrency number (thing like maxConcurrency set to 1000) and the on disk packfiles, just to be sure those ReadAt won't be too much. It's a one time thing so it shouldn't be too bad.
