### PR TITLE
ci: use go.mod toolchain version instead of pinned 1.23.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,16 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        go: [ '1.23.3' ]
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
## Summary

Main is currently failing to build with:

\`\`\`
# github.com/PlakarKorp/kloset/testing
go: no such tool \"covdata\"
\`\`\`

(see e.g. [run 26403053132](https://github.com/PlakarKorp/kloset/actions/runs/26403053132)).

### Root cause

- \`go.mod\` declares \`go 1.25.0\`.
- \`.github/workflows/go.yml\` pinned the runner to Go \`1.23.3\` via a 1-element matrix.
- Building a \`go 1.25.0\` module under Go 1.23.3 triggers Go's auto-toolchain download (the \`golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64\` paths visible in the \`Set up Go\` step).
- That extraction collides with the \`actions/setup-go\` cache layout — the logs show many \`tar: ... Cannot open: File exists\` warnings, including for files under \`src/cmd/covdata/\`.
- Result: the downloaded 1.25 toolchain is missing \`covdata\`, and \`go test ./...\` shells out to it (to merge coverage data for the empty-at-top-level \`testing/\` package), which fails.

### Fix

Read the Go version directly from \`go.mod\` so \`actions/setup-go\` installs a complete 1.25.x toolchain from its own tarball. No more auto-toolchain dance, no more half-extracted cache. This is the same pattern the [plakar repo's workflow](https://github.com/PlakarKorp/plakar/blob/main/.github/workflows/go.yml) already uses.

The single-element matrix is dropped since it was no longer pinning anything meaningful.

## Test plan
- [ ] CI on this PR passes (which it could not before, since main itself is red).
- [ ] No \`Cannot open: File exists\` warnings in the \`Set up Go\` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)