### PR TITLE
tests: add comprehensive test suite for uncovered packages

### DIFF
--- a/caching/pebble/pebble_full_test.go
+++ b/caching/pebble/pebble_full_test.go
@@ -1,0 +1,182 @@
+package pebble
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryCache(t *testing.T) {
+	c, err := New("", false)
+	require.NoError(t, err)
+	defer c.Close()
+
+	key := []byte("mykey")
+	val := []byte("myvalue")
+
+	require.NoError(t, c.Put(key, val))
+
+	got, err := c.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, val, got)
+
+	exists, err := c.Has(key)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestGetMissingKey(t *testing.T) {
+	c, err := New("", false)
+	require.NoError(t, err)
+	defer c.Close()
+
+	got, err := c.Get([]byte("missing"))
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestHasMissingKey(t *testing.T) {
+	c, err := New("", false)
+	require.NoError(t, err)
+	defer c.Close()
+
+	exists, err := c.Has([]byte("missing"))
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestScanForward(t *testing.T) {
+	c, err := New("", false)
+	require.NoError(t, err)
+	defer c.Close()
+
+	prefix := []byte("prefix:")
+	keys := [][]byte{
+		append(append([]byte{}, prefix...), 'a'),
+		append(append([]byte{}, prefix...), 'b'),
+		append(append([]byte{}, prefix...), 'c'),
+	}
+	for i, k := range keys {
+		require.NoError(t, c.Put(k, []byte{byte(i)}))
+	}
+
+	var collected [][]byte
+	for k, _ := range c.Scan(prefix, false) {
+		collected = append(collected, append([]byte{}, k...))
+	}
+	require.Len(t, collected, 3)
+	// Should be in ascending order
+	require.Equal(t, keys[0], collected[0])
+	require.Equal(t, keys[1], collected[1])
+	require.Equal(t, keys[2], collected[2])
+}
+
+func TestScanReverse(t *testing.T) {
+	c, err := New("", false)
+	require.NoError(t, err)
+	defer c.Close()
+
+	prefix := []byte("rev:")
+	keys := [][]byte{
+		append(append([]byte{}, prefix...), 'a'),
+		append(append([]byte{}, prefix...), 'b'),
+		append(append([]byte{}, prefix...), 'c'),
+	}
+	for i, k := range keys {
+		require.NoError(t, c.Put(k, []byte{byte(i)}))
+	}
+
+	var collected [][]byte
+	for k, _ := range c.Scan(prefix, true) {
+		collected = append(collected, append([]byte{}, k...))
+	}
+	require.Len(t, collected, 3)
+	// Should be in descending order
+	require.Equal(t, keys[2], collected[0])
+	require.Equal(t, keys[0], collected[2])
+}
+
+func TestScanEmpty(t *testing.T) {
+	c, err := New("", false)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var count int
+	for range c.Scan([]byte("no-such-prefix:"), false) {
+		count++
+	}
+	require.Equal(t, 0, count)
+}
+
+func TestBatchPutAndCommit(t *testing.T) {
+	c, err := New("", false)
+	require.NoError(t, err)
+	defer c.Close()
+
+	b := c.NewBatch()
+	require.NotNil(t, b)
+
+	require.NoError(t, b.Put([]byte("bk1"), []byte("bv1")))
+	require.NoError(t, b.Put([]byte("bk2"), []byte("bv2")))
+	require.Equal(t, uint32(2), b.Count())
+
+	require.NoError(t, b.Commit())
+
+	got, err := c.Get([]byte("bk1"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("bv1"), got)
+
+	got, err = c.Get([]byte("bk2"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("bv2"), got)
+}
+
+func TestConstructor(t *testing.T) {
+	dir := t.TempDir()
+	ctor := Constructor(dir)
+	require.NotNil(t, ctor)
+
+	c, err := ctor("v1", "testcache", "repo-123", 0)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	defer c.Close()
+}
+
+func TestInMemoryConstructor(t *testing.T) {
+	ctor := InMemoryConstructor()
+	require.NotNil(t, ctor)
+
+	c, err := ctor("v1", "testcache", "repo-123", 0)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	defer c.Close()
+}
+
+func TestDeleteOnClose(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(dir, true)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+}
+
+func TestMakeKeyUpperBound(t *testing.T) {
+	cases := []struct {
+		input    []byte
+		expected []byte
+	}{
+		{[]byte{0x01}, []byte{0x02}},
+		{[]byte{0x01, 0x02}, []byte{0x01, 0x03}},
+		{[]byte{0xFF}, nil}, // overflow → nil
+	}
+
+	for _, c := range cases {
+		got := makeKeyUpperBound(c.input)
+		require.Equal(t, c.expected, got)
+	}
+}
+
+func TestMakeKeyUpperBoundAllFF(t *testing.T) {
+	key := []byte{0xFF, 0xFF, 0xFF}
+	got := makeKeyUpperBound(key)
+	require.Nil(t, got)
+}

--- a/caching/sqlite/sqlite_test.go
+++ b/caching/sqlite/sqlite_test.go
@@ -1,0 +1,142 @@
+package sqlite_test
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/caching/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInMemory(t *testing.T) {
+	db, err := sqlite.New("", ":memory:", nil)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer db.Close()
+}
+
+func TestNewOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sqlite.New(dir, "test.db", nil)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer db.Close()
+}
+
+func TestNewWithOptions(t *testing.T) {
+	dir := t.TempDir()
+	opts := &sqlite.Options{
+		DeleteOnClose: true,
+		Compressed:    false,
+		ReadOnly:      false,
+	}
+	db, err := sqlite.New(dir, "opts.db", opts)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	err = db.Close()
+	require.NoError(t, err)
+}
+
+func TestNewReadOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create the database first
+	db, err := sqlite.New(dir, "readonly.db", nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Open as read-only
+	opts := &sqlite.Options{ReadOnly: true}
+	db2, err := sqlite.New(dir, "readonly.db", opts)
+	require.NoError(t, err)
+	require.NotNil(t, db2)
+	defer db2.Close()
+}
+
+func TestNewReadOnlyCreatesFileIfMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	// Should create the file and open read-only
+	opts := &sqlite.Options{ReadOnly: true}
+	db, err := sqlite.New(dir, "new_readonly.db", opts)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer db.Close()
+}
+
+func TestEncodeDecodeNoCompression(t *testing.T) {
+	db, err := sqlite.New("", ":memory:", &sqlite.Options{Compressed: false})
+	require.NoError(t, err)
+	defer db.Close()
+
+	data := []byte("hello, world!")
+	encoded := db.Encode(data)
+	require.Equal(t, data, encoded)
+
+	decoded, err := db.Decode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded)
+}
+
+func TestEncodeDecodeWithCompression(t *testing.T) {
+	db, err := sqlite.New("", ":memory:", &sqlite.Options{Compressed: true})
+	require.NoError(t, err)
+	defer db.Close()
+
+	data := []byte("this is some compressible data that repeats: aaaaaaaaaaaaaaaaaaaaaaaa")
+	encoded := db.Encode(data)
+	// Encoded should differ from original (compressed)
+	require.NotEqual(t, data, encoded)
+
+	decoded, err := db.Decode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded)
+}
+
+func TestEncodeDecodeEmpty(t *testing.T) {
+	db, err := sqlite.New("", ":memory:", &sqlite.Options{Compressed: true})
+	require.NoError(t, err)
+	defer db.Close()
+
+	encoded := db.Encode([]byte{})
+	require.Empty(t, encoded)
+
+	decoded, err := db.Decode([]byte{})
+	require.NoError(t, err)
+	require.Empty(t, decoded)
+}
+
+func TestClose(t *testing.T) {
+	db, err := sqlite.New("", ":memory:", nil)
+	require.NoError(t, err)
+
+	err = db.Close()
+	require.NoError(t, err)
+}
+
+func TestUsableAsDatabase(t *testing.T) {
+	db, err := sqlite.New("", ":memory:", nil)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec(`CREATE TABLE test (id INTEGER PRIMARY KEY, val TEXT)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`INSERT INTO test (val) VALUES (?)`, "hello")
+	require.NoError(t, err)
+
+	var val string
+	err = db.QueryRow(`SELECT val FROM test WHERE id = 1`).Scan(&val)
+	require.NoError(t, err)
+	require.Equal(t, "hello", val)
+}
+
+func TestDeleteOnClose(t *testing.T) {
+	dir := t.TempDir()
+	opts := &sqlite.Options{DeleteOnClose: true}
+
+	db, err := sqlite.New(dir, "deleteme.db", opts)
+	require.NoError(t, err)
+
+	err = db.Close()
+	require.NoError(t, err)
+}

--- a/caching/sqlitedbstore_test.go
+++ b/caching/sqlitedbstore_test.go
@@ -1,0 +1,71 @@
+package caching_test
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/btree"
+	"github.com/PlakarKorp/kloset/caching"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteDBStorePutGetUpdate(t *testing.T) {
+	dir := t.TempDir()
+	store, err := caching.NewSQLiteDBStore[string, int](dir, "test.db")
+	require.NoError(t, err)
+	defer store.Close()
+
+	node := &btree.Node[string, int, int]{
+		Keys:   []string{"alpha", "beta"},
+		Values: []int{1, 2},
+	}
+
+	idx, err := store.Put(node)
+	require.NoError(t, err)
+	require.Greater(t, idx, 0)
+
+	retrieved, err := store.Get(idx)
+	require.NoError(t, err)
+	require.Equal(t, node.Keys, retrieved.Keys)
+	require.Equal(t, node.Values, retrieved.Values)
+
+	// Update the node
+	retrieved.Values = []int{10, 20}
+	require.NoError(t, store.Update(idx, retrieved))
+
+	updated, err := store.Get(idx)
+	require.NoError(t, err)
+	require.Equal(t, []int{10, 20}, updated.Values)
+}
+
+func TestSQLiteDBStoreMultiplePuts(t *testing.T) {
+	dir := t.TempDir()
+	store, err := caching.NewSQLiteDBStore[int, string](dir, "multi.db")
+	require.NoError(t, err)
+	defer store.Close()
+
+	var indices []int
+	for i := 0; i < 5; i++ {
+		node := &btree.Node[int, int, string]{
+			Keys:   []int{i},
+			Values: []string{"value"},
+		}
+		idx, err := store.Put(node)
+		require.NoError(t, err)
+		indices = append(indices, idx)
+	}
+
+	// All indices should be distinct
+	seen := make(map[int]bool)
+	for _, idx := range indices {
+		require.False(t, seen[idx], "duplicate index %d", idx)
+		seen[idx] = true
+	}
+}
+
+func TestSQLiteDBStoreClose(t *testing.T) {
+	dir := t.TempDir()
+	store, err := caching.NewSQLiteDBStore[string, int](dir, "close.db")
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+}
+

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,0 +1,374 @@
+package events_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEventsBUS(t *testing.T) {
+	bus := events.NewEventsBUS(10)
+	require.NotNil(t, bus)
+}
+
+func TestEventsBUSClose(t *testing.T) {
+	bus := events.NewEventsBUS(10)
+	ch := bus.Listen()
+	require.NotNil(t, ch)
+	// Close should close the channel
+	bus.Close()
+	_, ok := <-ch
+	require.False(t, ok, "channel should be closed")
+}
+
+func TestEventsBUSCloseWithoutListen(t *testing.T) {
+	bus := events.NewEventsBUS(10)
+	// Close without Listen should not panic
+	bus.Close()
+}
+
+func TestNewDummyEmitter(t *testing.T) {
+	bus := events.NewEventsBUS(0)
+	emitter := bus.NewDummyEmitter()
+	require.NotNil(t, emitter)
+
+	// Dummy emitter should not send any events
+	ch := bus.Listen()
+	emitter.Info("test", nil)
+	emitter.Warn("test", nil)
+	emitter.Error("test", nil)
+	emitter.Quiet("test", nil)
+
+	select {
+	case <-ch:
+		t.Error("dummy emitter should not send events")
+	default:
+	}
+}
+
+func TestNewRepositoryEmitter(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	repoID := uuid.New()
+	emitter := bus.NewRepositoryEmitter(repoID, "test-workflow")
+	require.NotNil(t, emitter)
+
+	// Should receive the workflow.start event
+	select {
+	case ev := <-ch:
+		require.Equal(t, "workflow.start", ev.Type)
+		require.Equal(t, events.Info, ev.Level)
+		require.Equal(t, repoID, ev.Repository)
+		require.Equal(t, "test-workflow", ev.Workflow)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for workflow.start event")
+	}
+
+	emitter.Close()
+
+	select {
+	case ev := <-ch:
+		require.Equal(t, "workflow.end", ev.Type)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for workflow.end event")
+	}
+}
+
+func TestNewSnapshotEmitter(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	repoID := uuid.New()
+	snap := objects.MAC{1, 2, 3}
+	emitter := bus.NewSnapshotEmitter(repoID, snap, "snapshot-workflow")
+	require.NotNil(t, emitter)
+
+	select {
+	case ev := <-ch:
+		require.Equal(t, "workflow.start", ev.Type)
+		require.Equal(t, repoID, ev.Repository)
+		require.Equal(t, snap, ev.Snapshot)
+		require.Equal(t, "snapshot-workflow", ev.Workflow)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+	emitter.Close()
+	<-ch // consume workflow.end
+}
+
+func TestEmitterLevels(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	repoID := uuid.New()
+	emitter := bus.NewRepositoryEmitter(repoID, "test")
+	<-ch // consume workflow.start
+
+	cases := []struct {
+		fn    func(string, map[string]any)
+		level string
+	}{
+		{emitter.Info, events.Info},
+		{emitter.Warn, events.Warn},
+		{emitter.Error, events.Error},
+		{emitter.Quiet, events.Quiet},
+	}
+
+	for _, c := range cases {
+		c.fn("test.event", map[string]any{"key": "value"})
+		select {
+		case ev := <-ch:
+			require.Equal(t, c.level, ev.Level)
+			require.Equal(t, "test.event", ev.Type)
+		case <-time.After(time.Second):
+			t.Fatalf("timeout for level %s", c.level)
+		}
+	}
+
+	emitter.Close()
+	<-ch // workflow.end
+	bus.Close()
+}
+
+func TestEmitterPathEvents(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	emitter := bus.NewRepositoryEmitter(uuid.New(), "w")
+	<-ch
+
+	emitter.Path("/foo/bar")
+	ev := <-ch
+	require.Equal(t, "path", ev.Type)
+	require.Equal(t, "/foo/bar", ev.Data["path"])
+
+	emitter.Directory("/foo")
+	ev = <-ch
+	require.Equal(t, "directory", ev.Type)
+
+	emitter.File("/foo/file.txt")
+	ev = <-ch
+	require.Equal(t, "file", ev.Type)
+
+	emitter.Xattr("/foo/file.txt")
+	ev = <-ch
+	require.Equal(t, "xattr", ev.Type)
+
+	emitter.Symlink("/foo/link")
+	ev = <-ch
+	require.Equal(t, "symlink", ev.Type)
+
+	mac := objects.MAC{1}
+	emitter.Object(mac)
+	ev = <-ch
+	require.Equal(t, "object", ev.Type)
+
+	emitter.Chunk(mac)
+	ev = <-ch
+	require.Equal(t, "chunk", ev.Type)
+
+	emitter.Close()
+	<-ch
+	bus.Close()
+}
+
+func TestEmitterOkEvents(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	emitter := bus.NewRepositoryEmitter(uuid.New(), "w")
+	<-ch
+
+	mac := objects.MAC{2}
+
+	emitter.PathOk("/foo")
+	ev := <-ch
+	require.Equal(t, "path.ok", ev.Type)
+
+	emitter.DirectoryOk("/foo", objects.FileInfo{})
+	ev = <-ch
+	require.Equal(t, "directory.ok", ev.Type)
+
+	emitter.FileOk("/foo/f", objects.FileInfo{})
+	ev = <-ch
+	require.Equal(t, "file.ok", ev.Type)
+
+	emitter.XattrOk("/foo/f", 42)
+	ev = <-ch
+	require.Equal(t, "xattr.ok", ev.Type)
+	require.Equal(t, int64(42), ev.Data["size"])
+
+	emitter.SymlinkOk("/foo/link")
+	ev = <-ch
+	require.Equal(t, "symlink.ok", ev.Type)
+
+	emitter.ObjectOk(mac)
+	ev = <-ch
+	require.Equal(t, "object.ok", ev.Type)
+
+	emitter.ChunkOk(mac)
+	ev = <-ch
+	require.Equal(t, "chunk.ok", ev.Type)
+
+	emitter.Close()
+	<-ch
+	bus.Close()
+}
+
+func TestEmitterCachedEvents(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	emitter := bus.NewRepositoryEmitter(uuid.New(), "w")
+	<-ch
+
+	mac := objects.MAC{3}
+
+	emitter.PathCached("/foo")
+	ev := <-ch
+	require.Equal(t, "path.cached", ev.Type)
+
+	emitter.DirectoryCached("/foo", objects.FileInfo{})
+	ev = <-ch
+	require.Equal(t, "directory.cached", ev.Type)
+
+	emitter.FileCached("/foo/f", objects.FileInfo{})
+	ev = <-ch
+	require.Equal(t, "file.cached", ev.Type)
+
+	emitter.XattrCached("/foo/f", 100)
+	ev = <-ch
+	require.Equal(t, "xattr.cached", ev.Type)
+
+	emitter.SymlinkCached("/foo/link")
+	ev = <-ch
+	require.Equal(t, "symlink.cached", ev.Type)
+
+	emitter.ObjectCached(mac)
+	ev = <-ch
+	require.Equal(t, "object.cached", ev.Type)
+
+	emitter.ChunkCached(mac)
+	ev = <-ch
+	require.Equal(t, "chunk.cached", ev.Type)
+
+	emitter.Close()
+	<-ch
+	bus.Close()
+}
+
+func TestEmitterErrorEvents(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	emitter := bus.NewRepositoryEmitter(uuid.New(), "w")
+	<-ch
+
+	mac := objects.MAC{4}
+	someErr := errors.New("test error")
+
+	emitter.PathError("/foo", someErr)
+	ev := <-ch
+	require.Equal(t, "path.error", ev.Type)
+	require.Equal(t, events.Error, ev.Level)
+
+	emitter.DirectoryError("/foo", someErr)
+	ev = <-ch
+	require.Equal(t, "directory.error", ev.Type)
+
+	emitter.FileError("/foo/f", someErr)
+	ev = <-ch
+	require.Equal(t, "file.error", ev.Type)
+
+	emitter.XattrError("/foo/f", someErr)
+	ev = <-ch
+	require.Equal(t, "xattr.error", ev.Type)
+
+	emitter.SymlinkError("/foo/link", someErr)
+	ev = <-ch
+	require.Equal(t, "symlink.error", ev.Type)
+
+	emitter.ObjectError(mac, someErr)
+	ev = <-ch
+	require.Equal(t, "object.error", ev.Type)
+
+	emitter.ChunkError(mac, someErr)
+	ev = <-ch
+	require.Equal(t, "chunk.error", ev.Type)
+
+	emitter.Close()
+	<-ch
+	bus.Close()
+}
+
+func TestEmitterResult(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	emitter := bus.NewRepositoryEmitter(uuid.New(), "w")
+	<-ch
+
+	emitter.Result("/target", 1024, 0, time.Second, 512, 256)
+	ev := <-ch
+	require.Equal(t, "result", ev.Type)
+	require.Equal(t, events.Quiet, ev.Level)
+	require.Equal(t, uint64(1024), ev.Data["size"])
+	require.Equal(t, uint64(0), ev.Data["errors"])
+
+	emitter.Close()
+	<-ch
+	bus.Close()
+}
+
+func TestEmitterFilesystemSummary(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	emitter := bus.NewRepositoryEmitter(uuid.New(), "w")
+	<-ch
+
+	emitter.FilesystemSummary(10, 5, 2, 1, 4096)
+	ev := <-ch
+	require.Equal(t, "fs.summary", ev.Type)
+	require.Equal(t, uint64(10), ev.Data["files"])
+	require.Equal(t, uint64(5), ev.Data["directories"])
+	require.Equal(t, uint64(2), ev.Data["symlinks"])
+	require.Equal(t, uint64(1), ev.Data["xattrs"])
+	require.Equal(t, uint64(4096), ev.Data["size"])
+
+	emitter.Close()
+	<-ch
+	bus.Close()
+}
+
+func TestEventFields(t *testing.T) {
+	bus := events.NewEventsBUS(100)
+	ch := bus.Listen()
+
+	repoID := uuid.New()
+	emitter := bus.NewRepositoryEmitter(repoID, "check")
+	ev := <-ch
+
+	require.Equal(t, 1, ev.Version)
+	require.Equal(t, repoID, ev.Repository)
+	require.False(t, ev.Timestamp.IsZero())
+	require.NotEqual(t, uuid.Nil, ev.Job)
+
+	emitter.Close()
+	<-ch
+	bus.Close()
+}
+
+func TestListenReturnsConsistentChannel(t *testing.T) {
+	bus := events.NewEventsBUS(10)
+	ch1 := bus.Listen()
+	ch2 := bus.Listen()
+	require.Equal(t, ch1, ch2, "Listen should return the same channel")
+	bus.Close()
+}

--- a/exclude/ruleset_test.go
+++ b/exclude/ruleset_test.go
@@ -1,0 +1,209 @@
+package exclude_test
+
+import (
+	"bytes"
+	"errors"
+	"iter"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/exclude"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRuleSet(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NotNil(t, rs)
+	require.Empty(t, rs.Rules)
+}
+
+func TestAddRule(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("*.log"))
+	require.Len(t, rs.Rules, 1)
+}
+
+func TestAddRulesFromArray(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	lines := []string{
+		"*.log",
+		"# this is a comment",
+		"",
+		"tmp/",
+		"build/",
+	}
+	require.NoError(t, rs.AddRulesFromArray(lines))
+	// Comments and empty lines are ignored
+	require.Len(t, rs.Rules, 3)
+}
+
+func TestAddRulesFromReader(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	content := "*.tmp\n# comment\n\n.DS_Store\n"
+	require.NoError(t, rs.AddRulesFromReader(bytes.NewBufferString(content)))
+	require.Len(t, rs.Rules, 2)
+}
+
+func TestAddRulesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	content := "*.log\n*.tmp\n# comment\n\nbuild/\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRulesFromFile(path))
+	require.Len(t, rs.Rules, 3)
+}
+
+func TestAddRulesFromFileMissing(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	err := rs.AddRulesFromFile("/does/not/exist/.gitignore")
+	require.Error(t, err)
+}
+
+func TestMatchExclude(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("*.log"))
+
+	matched, rule, err := rs.Match("app.log", false)
+	require.NoError(t, err)
+	require.True(t, matched, "*.log should match app.log")
+	require.NotNil(t, rule)
+}
+
+func TestMatchNoMatch(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("*.log"))
+
+	matched, rule, err := rs.Match("app.go", false)
+	require.NoError(t, err)
+	require.False(t, matched)
+	require.Nil(t, rule)
+}
+
+func TestMatchWithLeadingSlash(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("*.log"))
+
+	matched, _, err := rs.Match("/app.log", false)
+	require.NoError(t, err)
+	require.True(t, matched)
+}
+
+func TestIsExcluded(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("*.log"))
+	require.NoError(t, rs.AddRule("tmp/"))
+
+	require.True(t, rs.IsExcluded("app.log", false))
+	require.False(t, rs.IsExcluded("app.go", false))
+	require.True(t, rs.IsExcluded("tmp", true))
+	require.False(t, rs.IsExcluded("tmp", false))
+}
+
+func TestMatchDirectory(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("build/"))
+
+	matched, _, err := rs.Match("build", true)
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	matched, _, err = rs.Match("build", false)
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+func TestMatchNestedPath(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("*.log"))
+
+	require.True(t, rs.IsExcluded("foo/bar/baz.log", false))
+	require.False(t, rs.IsExcluded("foo/bar/baz.go", false))
+}
+
+func TestLastRuleWins(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.NoError(t, rs.AddRule("*.log"))
+	require.NoError(t, rs.AddRule("!important.log"))
+
+	// The last matching rule wins: !important.log re-includes
+	matched, _, err := rs.Match("important.log", false)
+	require.NoError(t, err)
+	require.False(t, matched, "negation rule should re-include important.log")
+}
+
+func TestAddRulesFromArrayWithCRLF(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	lines := []string{"*.log\r", "*.tmp\r"}
+	require.NoError(t, rs.AddRulesFromArray(lines))
+	require.Len(t, rs.Rules, 2)
+	require.True(t, rs.IsExcluded("app.log", false))
+}
+
+func TestAddRulesFromArrayEscapedHash(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	// \# should be treated as a literal #, not a comment
+	require.NoError(t, rs.AddRulesFromArray([]string{`\#special`}))
+	require.Len(t, rs.Rules, 1)
+}
+
+func TestAddRulesIteratorError(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	errIter := func(yield func(string, error) bool) {
+		yield("", errors.New("read error"))
+	}
+	err := rs.AddRules(iter.Seq2[string, error](errIter))
+	require.Error(t, err)
+}
+
+func TestMustParseRule(t *testing.T) {
+	rule := exclude.MustParseRule("*.go")
+	require.NotNil(t, rule)
+}
+
+func TestRuleMatch(t *testing.T) {
+	rule, err := exclude.ParseRule("*.log")
+	require.NoError(t, err)
+
+	// Match returns (matched, excluded, error)
+	matched, excluded, err := rule.Match([]string{"app", "log"}, false)
+	require.NoError(t, err)
+	// Depends on gitignore semantics; just check no panic
+	_ = matched
+	_ = excluded
+
+	matched2, excluded2, err2 := rule.Match([]string{"app.log"}, false)
+	require.NoError(t, err2)
+	if matched2 {
+		require.True(t, excluded2)
+	}
+}
+
+func TestRuleMatchNoMatch(t *testing.T) {
+	rule, err := exclude.ParseRule("*.log")
+	require.NoError(t, err)
+
+	matched, excluded, err := rule.Match([]string{"app.go"}, false)
+	require.NoError(t, err)
+	require.False(t, matched)
+	require.False(t, excluded)
+}
+
+func TestAddRulesFromReaderCRLF(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	content := "*.log\r\n*.tmp\r\n"
+	require.NoError(t, rs.AddRulesFromReader(bytes.NewBufferString(content)))
+	require.Len(t, rs.Rules, 2)
+}
+
+func TestEmptyRuleSet(t *testing.T) {
+	rs := exclude.NewRuleSet()
+	require.False(t, rs.IsExcluded("anything.log", false))
+
+	matched, rule, err := rs.Match("foo", false)
+	require.NoError(t, err)
+	require.False(t, matched)
+	require.Nil(t, rule)
+}

--- a/hashing/hashing_full_test.go
+++ b/hashing/hashing_full_test.go
@@ -1,0 +1,138 @@
+package hashing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHasherSHA256(t *testing.T) {
+	h := GetHasher("SHA256")
+	require.NotNil(t, h)
+
+	h.Write([]byte("hello"))
+	sum := h.Sum(nil)
+	require.Equal(t, 32, len(sum))
+}
+
+func TestGetHasherBLAKE3(t *testing.T) {
+	h := GetHasher("BLAKE3")
+	require.NotNil(t, h)
+
+	h.Write([]byte("hello"))
+	sum := h.Sum(nil)
+	require.Equal(t, 32, len(sum))
+}
+
+func TestGetHasherUnknown(t *testing.T) {
+	h := GetHasher("MD5")
+	require.Nil(t, h)
+}
+
+func TestGetHasherEmpty(t *testing.T) {
+	h := GetHasher("")
+	require.Nil(t, h)
+}
+
+func TestGetHasherDifferentAlgorithmsProduceDifferentHashes(t *testing.T) {
+	data := []byte("test data")
+
+	h1 := GetHasher("SHA256")
+	h1.Write(data)
+	sum1 := h1.Sum(nil)
+
+	h2 := GetHasher("BLAKE3")
+	h2.Write(data)
+	sum2 := h2.Sum(nil)
+
+	require.NotEqual(t, sum1, sum2, "SHA256 and BLAKE3 should produce different hashes")
+}
+
+func TestGetMACHasherSHA256(t *testing.T) {
+	secret := make([]byte, 32)
+	h := GetMACHasher("SHA256", secret)
+	require.NotNil(t, h)
+
+	h.Write([]byte("message"))
+	sum := h.Sum(nil)
+	require.Equal(t, 32, len(sum))
+}
+
+func TestGetMACHasherBLAKE3(t *testing.T) {
+	secret := make([]byte, 32)
+	h := GetMACHasher("BLAKE3", secret)
+	require.NotNil(t, h)
+
+	h.Write([]byte("message"))
+	sum := h.Sum(nil)
+	require.Equal(t, 32, len(sum))
+}
+
+func TestGetMACHasherUnknown(t *testing.T) {
+	h := GetMACHasher("MD5", []byte("key"))
+	require.Nil(t, h)
+}
+
+func TestGetMACHasherDeterministic(t *testing.T) {
+	secret := []byte("supersecretkey!!")
+	secret32 := make([]byte, 32)
+	copy(secret32, secret)
+
+	data := []byte("hello")
+
+	h1 := GetMACHasher("SHA256", secret32)
+	h1.Write(data)
+	sum1 := h1.Sum(nil)
+
+	h2 := GetMACHasher("SHA256", secret32)
+	h2.Write(data)
+	sum2 := h2.Sum(nil)
+
+	require.Equal(t, sum1, sum2, "MAC should be deterministic")
+}
+
+func TestGetMACHasherDifferentKeysProduceDifferentMACs(t *testing.T) {
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	key2[0] = 1
+
+	data := []byte("same data")
+
+	h1 := GetMACHasher("BLAKE3", key1)
+	h1.Write(data)
+	sum1 := h1.Sum(nil)
+
+	h2 := GetMACHasher("BLAKE3", key2)
+	h2.Write(data)
+	sum2 := h2.Sum(nil)
+
+	require.NotEqual(t, sum1, sum2, "different keys should produce different MACs")
+}
+
+func TestLookupDefaultConfigurationSHA256(t *testing.T) {
+	cfg, err := LookupDefaultConfiguration("SHA256")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Equal(t, "SHA256", cfg.Algorithm)
+	require.Equal(t, uint32(256), cfg.Bits)
+}
+
+func TestNewDefaultConfiguration(t *testing.T) {
+	cfg := NewDefaultConfiguration()
+	require.NotNil(t, cfg)
+	require.Equal(t, DEFAULT_HASHING_ALGORITHM, cfg.Algorithm)
+}
+
+func TestHasherReset(t *testing.T) {
+	h := GetHasher("SHA256")
+	h.Write([]byte("hello"))
+	h.Reset()
+	h.Write([]byte("world"))
+	sum1 := h.Sum(nil)
+
+	h2 := GetHasher("SHA256")
+	h2.Write([]byte("world"))
+	sum2 := h2.Sum(nil)
+
+	require.Equal(t, sum1, sum2, "reset should clear prior state")
+}

--- a/iostat/iostat_test.go
+++ b/iostat/iostat_test.go
@@ -1,0 +1,258 @@
+package iostat
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	tracker := New()
+	if tracker == nil {
+		t.Fatal("expected non-nil IOTracker")
+	}
+	if tracker.Read == nil {
+		t.Fatal("expected non-nil Read tracker")
+	}
+	if tracker.Write == nil {
+		t.Fatal("expected non-nil Write tracker")
+	}
+}
+
+func TestTrackerAddAndStats(t *testing.T) {
+	tr := newTracker()
+
+	// Empty stats
+	s := tr.Stats()
+	if s.TotalBytes != 0 {
+		t.Errorf("expected 0 total bytes, got %d", s.TotalBytes)
+	}
+	if s.Duration != 0 {
+		t.Errorf("expected 0 duration, got %v", s.Duration)
+	}
+
+	// Add bytes with zero duration — counted but no throughput sample
+	tr.add(100, 0)
+	s = tr.Stats()
+	if s.TotalBytes != 100 {
+		t.Errorf("expected 100 total bytes, got %d", s.TotalBytes)
+	}
+
+	// Add bytes with a duration large enough to emit a sample
+	tr.add(1<<20, 100*time.Millisecond)
+	s = tr.Stats()
+	if s.TotalBytes != 100+1<<20 {
+		t.Errorf("unexpected total bytes %d", s.TotalBytes)
+	}
+	if s.Overall == 0 {
+		t.Error("expected non-zero overall throughput")
+	}
+}
+
+func TestTrackerAddZeroBytes(t *testing.T) {
+	tr := newTracker()
+	tr.add(0, 100*time.Millisecond)
+	s := tr.Stats()
+	if s.TotalBytes != 0 {
+		t.Errorf("expected 0 bytes, got %d", s.TotalBytes)
+	}
+	if len(tr.samples) != 0 {
+		t.Errorf("expected no samples after adding 0 bytes, got %d", len(tr.samples))
+	}
+}
+
+func TestTrackerReset(t *testing.T) {
+	tr := newTracker()
+	tr.add(1<<20, 200*time.Millisecond)
+	tr.Reset()
+
+	s := tr.Stats()
+	if s.TotalBytes != 0 {
+		t.Errorf("expected 0 total bytes after reset, got %d", s.TotalBytes)
+	}
+	if s.Duration != 0 {
+		t.Errorf("expected 0 duration after reset, got %v", s.Duration)
+	}
+}
+
+func TestIOTrackerReset(t *testing.T) {
+	iot := New()
+	span := iot.GetWriteSpan()
+	span.Add(1 << 20)
+
+	iot.Reset()
+	ws := iot.Write.Stats()
+	if ws.TotalBytes != 0 {
+		t.Errorf("expected 0 bytes after reset, got %d", ws.TotalBytes)
+	}
+}
+
+func TestSpanAdd(t *testing.T) {
+	iot := New()
+	span := iot.GetWriteSpan()
+
+	span.Add(4096)
+	span.Add(8192)
+
+	ws := iot.Write.Stats()
+	if ws.TotalBytes != 4096+8192 {
+		t.Errorf("expected %d bytes, got %d", 4096+8192, ws.TotalBytes)
+	}
+}
+
+func TestSpanAddNil(t *testing.T) {
+	var s *Span
+	// should not panic
+	s.Add(1000)
+}
+
+func TestGetReadSpan(t *testing.T) {
+	iot := New()
+	span := iot.GetReadSpan()
+
+	span.Add(2048)
+	span.Add(2048)
+
+	rs := iot.Read.Stats()
+	if rs.TotalBytes != 4096 {
+		t.Errorf("expected 4096 bytes, got %d", rs.TotalBytes)
+	}
+}
+
+func TestStatsMultipleSamples(t *testing.T) {
+	tr := newTracker()
+
+	// Add enough data with long durations so we get multiple samples
+	for i := 0; i < 5; i++ {
+		tr.add(1<<20, 200*time.Millisecond)
+	}
+
+	s := tr.Stats()
+	if s.Min == 0 {
+		t.Error("expected non-zero Min")
+	}
+	if s.Max == 0 {
+		t.Error("expected non-zero Max")
+	}
+	if s.Avg == 0 {
+		t.Error("expected non-zero Avg")
+	}
+	if s.P50 == 0 {
+		t.Error("expected non-zero P50")
+	}
+	if s.P75 == 0 {
+		t.Error("expected non-zero P75")
+	}
+	if s.P90 == 0 {
+		t.Error("expected non-zero P90")
+	}
+	if s.P95 == 0 {
+		t.Error("expected non-zero P95")
+	}
+	if s.P99 == 0 {
+		t.Error("expected non-zero P99")
+	}
+}
+
+func TestPercentileEdgeCases(t *testing.T) {
+	// empty slice
+	if v := percentile([]float64{}, 50); v != 0 {
+		t.Errorf("expected 0 for empty slice, got %f", v)
+	}
+
+	// p <= 0 returns first element
+	data := []float64{1.0, 2.0, 3.0}
+	if v := percentile(data, 0); v != 1.0 {
+		t.Errorf("expected 1.0 for p=0, got %f", v)
+	}
+
+	// p >= 100 returns last element
+	if v := percentile(data, 100); v != 3.0 {
+		t.Errorf("expected 3.0 for p=100, got %f", v)
+	}
+
+	// interpolation
+	if v := percentile(data, 50); v == 0 {
+		t.Error("expected non-zero for p=50")
+	}
+}
+
+func TestSummaryString(t *testing.T) {
+	iot := New()
+
+	// Add some data so the summary is non-trivial
+	wspan := iot.GetWriteSpan()
+	wspan.Add(1 << 20)
+
+	rspan := iot.GetReadSpan()
+	rspan.Add(512)
+
+	summary := iot.SummaryString()
+	if !strings.Contains(summary, "r:") {
+		t.Error("expected 'r:' in summary")
+	}
+	if !strings.Contains(summary, "w:") {
+		t.Error("expected 'w:' in summary")
+	}
+}
+
+func TestSummaryStringEmpty(t *testing.T) {
+	iot := New()
+	summary := iot.SummaryString()
+	// Should not panic and should contain both sections
+	if !strings.Contains(summary, "r:") || !strings.Contains(summary, "w:") {
+		t.Error("expected both r: and w: sections in empty summary")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		input    int64
+		wantZero bool
+	}{
+		{0, true},
+		{-1, true},
+		{1024, false},
+	}
+	for _, c := range cases {
+		got := formatBytes(c.input)
+		isZero := got == "0 B"
+		if isZero != c.wantZero {
+			t.Errorf("formatBytes(%d) = %q, wantZero=%v", c.input, got, c.wantZero)
+		}
+	}
+}
+
+func TestFormatThroughput(t *testing.T) {
+	cases := []struct {
+		input    float64
+		wantZero bool
+	}{
+		{0, true},
+		{-1, true},
+		{1024, false},
+	}
+	for _, c := range cases {
+		got := formatThroughput(c.input)
+		isZero := got == "0 B/s"
+		if isZero != c.wantZero {
+			t.Errorf("formatThroughput(%f) = %q, wantZero=%v", c.input, got, c.wantZero)
+		}
+	}
+}
+
+func TestBucketAccumulation(t *testing.T) {
+	tr := newTracker()
+
+	// Add bytes with a duration shorter than sampleWindow — no sample yet
+	tr.add(1024, 10*time.Millisecond)
+	if len(tr.samples) != 0 {
+		t.Errorf("expected 0 samples for short duration, got %d", len(tr.samples))
+	}
+
+	// Stats flushes partial bucket
+	s := tr.Stats()
+	if s.TotalBytes != 1024 {
+		t.Errorf("expected 1024 bytes, got %d", s.TotalBytes)
+	}
+}

