### PR TITLE
do not allow evading the restore root path

### DIFF
--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -1,6 +1,7 @@
 package snapshot
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -103,6 +104,11 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 			}
 
 			emitter.Path(entrypath)
+
+			if !path.IsAbs(entrypath) {
+				emitter.PathError(entrypath, fmt.Errorf("snapshot entry has non-absolute path %q", entrypath))
+				return fmt.Errorf("snapshot entry has non-absolute path %q", entrypath)
+			}
 
 			if e.FileInfo.IsDir() {
 				emitter.Directory(entrypath)


### PR DESCRIPTION
Our VFS only deals with an absolute tree, entries should therefore never have a parent path that's not absolute.

This fixes a potential security issue where a user may have his files arbitrarily overwritten should they import and restore a snapshot that was crafted by a malicious author.

This will be reviewed tomorrow and merged into a new RC

This was reported by @poeck, thanks