### PR TITLE
test(snapshot): cover Synchronize and syncImporter

### DIFF
--- a/snapshot/synchronize_internal_test.go
+++ b/snapshot/synchronize_internal_test.go
@@ -1,0 +1,18 @@
+package snapshot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncImporterPingClose covers the interface-satisfying Ping and Close
+// methods on syncImporter.  Synchronize itself does not call them, so they
+// stay at 0% from the public-API tests.
+func TestSyncImporterPingClose(t *testing.T) {
+	imp := &syncImporter{}
+	ctx := context.Background()
+	require.NoError(t, imp.Ping(ctx))
+	require.NoError(t, imp.Close(ctx))
+}

--- a/snapshot/synchronize_test.go
+++ b/snapshot/synchronize_test.go
@@ -1,0 +1,81 @@
+package snapshot_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSynchronize copies a snapshot from a source repository into a destination
+// repository.  This exercises Synchronize and, transitively, every method on
+// the unexported syncImporter type (Origin/Type/Root/Flags/Ping/Close/Import).
+func TestSynchronize(t *testing.T) {
+	srcRepo := ptesting.GenerateRepository(t, nil, nil, nil)
+	dstRepo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	srcSnap := ptesting.GenerateSnapshot(t, srcRepo, []ptesting.MockFile{
+		ptesting.NewMockDir("docs"),
+		ptesting.NewMockFile("docs/readme.txt", 0644, "sync me"),
+		ptesting.NewMockFile("docs/notes.txt", 0644, "and me too"),
+	})
+	defer srcSnap.Close()
+
+	dstBuilder, err := snapshot.Create(dstRepo, repository.DefaultType, "", objects.NilMac, &snapshot.BuilderOptions{
+		Name: "sync-test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, dstBuilder)
+
+	require.NoError(t, srcSnap.Synchronize(dstBuilder))
+	require.NoError(t, dstBuilder.Close())
+	require.NoError(t, dstBuilder.Repository().RebuildState())
+
+	syncedID := dstBuilder.Header.Identifier
+	synced, err := snapshot.Load(dstRepo, syncedID)
+	require.NoError(t, err)
+	defer synced.Close()
+
+	fs, err := synced.Filesystem()
+	require.NoError(t, err)
+
+	var hasReadme, hasNotes bool
+	for p, err := range fs.Pathnames() {
+		require.NoError(t, err)
+		if strings.HasSuffix(p, "readme.txt") {
+			hasReadme = true
+		}
+		if strings.HasSuffix(p, "notes.txt") {
+			hasNotes = true
+		}
+	}
+	require.True(t, hasReadme, "readme.txt missing from synchronized snapshot")
+	require.True(t, hasNotes, "notes.txt missing from synchronized snapshot")
+}
+
+// TestSynchronizeNoCommit covers the NoCommit branch of Synchronize, where the
+// destination builder is told not to commit and Synchronize falls back to
+// PutSnapshot.
+func TestSynchronizeNoCommit(t *testing.T) {
+	srcRepo := ptesting.GenerateRepository(t, nil, nil, nil)
+	dstRepo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	srcSnap := ptesting.GenerateSnapshot(t, srcRepo, []ptesting.MockFile{
+		ptesting.NewMockFile("hello.txt", 0644, "world"),
+	})
+	defer srcSnap.Close()
+
+	dstBuilder, err := snapshot.Create(dstRepo, repository.DefaultType, "", objects.NilMac, &snapshot.BuilderOptions{
+		Name:     "sync-nocommit",
+		NoCommit: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, dstBuilder)
+	defer dstBuilder.Close()
+
+	require.NoError(t, srcSnap.Synchronize(dstBuilder))
+}


### PR DESCRIPTION
## Summary

`Snapshot.Synchronize` and the unexported `syncImporter` type were entirely
uncovered. This PR adds:

- `snapshot/synchronize_test.go` — drives `Synchronize` end-to-end (default
  commit path + `NoCommit` path) by replicating a source snapshot into a
  destination repository and checking the result.
- `snapshot/synchronize_internal_test.go` — covers `syncImporter.Ping` and
  `syncImporter.Close`, which are interface-satisfying methods that
  `Synchronize` itself never calls.

Tests only; no production code changes.

## Test plan

- [x] `go test ./snapshot/ -run TestSync` passes