--- a/kcontext/kcontext_extra_test.go
+++ b/kcontext/kcontext_extra_test.go
@@ -1,0 +1,105 @@
+package kcontext
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKContext(t *testing.T) {
+	ctx := NewKContext()
+	require.NotNil(t, ctx)
+	require.NotNil(t, ctx.Stdin)
+	require.NotNil(t, ctx.Stdout)
+	require.NotNil(t, ctx.Stderr)
+	require.NotNil(t, ctx.Context)
+	require.NotNil(t, ctx.Cancel)
+	require.NotNil(t, ctx.events)
+}
+
+func TestNewKContextFrom(t *testing.T) {
+	base := NewKContext()
+	base.Username = "alice"
+	base.Hostname = "server"
+
+	derived := NewKContextFrom(base)
+	require.NotNil(t, derived)
+	require.Equal(t, "alice", derived.Username)
+	require.Equal(t, "server", derived.Hostname)
+	// derived should have its own events bus (different pointer)
+	require.NotSame(t, base.events, derived.events)
+}
+
+func TestKContextDeadline(t *testing.T) {
+	ctx := NewKContext()
+	defer ctx.Close()
+
+	deadline, ok := ctx.Deadline()
+	// Background context has no deadline
+	require.False(t, ok)
+	require.True(t, deadline.IsZero())
+}
+
+func TestKContextDone(t *testing.T) {
+	ctx := NewKContext()
+	ch := ctx.Done()
+	require.NotNil(t, ch)
+
+	// Channel should be open before Close
+	select {
+	case <-ch:
+		t.Error("context done before Close")
+	default:
+	}
+
+	ctx.Close()
+
+	// After close, channel should be closed
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Error("context done channel not closed after Close")
+	}
+}
+
+func TestKContextErr(t *testing.T) {
+	ctx := NewKContext()
+	require.NoError(t, ctx.Err())
+
+	ctx.Close()
+	// After cancel, Err() should be non-nil
+	require.Error(t, ctx.Err())
+}
+
+func TestKContextValue(t *testing.T) {
+	ctx := NewKContext()
+	defer ctx.Close()
+	// Background context has no values
+	require.Nil(t, ctx.Value("nonexistent"))
+}
+
+func TestKContextEvents(t *testing.T) {
+	ctx := NewKContext()
+	defer ctx.Close()
+
+	ev := ctx.Events()
+	require.NotNil(t, ev)
+	require.Equal(t, ctx.events, ev)
+}
+
+func TestNewKContextFromCancelPropagation(t *testing.T) {
+	parent := NewKContext()
+	child := NewKContextFrom(parent)
+
+	// Cancel parent — child should also be cancelled
+	parent.Cancel(nil)
+
+	select {
+	case <-child.Done():
+	case <-time.After(time.Second):
+		t.Error("child context not cancelled when parent cancelled")
+	}
+
+	child.Close()
+}

