### PR TITLE
ci: upload coverage to Codecov and add badge

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,4 +23,10 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v -cover -timeout 1m ./...
+      run: go test -v -coverprofile=coverage.out -covermode=atomic -timeout 1m ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: ./coverage.out
+        fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kloset - Immutable Data Store Engine
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/PlakarKorp/kloset)](https://goreportcard.com/report/github.com/PlakarKorp/kloset)
+[![codecov](https://codecov.io/gh/PlakarKorp/kloset/branch/main/graph/badge.svg)](https://codecov.io/gh/PlakarKorp/kloset)
 
 ## Plakar V1.0.1 released
 


### PR DESCRIPTION
## Summary

- Replaces the inline `-cover` flag with `-coverprofile=coverage.out` so the coverage report can be uploaded.
- Adds a `codecov/codecov-action@v4` step to upload `coverage.out` to Codecov.
- Adds a Codecov badge next to the Go Report Card badge in the README.

`fail_ci_if_error: false` keeps the build green if the upload hiccups — flip to `true` once the integration is confirmed stable.

The Codecov project is already enabled for `PlakarKorp/kloset`, so no token is required for public-repo uploads.

## Test plan
- [ ] CI on this PR runs `Upload coverage to Codecov` successfully.
- [ ] After merge to `main`, Codecov badge populates with a coverage percentage (it currently renders "unknown" until the first `main` upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)