### PR TITLE
test: cover Close methods in btree, caching, compression

### DIFF
--- a/btree/btree_internal_test.go
+++ b/btree/btree_internal_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInMemoryStoreClose(t *testing.T) {
+	s := InMemoryStore[rune, string]{}
+	require.NoError(t, s.Close())
+}
+
 func TestFromStorage_RootMustExists(t *testing.T) {
 	root := 999
 

--- a/caching/store_test.go
+++ b/caching/store_test.go
@@ -84,4 +84,8 @@ func TestDBStore(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, idx)
 	})
+
+	t.Run("Close is a no-op (cache is not owned)", func(t *testing.T) {
+		require.NoError(t, store.Close())
+	})
 }

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -457,6 +457,40 @@ func TestInflateStream(t *testing.T) {
 	})
 }
 
+func TestInflateStreamCloseClosesUnderlyingReader(t *testing.T) {
+	// readCloserInternal.Close() closes both the inflated stream and the
+	// caller-supplied input reader. Verify both happen.
+	for _, algo := range []string{"GZIP", "LZ4"} {
+		t.Run(algo, func(t *testing.T) {
+			compressed := compressDataForTest(t, algo, []byte("payload"))
+			inputClosed := false
+			input := &closeRecorder{Reader: bytes.NewReader(compressed), onClose: func() { inputClosed = true }}
+
+			rc, err := cprss.InflateStream(algo, input)
+			require.NoError(t, err)
+			require.NotNil(t, rc)
+
+			_, err = io.ReadAll(rc)
+			require.NoError(t, err)
+
+			require.NoError(t, rc.Close())
+			require.True(t, inputClosed, "underlying input reader must be closed by Close()")
+		})
+	}
+}
+
+type closeRecorder struct {
+	io.Reader
+	onClose func()
+}
+
+func (c *closeRecorder) Close() error {
+	if c.onClose != nil {
+		c.onClose()
+	}
+	return nil
+}
+
 func TestLargeData(t *testing.T) {
 	t.Run("GZIP", func(t *testing.T) {
 		data := make([]byte, 10*1024*1024)


### PR DESCRIPTION
## Summary

Three Close methods were at 0% coverage. This PR adds focused tests:

- `btree.InMemoryStore.Close` — direct call
- `caching.DBStore.Close` — added as a subtest of the existing `TestDBStore`
- `compression.readCloserInternal.Close` (the unexported wrapper returned by
  `InflateStream`) — the test verifies that closing the wrapper also closes
  the underlying input reader passed by the caller

Tests only; no production code changes.

## Test plan

- [x] `go test ./btree/ ./caching/ ./compression/` passes