--- a/objects/objects_extra_test.go
+++ b/objects/objects_extra_test.go
@@ -1,0 +1,174 @@
+package objects
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomMAC(t *testing.T) {
+	m1 := RandomMAC()
+	m2 := RandomMAC()
+
+	// Should be non-zero
+	require.NotEqual(t, NilMac, m1)
+	require.NotEqual(t, NilMac, m2)
+	// Two random MACs should differ (with overwhelming probability)
+	require.NotEqual(t, m1, m2)
+}
+
+func TestMACFormatHex(t *testing.T) {
+	m := MAC{0x01, 0x02, 0x03}
+	hex := m.FormatHex()
+	require.Equal(t, 64, len(hex))
+	require.Contains(t, hex, "010203")
+}
+
+func TestMACParseHex(t *testing.T) {
+	original := MAC{1, 2, 3, 4}
+	hexStr := original.FormatHex()
+
+	var parsed MAC
+	require.NoError(t, parsed.ParseHex(hexStr))
+	require.Equal(t, original, parsed)
+}
+
+func TestMACParseHexInvalid(t *testing.T) {
+	var m MAC
+	require.Error(t, m.ParseHex("not-hex"))
+}
+
+func TestMACParseHexWrongLength(t *testing.T) {
+	var m MAC
+	require.Error(t, m.ParseHex("0102"))
+}
+
+func TestMACJSONRoundtrip(t *testing.T) {
+	original := MAC{5, 6, 7, 8, 9}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored MAC
+	require.NoError(t, json.Unmarshal(data, &restored))
+	require.Equal(t, original, restored)
+}
+
+func TestMACUnmarshalJSONBadJSON(t *testing.T) {
+	var m MAC
+	require.Error(t, json.Unmarshal([]byte(`12345`), &m))
+}
+
+func TestNewChunk(t *testing.T) {
+	c := NewChunk()
+	require.NotNil(t, c)
+	require.Equal(t, NilMac, c.ContentMAC)
+	require.Equal(t, uint32(0), c.Length)
+	require.Equal(t, float64(0), c.Entropy)
+}
+
+func TestChunkSerializeRoundtrip(t *testing.T) {
+	c := NewChunk()
+	c.ContentMAC = MAC{1, 2, 3}
+	c.Length = 1024
+	c.Entropy = 0.75
+
+	data, err := c.Serialize()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	restored, err := NewChunkFromBytes(data)
+	require.NoError(t, err)
+	require.Equal(t, c.ContentMAC, restored.ContentMAC)
+	require.Equal(t, c.Length, restored.Length)
+	require.InDelta(t, c.Entropy, restored.Entropy, 0.001)
+}
+
+func TestNewChunkFromBytesInvalid(t *testing.T) {
+	_, err := NewChunkFromBytes([]byte{0x01, 0x02, 0x03})
+	require.Error(t, err)
+}
+
+func TestChunkMarshalJSON(t *testing.T) {
+	c := NewChunk()
+	c.ContentMAC = MAC{10, 11, 12}
+	c.Length = 512
+
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+}
+
+func TestObjectSize(t *testing.T) {
+	o := NewObject()
+	require.Equal(t, int64(0), o.Size())
+
+	o.Chunks = []Chunk{
+		{Length: 100},
+		{Length: 200},
+		{Length: 50},
+	}
+	require.Equal(t, int64(350), o.Size())
+}
+
+func TestObjectSerializeRoundtrip(t *testing.T) {
+	o := NewObject()
+	o.ContentMAC = MAC{20, 21, 22}
+	o.ContentType = "application/octet-stream"
+	o.Entropy = 0.5
+	o.Chunks = []Chunk{
+		{Length: 512, ContentMAC: MAC{1}},
+		{Length: 1024, ContentMAC: MAC{2}},
+	}
+
+	data, err := o.Serialize()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	restored, err := NewObjectFromBytes(data)
+	require.NoError(t, err)
+	require.Equal(t, o.ContentMAC, restored.ContentMAC)
+	require.Equal(t, o.ContentType, restored.ContentType)
+	require.InDelta(t, o.Entropy, restored.Entropy, 0.001)
+	require.Len(t, restored.Chunks, 2)
+}
+
+func TestNewObjectFromBytesInvalid(t *testing.T) {
+	_, err := NewObjectFromBytes([]byte{0xFF, 0xFE})
+	require.Error(t, err)
+}
+
+func TestCachedPathRoundtrip(t *testing.T) {
+	cp := &CachedPath{
+		MAC:         MAC{30},
+		ObjectMAC:   MAC{31},
+		ContentType: "text/plain",
+		Chunks:      5,
+		Entropy:     0.3,
+	}
+
+	data, err := cp.Serialize()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	restored, err := NewCachedPathFromBytes(data)
+	require.NoError(t, err)
+	require.Equal(t, cp.MAC, restored.MAC)
+	require.Equal(t, cp.ContentType, restored.ContentType)
+	require.Equal(t, cp.Chunks, restored.Chunks)
+}
+
+func TestNewCachedPathFromBytesInvalid(t *testing.T) {
+	_, err := NewCachedPathFromBytes([]byte{0x01})
+	require.Error(t, err)
+}
+
+func TestCachedPathStat(t *testing.T) {
+	cp := &CachedPath{
+		FileInfo: FileInfo{Lname: "test.txt"},
+	}
+	fi := cp.Stat()
+	require.NotNil(t, fi)
+	require.Equal(t, "test.txt", fi.Lname)
+}

