### PR TITLE
test(snapshot/vfs): cover vfile getters, NewXattr, IterErrorNodes

### DIFF
--- a/snapshot/vfs/entry_test.go
+++ b/snapshot/vfs/entry_test.go
@@ -82,6 +82,33 @@ func TestVfile(t *testing.T) {
 	require.Implements(t, (*iofs.FileInfo)(nil), statinfo)
 }
 
+// vfileMeta exposes the optional metadata accessors that the unexported
+// vfile struct implements (Name / Size / Path).  Asserting against this
+// interface lets us cover them without making vfile public.
+type vfileMeta interface {
+	Name() string
+	Size() int64
+	Path() string
+}
+
+func TestVfileMetaAccessors(t *testing.T) {
+	_, snap := generateSnapshot(t)
+	defer snap.Close()
+
+	fsc, err := snap.Filesystem()
+	require.NoError(t, err)
+
+	f, err := fsc.Open("/subdir/dummy.txt")
+	require.NoError(t, err)
+	defer f.Close()
+
+	meta, ok := f.(vfileMeta)
+	require.True(t, ok, "opened file should expose Name/Size/Path")
+	require.Equal(t, "dummy.txt", meta.Name())
+	require.Equal(t, int64(5), meta.Size())
+	require.Equal(t, "/subdir/dummy.txt", meta.Path())
+}
+
 func TestVdir(t *testing.T) {
 	_, snap := generateSnapshot(t)
 	defer snap.Close()

--- a/snapshot/vfs/vfs_extra_test.go
+++ b/snapshot/vfs/vfs_extra_test.go
@@ -466,6 +466,19 @@ func TestErrorNodeFromBytes(t *testing.T) {
 // Xattr serialization round-trip
 // -----------------------------------------------------------------------
 
+func TestNewXattr(t *testing.T) {
+	rec := connectors.NewXattr("/etc/passwd", "user.comment", objects.AttributeExtended, nil)
+	mac := objects.MAC{1, 2, 3}
+
+	x := vfs.NewXattr(rec, mac, 128)
+	require.NotNil(t, x)
+	require.Equal(t, "/etc/passwd", x.Path)
+	require.Equal(t, "user.comment", x.Name)
+	require.Equal(t, objects.AttributeExtended, x.Type)
+	require.Equal(t, mac, x.Object)
+	require.Equal(t, int64(128), x.Size)
+}
+
 func TestXattrToBytes(t *testing.T) {
 	x := &vfs.Xattr{
 		Path: "/etc/passwd",
@@ -541,6 +554,20 @@ func TestNodeFromBytes(t *testing.T) {
 // -----------------------------------------------------------------------
 // IterNodes / XattrNodes / BTrees
 // -----------------------------------------------------------------------
+
+func TestIterErrorNodes(t *testing.T) {
+	_, snap := generateSnapshot2(t)
+	defer snap.Close()
+
+	fsc, err := snap.Filesystem()
+	require.NoError(t, err)
+
+	iter := fsc.IterErrorNodes()
+	require.NotNil(t, iter)
+	for iter.Next() {
+	}
+	require.NoError(t, iter.Err())
+}
 
 func TestIterNodes(t *testing.T) {
 	_, snap := generateSnapshot2(t)


### PR DESCRIPTION
## Summary

Add tests for three uncovered paths in snapshot/vfs:

- `vfile.Name() / Size() / Path()` — these aren't exposed through `fs.File`,
  so a small in-test interface assertion exercises them via what `fs.Open`
  returns.
- `vfs.NewXattr(record, mac, size)` constructor — covered with a direct call.
- `Filesystem.IterErrorNodes()` — iterated to completion on a snapshot with
  no errors, ensuring the iterator returns cleanly.

Tests only; no production code changes.

## Test plan

- [x] `go test ./snapshot/vfs/...` passes
- [x] `go vet ./...` clean