--- a/packfile/packfile_disk_test.go
+++ b/packfile/packfile_disk_test.go
@@ -1,0 +1,250 @@
+package packfile
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"hash"
+	"io"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/resources"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/stretchr/testify/require"
+)
+
+// Suppress unused import warning — io is used in other tests
+var _ = io.EOF
+
+func sha256Factory() hash.Hash {
+	return sha256.New()
+}
+
+func identityEncoder(r io.Reader) (io.Reader, error) {
+	return r, nil
+}
+
+func TestPackfileOnDiskAddAndEntries(t *testing.T) {
+	tmp := t.TempDir()
+	p, err := NewPackfileOnDisk(tmp, sha256Factory)
+	require.NoError(t, err)
+	defer p.Cleanup()
+
+	data1 := []byte("chunk one data")
+	data2 := []byte("chunk two data")
+	mac1 := objects.MAC{1}
+	mac2 := objects.MAC{2}
+	ver := versioning.GetCurrentVersion(resources.RT_CHUNK)
+
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac1, data1, 0))
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac2, data2, 0))
+
+	entries := p.Entries()
+	require.Len(t, entries, 2)
+	require.Equal(t, mac1, entries[0].MAC)
+	require.Equal(t, mac2, entries[1].MAC)
+}
+
+func TestPackfileOnDiskSize(t *testing.T) {
+	tmp := t.TempDir()
+	p, err := NewPackfileOnDisk(tmp, sha256Factory)
+	require.NoError(t, err)
+	defer p.Cleanup()
+
+	require.Equal(t, uint64(0), p.Size())
+
+	data := []byte("some data here")
+	mac := objects.MAC{5}
+	ver := versioning.GetCurrentVersion(resources.RT_CHUNK)
+
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac, data, 0))
+	require.Equal(t, uint64(len(data)), p.Size())
+}
+
+func TestPackfileOnDiskSerialize(t *testing.T) {
+	tmp := t.TempDir()
+	p, err := NewPackfileOnDisk(tmp, sha256Factory)
+	require.NoError(t, err)
+
+	data := []byte("test blob data")
+	mac := objects.MAC{10}
+	ver := versioning.GetCurrentVersion(resources.RT_CHUNK)
+
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac, data, 0))
+
+	reader, fileMac, err := p.Serialize(identityEncoder)
+	require.NoError(t, err)
+	require.NotEqual(t, objects.NilMac, fileMac)
+	require.NotNil(t, reader)
+
+	// Read all serialized content
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NotEmpty(t, content)
+
+	// The blob data should appear somewhere in the output
+	require.Contains(t, string(content), string(data))
+}
+
+func TestPackfileOnDiskCleanup(t *testing.T) {
+	tmp := t.TempDir()
+	p, err := NewPackfileOnDisk(tmp, sha256Factory)
+	require.NoError(t, err)
+
+	err = p.Cleanup()
+	require.NoError(t, err)
+}
+
+func TestPackfileOnDiskMultipleBlobs(t *testing.T) {
+	tmp := t.TempDir()
+	p, err := NewPackfileOnDisk(tmp, sha256Factory)
+	require.NoError(t, err)
+	defer p.Cleanup()
+
+	ver := versioning.GetCurrentVersion(resources.RT_CHUNK)
+	blobs := []struct {
+		mac  objects.MAC
+		data []byte
+	}{
+		{objects.MAC{1}, []byte("first blob")},
+		{objects.MAC{2}, []byte("second blob")},
+		{objects.MAC{3}, []byte("third blob")},
+	}
+
+	for _, b := range blobs {
+		require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, b.mac, b.data, 0))
+	}
+
+	entries := p.Entries()
+	require.Len(t, entries, 3)
+
+	// Verify offsets are sequential
+	offset := uint64(0)
+	for i, b := range blobs {
+		require.Equal(t, offset, entries[i].Offset)
+		require.Equal(t, uint32(len(b.data)), entries[i].Length)
+		offset += uint64(len(b.data))
+	}
+}
+
+func TestPackfileInMemorySerializeRoundtrip(t *testing.T) {
+	// The packfile format uses an encoder; use a real compression-free passthrough
+	// that still wraps the bytes so the format remains parseable. Use nil-bytes passthrough.
+	hasher := sha256.New()
+	p := newPackfileInMemory(hasher).(*PackfileInMemory)
+
+	data1 := []byte("hello world data")
+	data2 := []byte("goodbye world data")
+	mac1 := objects.MAC{11}
+	mac2 := objects.MAC{12}
+	ver := versioning.GetCurrentVersion(resources.RT_CHUNK)
+
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac1, data1, 0))
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac2, data2, 0))
+
+	entries := p.Entries()
+	require.Len(t, entries, 2)
+	require.Equal(t, mac1, entries[0].MAC)
+	require.Equal(t, mac2, entries[1].MAC)
+	require.Equal(t, uint32(len(data1)), entries[0].Length)
+	require.Equal(t, uint32(len(data2)), entries[1].Length)
+
+	got1, ok := p.getBlob(mac1)
+	require.True(t, ok)
+	require.Equal(t, data1, got1)
+
+	got2, ok := p.getBlob(mac2)
+	require.True(t, ok)
+	require.Equal(t, data2, got2)
+}
+
+func TestNewInMemoryIndexFromBytes(t *testing.T) {
+	ver := versioning.GetCurrentVersion(resources.RT_CHUNK)
+	mac := objects.MAC{40}
+
+	// Use the in-memory packfile to get a real index buffer
+	p := newPackfileInMemory(sha256.New()).(*PackfileInMemory)
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac, []byte("data"), 0))
+
+	// The index is p.Index; serialize it to bytes in the expected binary format
+	idxBuf := &bytes.Buffer{}
+	for _, b := range p.Index {
+		writeLE(idxBuf, b)
+	}
+
+	index, err := NewInMemoryIndexFromBytes(p.Footer.Version, idxBuf.Bytes())
+	require.NoError(t, err)
+	require.Len(t, index, 1)
+	require.Equal(t, mac, index[0].MAC)
+}
+
+func TestNewInMemoryFooterFromBytesTooShort(t *testing.T) {
+	// Too short buffer — should return error
+	_, err := NewInMemoryFooterFromBytes(versioning.FromString(VERSION), make([]byte, 4))
+	require.Error(t, err)
+}
+
+// writeLE writes a Blob to a buffer in little-endian binary format matching the packfile format.
+func writeLE(buf *bytes.Buffer, b Blob) {
+	type4 := make([]byte, 4)
+	type4[0] = byte(b.Type)
+	buf.Write(type4)
+
+	ver4 := make([]byte, 4)
+	ver4[0] = byte(b.Version)
+	buf.Write(ver4)
+
+	buf.Write(b.MAC[:])
+
+	off8 := make([]byte, 8)
+	for i := 0; i < 8; i++ {
+		off8[i] = byte(b.Offset >> (uint(i) * 8))
+	}
+	buf.Write(off8)
+
+	len4 := make([]byte, 4)
+	for i := 0; i < 4; i++ {
+		len4[i] = byte(b.Length >> (uint(i) * 8))
+	}
+	buf.Write(len4)
+
+	flags4 := make([]byte, 4)
+	for i := 0; i < 4; i++ {
+		flags4[i] = byte(b.Flags >> (uint(i) * 8))
+	}
+	buf.Write(flags4)
+}
+
+func TestNewPackfileInMemory(t *testing.T) {
+	p, err := NewPackfileInMemory(sha256Factory)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.Equal(t, uint64(0), p.Size())
+	require.Empty(t, p.Entries())
+}
+
+func TestPackfileInMemoryCleanup(t *testing.T) {
+	p, err := NewPackfileInMemory(sha256Factory)
+	require.NoError(t, err)
+	require.NoError(t, p.Cleanup())
+}
+
+func TestPackfileInMemorySerialize(t *testing.T) {
+	p, err := NewPackfileInMemory(sha256Factory)
+	require.NoError(t, err)
+
+	data := []byte("serialize test data")
+	mac := objects.MAC{50}
+	ver := versioning.GetCurrentVersion(resources.RT_CHUNK)
+	require.NoError(t, p.AddBlob(resources.RT_CHUNK, ver, mac, data, 0))
+
+	reader, fileMac, err := p.Serialize(identityEncoder)
+	require.NoError(t, err)
+	require.NotEqual(t, objects.NilMac, fileMac)
+	require.NotNil(t, reader)
+
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NotEmpty(t, content)
+}
+

--- a/reading/reading_test.go
+++ b/reading/reading_test.go
@@ -1,0 +1,118 @@
+package reading_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/reading"
+	"github.com/stretchr/testify/require"
+)
+
+type mockReaderAtCloser struct {
+	data   []byte
+	closed bool
+}
+
+func (m *mockReaderAtCloser) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(m.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (m *mockReaderAtCloser) Close() error {
+	m.closed = true
+	return nil
+}
+
+func TestNewSectionReadCloser(t *testing.T) {
+	data := []byte("hello, world!")
+	mock := &mockReaderAtCloser{data: data}
+
+	src := reading.NewSectionReadCloser(mock, 0, int64(len(data)))
+	require.NotNil(t, src)
+}
+
+func TestSectionReadCloserRead(t *testing.T) {
+	data := []byte("hello, world!")
+	mock := &mockReaderAtCloser{data: data}
+
+	src := reading.NewSectionReadCloser(mock, 0, int64(len(data)))
+
+	got, err := io.ReadAll(src)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+}
+
+func TestSectionReadCloserOffset(t *testing.T) {
+	data := []byte("hello, world!")
+	mock := &mockReaderAtCloser{data: data}
+
+	// Read from offset 7, length 5 → "world"
+	src := reading.NewSectionReadCloser(mock, 7, 5)
+
+	got, err := io.ReadAll(src)
+	require.NoError(t, err)
+	require.Equal(t, []byte("world"), got)
+}
+
+func TestSectionReadCloserClose(t *testing.T) {
+	data := []byte("test data")
+	mock := &mockReaderAtCloser{data: data}
+
+	src := reading.NewSectionReadCloser(mock, 0, int64(len(data)))
+	err := src.Close()
+	require.NoError(t, err)
+	require.True(t, mock.closed, "underlying closer should be called")
+}
+
+func TestSectionReadCloserReadAt(t *testing.T) {
+	data := []byte("abcdefghij")
+	mock := &mockReaderAtCloser{data: data}
+
+	src := reading.NewSectionReadCloser(mock, 0, int64(len(data)))
+
+	buf := make([]byte, 3)
+	n, err := src.ReadAt(buf, 2)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, []byte("cde"), buf)
+}
+
+func TestSectionReadCloserEmptyData(t *testing.T) {
+	mock := &mockReaderAtCloser{data: []byte{}}
+
+	src := reading.NewSectionReadCloser(mock, 0, 0)
+	got, err := io.ReadAll(src)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestSectionReadCloserLargerThanData(t *testing.T) {
+	data := []byte("hi")
+	mock := &mockReaderAtCloser{data: data}
+
+	// Section larger than actual data — SectionReader limits to available bytes
+	src := reading.NewSectionReadCloser(mock, 0, 100)
+	got, err := io.ReadAll(src)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+}
+
+func TestSectionReadCloserCopyTo(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 1024)
+	mock := &mockReaderAtCloser{data: data}
+
+	src := reading.NewSectionReadCloser(mock, 0, int64(len(data)))
+
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, src)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(data)), n)
+	require.Equal(t, data, buf.Bytes())
+}

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -1,0 +1,121 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeString(t *testing.T) {
+	cases := []struct {
+		typ  resources.Type
+		want string
+	}{
+		{resources.RT_CONFIG, "config"},
+		{resources.RT_LOCK, "lock"},
+		{resources.RT_STATE, "state"},
+		{resources.RT_PACKFILE, "packfile"},
+		{resources.RT_SNAPSHOT, "snapshot"},
+		{resources.RT_SIGNATURE, "signature"},
+		{resources.RT_OBJECT, "object"},
+		{resources.RT_CHUNK, "chunk"},
+		{resources.RT_VFS_BTREE, "vfs-btree"},
+		{resources.RT_VFS_NODE, "vfs-node"},
+		{resources.RT_VFS_ENTRY, "vfs-entry"},
+		{resources.RT_ERROR_BTREE, "error-btree"},
+		{resources.RT_ERROR_NODE, "error-node"},
+		{resources.RT_ERROR_ENTRY, "error-entry"},
+		{resources.RT_XATTR_BTREE, "xattr-btree"},
+		{resources.RT_XATTR_NODE, "xattr-node"},
+		{resources.RT_XATTR_ENTRY, "xattr-entry"},
+		{resources.RT_BTREE_ROOT, "btree-root"},
+		{resources.RT_BTREE_NODE, "btree-node"},
+		{resources.RT_VFS_SUMMARY, "vfs-summary"},
+		{resources.RT_RANDOM, "random"},
+		{resources.Type(0), "unknown"},
+		{resources.Type(255), "random"},
+	}
+
+	for _, c := range cases {
+		got := c.typ.String()
+		require.Equal(t, c.want, got, "Type(%d).String()", c.typ)
+	}
+}
+
+func TestFromString(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  resources.Type
+	}{
+		{"config", resources.RT_CONFIG},
+		{"lock", resources.RT_LOCK},
+		{"state", resources.RT_STATE},
+		{"packfile", resources.RT_PACKFILE},
+		{"snapshot", resources.RT_SNAPSHOT},
+		{"signature", resources.RT_SIGNATURE},
+		{"object", resources.RT_OBJECT},
+		{"chunk", resources.RT_CHUNK},
+		{"vfs-btree", resources.RT_VFS_BTREE},
+		{"vfs-node", resources.RT_VFS_NODE},
+		{"vfs-entry", resources.RT_VFS_ENTRY},
+		{"error-btree", resources.RT_ERROR_BTREE},
+		{"error-node", resources.RT_ERROR_NODE},
+		{"error-entry", resources.RT_ERROR_ENTRY},
+		{"xattr-btree", resources.RT_XATTR_BTREE},
+		{"xattr-node", resources.RT_XATTR_NODE},
+		{"xattr-entry", resources.RT_XATTR_ENTRY},
+		{"btree-root", resources.RT_BTREE_ROOT},
+		{"btree-node", resources.RT_BTREE_NODE},
+		{"vfs-summary", resources.RT_VFS_SUMMARY},
+		{"random", resources.RT_RANDOM},
+	}
+
+	for _, c := range cases {
+		got, err := resources.FromString(c.name)
+		require.NoError(t, err, "FromString(%q)", c.name)
+		require.Equal(t, c.typ, got, "FromString(%q)", c.name)
+	}
+}
+
+func TestFromStringUnknown(t *testing.T) {
+	_, err := resources.FromString("unknown-type")
+	require.ErrorIs(t, err, resources.ErrInvalid)
+}
+
+func TestFromStringRoundTrip(t *testing.T) {
+	for _, typ := range resources.Types() {
+		name := typ.String()
+		if name == "unknown" {
+			continue
+		}
+		got, err := resources.FromString(name)
+		require.NoError(t, err, "round-trip for %v", typ)
+		require.Equal(t, typ, got, "round-trip for %v", typ)
+	}
+}
+
+func TestTypes(t *testing.T) {
+	types := resources.Types()
+	require.NotEmpty(t, types)
+
+	// All returned types should have non-empty string representations
+	for _, typ := range types {
+		s := typ.String()
+		require.NotEmpty(t, s)
+		require.NotEqual(t, "unknown", s, "Types() should not return unknown type values")
+	}
+}
+
+func TestTypeValues(t *testing.T) {
+	// Verify the constant values match the documented spec
+	require.Equal(t, resources.Type(1), resources.RT_CONFIG)
+	require.Equal(t, resources.Type(2), resources.RT_LOCK)
+	require.Equal(t, resources.Type(3), resources.RT_STATE)
+	require.Equal(t, resources.Type(4), resources.RT_PACKFILE)
+	require.Equal(t, resources.Type(5), resources.RT_SNAPSHOT)
+	require.Equal(t, resources.Type(6), resources.RT_SIGNATURE)
+	require.Equal(t, resources.Type(7), resources.RT_OBJECT)
+	require.Equal(t, resources.Type(9), resources.RT_CHUNK)
+	require.Equal(t, resources.Type(255), resources.RT_RANDOM)
+}

--- a/snapshot/scanlog/scanlog_test.go
+++ b/snapshot/scanlog/scanlog_test.go
@@ -1,0 +1,273 @@
+package scanlog_test
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/snapshot/scanlog"
+	"github.com/stretchr/testify/require"
+)
+
+func newScanLog(t *testing.T) *scanlog.ScanLog {
+	t.Helper()
+	dir := t.TempDir()
+	sl, err := scanlog.New(dir)
+	require.NoError(t, err)
+	return sl
+}
+
+func TestNew(t *testing.T) {
+	sl := newScanLog(t)
+	require.NotNil(t, sl)
+	require.NoError(t, sl.Close())
+}
+
+func TestPutAndGetDirectory(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{1, 2, 3}
+	payload := []byte("directory payload")
+
+	require.NoError(t, sl.PutDirectory("/foo/bar", mac, payload))
+
+	got, err := sl.GetDirectory("/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestPutAndGetFile(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{4, 5, 6}
+	payload := []byte("file payload")
+	summary := []byte("file summary")
+
+	require.NoError(t, sl.PutFile("/foo/file.txt", "text/plain", mac, payload, summary))
+
+	got, err := sl.GetFile("/foo/file.txt")
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestGetMissingDirectory(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	got, err := sl.GetDirectory("/does/not/exist")
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestGetMissingFile(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	got, err := sl.GetFile("/does/not/exist.txt")
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestListDirectories(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{10}
+	require.NoError(t, sl.PutDirectory("/alpha", mac, []byte("a")))
+	require.NoError(t, sl.PutDirectory("/beta", mac, []byte("b")))
+	require.NoError(t, sl.PutDirectory("/gamma", mac, []byte("c")))
+
+	var dirs []string
+	for entry := range sl.ListDirectories("/", false) {
+		dirs = append(dirs, entry.Path)
+	}
+	require.GreaterOrEqual(t, len(dirs), 3)
+}
+
+func TestListFiles(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{20}
+	require.NoError(t, sl.PutFile("/a.txt", "text/plain", mac, []byte("a"), nil))
+	require.NoError(t, sl.PutFile("/b.txt", "text/plain", mac, []byte("b"), nil))
+
+	var files []string
+	for entry := range sl.ListFiles(0, "/", false) {
+		files = append(files, entry.Path)
+	}
+	require.GreaterOrEqual(t, len(files), 2)
+}
+
+func TestListPathnames(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{30}
+	require.NoError(t, sl.PutDirectory("/dir1", mac, []byte("d")))
+	require.NoError(t, sl.PutFile("/dir1/file.txt", "text/plain", mac, []byte("f"), nil))
+
+	var paths []string
+	for entry := range sl.ListPathnames("/dir1", false) {
+		paths = append(paths, entry.Path)
+	}
+	require.GreaterOrEqual(t, len(paths), 2)
+}
+
+func TestListPathnameEntries(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{40}
+	payload := []byte("entry payload")
+	require.NoError(t, sl.PutFile("/myfile.txt", "text/plain", mac, payload, nil))
+
+	for entry := range sl.ListPathnameEntries("/myfile.txt", false) {
+		require.Equal(t, "/myfile.txt", entry.Path)
+		require.Equal(t, payload, entry.Payload)
+	}
+}
+
+func TestListDirectPathnames(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{50}
+	require.NoError(t, sl.PutDirectory("/parent", mac, []byte("parent")))
+	require.NoError(t, sl.PutDirectory("/parent/child1", mac, []byte("child1")))
+	require.NoError(t, sl.PutFile("/parent/file.txt", "text/plain", mac, []byte("file"), []byte("summary")))
+	require.NoError(t, sl.PutDirectory("/parent/child1/grandchild", mac, []byte("grandchild")))
+
+	var names []string
+	for entry := range sl.ListDirectPathnames("/parent", false) {
+		names = append(names, entry.Path)
+	}
+	// Only direct children: child1 and file.txt
+	require.GreaterOrEqual(t, len(names), 2)
+	for _, n := range names {
+		require.NotEqual(t, "/parent/child1/grandchild", n)
+	}
+}
+
+func TestPutPathMACAndGet(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{60, 61, 62}
+	require.NoError(t, sl.PutPathMAC(scanlog.KindError, "/foo/bar", mac))
+
+	got, err := sl.GetPathMAC(scanlog.KindError, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, mac, got)
+}
+
+func TestGetMissingPathMAC(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	got, err := sl.GetPathMAC(scanlog.KindXattr, "/does/not/exist")
+	require.NoError(t, err)
+	require.Equal(t, objects.NilMac, got)
+}
+
+func TestListPathMACsFrom(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac1 := objects.MAC{70}
+	mac2 := objects.MAC{71}
+	require.NoError(t, sl.PutPathMAC(scanlog.KindXattr, "/xattr/a", mac1))
+	require.NoError(t, sl.PutPathMAC(scanlog.KindXattr, "/xattr/b", mac2))
+
+	var entries []scanlog.PathMACEntry
+	for e := range sl.ListPathMACsFrom(scanlog.KindXattr, "/xattr/") {
+		entries = append(entries, e)
+	}
+	require.Len(t, entries, 2)
+}
+
+func TestCountDirectPathMACs(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{80}
+	require.NoError(t, sl.PutPathMAC(scanlog.KindError, "/errors/a", mac))
+	require.NoError(t, sl.PutPathMAC(scanlog.KindError, "/errors/b", mac))
+	require.NoError(t, sl.PutPathMAC(scanlog.KindError, "/errors/a/nested", mac))
+
+	count, err := sl.CountDirectPathMACs(scanlog.KindError, "/errors")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), count)
+}
+
+func TestBatchCommit(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{90}
+	batch := sl.NewBatch()
+	require.NotNil(t, batch)
+
+	require.NoError(t, batch.PutDirectory("/batch/dir", mac, []byte("d")))
+	require.NoError(t, batch.PutFile("/batch/file.txt", "text/plain", mac, []byte("f"), []byte("s")))
+	require.Equal(t, uint32(2), batch.Count())
+
+	require.NoError(t, batch.Commit())
+
+	// Verify committed data is readable
+	got, err := sl.GetDirectory("/batch/dir")
+	require.NoError(t, err)
+	require.Equal(t, []byte("d"), got)
+
+	got, err = sl.GetFile("/batch/file.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("f"), got)
+}
+
+func TestBatchCommitEmpty(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	batch := sl.NewBatch()
+	require.Equal(t, uint32(0), batch.Count())
+	require.NoError(t, batch.Commit())
+}
+
+func TestBatchCommitMultipleTimes(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{91}
+	batch := sl.NewBatch()
+
+	require.NoError(t, batch.PutFile("/batch2/a.txt", "text/plain", mac, []byte("a"), nil))
+	require.NoError(t, batch.Commit())
+	require.Equal(t, uint32(0), batch.Count())
+
+	require.NoError(t, batch.PutFile("/batch2/b.txt", "text/plain", mac, []byte("b"), nil))
+	require.NoError(t, batch.Commit())
+
+	got, err := sl.GetFile("/batch2/b.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("b"), got)
+}
+
+func TestSetMaxConn(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+	// Should not panic
+	sl.SetMaxConn(4)
+}
+
+func TestPutFileWithNilSummary(t *testing.T) {
+	sl := newScanLog(t)
+	defer sl.Close()
+
+	mac := objects.MAC{100}
+	require.NoError(t, sl.PutFile("/nosummary.txt", "text/plain", mac, []byte("data"), nil))
+
+	got, err := sl.GetFile("/nosummary.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("data"), got)
+}


### PR DESCRIPTION
## Summary

Adds 13 new test files covering packages that previously had 0% or very low test coverage. All 37 test packages pass with no regressions.

### Coverage improvements

| Package | Before | After |
|---------|--------|-------|
| `iostat` | 0% | 100% |
| `events` | 0% | 100% |
| `resources` | 0% | 100% |
| `reading` | 0% | 100% |
| `kcontext` | 52.9% | 100% |
| `hashing` | 29.4% | 94.1% |
| `objects` | 70.1% | 91.3% |
| `caching/sqlite` | 0% | 87.8% |
| `caching/pebble` | 34.8% | 86.4% |
| `snapshot/scanlog` | 0% | 81.5% |
| `exclude` (RuleSet) | 4.8% | 84.5% |
| `packfile` | 4.8% | 34.5% |

### What's tested

- **iostat**: tracker accumulation, bucket/sample logic, percentile calculation, `Span.Add`, `SummaryString`, format helpers
- **events**: `EventsBUS` lifecycle, all `Emitter` event methods (path/dir/file/xattr/symlink/object/chunk variants for ok/cached/error), `Result`, `FilesystemSummary`, dummy emitter no-op behaviour
- **resources**: `Type.String()` for all constants, `FromString()` round-trips, `Types()` completeness, `ErrInvalid` on unknown names
- **reading**: `SectionReadCloser` read, seek, offset, copy, close propagation
- **kcontext**: `NewKContext`/`NewKContextFrom`, `Deadline`/`Done`/`Err`/`Value` context interface, cancel propagation from parent to child
- **hashing**: `GetHasher` and `GetMACHasher` for SHA256 and BLAKE3, determinism, unknown algorithm returns nil, hasher reset
- **objects**: `MAC` hex encoding/JSON round-trips, `Object`/`Chunk`/`CachedPath` serialize+deserialize, `Object.Size()`, invalid bytes errors
- **caching/sqlite**: in-memory and on-disk construction, compress/decompress (snappy), read-only mode, `DeleteOnClose`
- **caching/pebble**: `Scan` forward/reverse, `Batch` commit, `Constructor`/`InMemoryConstructor`, `makeKeyUpperBound` edge cases
- **caching** (SQLiteDBStore): `Put`/`Get`/`Update` round-trip, multiple inserts produce distinct indices
- **snapshot/scanlog**: `ScanLog` put/get for files and directories, `ScanBatch` commit (including empty and multi-commit), `PathMAC` put/get/list/count, `ListDirectPathnames`
- **exclude**: `RuleSet.AddRule`, `AddRulesFromArray/Reader/File`, CRLF handling, comment/blank-line skipping, `Match`/`IsExcluded`, last-rule-wins negation, iterator error propagation

### Design notes

- Tests use `t.TempDir()` for all filesystem state — no global temp pollution
- No mocks for packages that provide real in-memory implementations (pebble, sqlite)
- Table-driven tests where multiple inputs share the same logic
- Error paths (invalid bytes, missing files, overflow) are covered alongside happy paths

## Test plan

- [x] `go test ./...` — all packages pass
- [x] No changes to existing test files or production code