### PR TITLE
test(packer): cover Finalize pipeline and AddPadding

### DIFF
--- a/repository/packer/packer_internal_test.go
+++ b/repository/packer/packer_internal_test.go
@@ -1,0 +1,59 @@
+package packer
+
+import (
+	"crypto/sha256"
+	"hash"
+	"io"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/kcontext"
+	"github.com/PlakarKorp/kloset/packfile"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestManager returns a seqPackerManager that has all of its dependencies
+// configured for in-memory packfiles with an identity encoder and a no-op
+// flusher. Useful for exercising AddPadding directly.
+func newTestManager(t *testing.T) *seqPackerManager {
+	t.Helper()
+	ctx := kcontext.NewKContext()
+	t.Cleanup(func() { ctx.Close() })
+
+	storageConf := storage.NewConfiguration()
+	hashFactory := func() hash.Hash { return sha256.New() }
+	encoder := func(r io.Reader) (io.Reader, error) { return r, nil }
+	packfileFactory := func(hf packfile.HashFactory) (packfile.Packfile, error) {
+		return packfile.NewPackfileInMemory(hf)
+	}
+	flusher := func(pf packfile.Packfile) error { return nil }
+
+	mgr := NewSeqPackerManager(ctx, storageConf, encoder, packfileFactory, hashFactory, flusher).(*seqPackerManager)
+	return mgr
+}
+
+// TestAddPaddingNegative exercises the maxSize < 0 branch.
+func TestAddPaddingNegative(t *testing.T) {
+	mgr := newTestManager(t)
+	pf, err := packfile.NewPackfileInMemory(sha256.New)
+	require.NoError(t, err)
+	require.Error(t, mgr.AddPadding(pf, -1))
+}
+
+// TestAddPaddingZero exercises the maxSize == 0 early return.
+func TestAddPaddingZero(t *testing.T) {
+	mgr := newTestManager(t)
+	pf, err := packfile.NewPackfileInMemory(sha256.New)
+	require.NoError(t, err)
+	require.NoError(t, mgr.AddPadding(pf, 0))
+	require.Equal(t, uint64(0), pf.Size())
+}
+
+// TestAddPaddingPositive ensures a positive maxSize actually appends padding.
+func TestAddPaddingPositive(t *testing.T) {
+	mgr := newTestManager(t)
+	pf, err := packfile.NewPackfileInMemory(sha256.New)
+	require.NoError(t, err)
+	require.NoError(t, mgr.AddPadding(pf, 64))
+	require.Greater(t, pf.Size(), uint64(0))
+}

--- a/repository/packer/packwriter_finalize_test.go
+++ b/repository/packer/packwriter_finalize_test.go
@@ -1,0 +1,115 @@
+package packer
+
+import (
+	"crypto/sha256"
+	"errors"
+	"hash"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/caching"
+	"github.com/PlakarKorp/kloset/caching/pebble"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/resources"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/stretchr/testify/require"
+)
+
+func newPackingCache(t *testing.T) *caching.PackingCache {
+	t.Helper()
+	tmpDir := t.TempDir()
+	cm := caching.NewManager(pebble.Constructor(tmpDir))
+	t.Cleanup(func() { cm.Close() })
+	pc, err := cm.Packing()
+	require.NoError(t, err)
+	t.Cleanup(func() { pc.Close() })
+	return pc
+}
+
+// drainPutter is a putter that drains the PackWriter's Reader pipe — the
+// canonical way PackWriter is consumed in production.
+func drainPutter(p *PackWriter) error {
+	_, err := io.Copy(io.Discard, p.Reader)
+	return err
+}
+
+// TestPackWriterFinalizeFull drives the full WriteBlob → Finalize flow with a
+// putter that drains the Reader. serializeIndex and serializeFooter both run.
+func TestPackWriterFinalizeFull(t *testing.T) {
+	pc := newPackingCache(t)
+
+	encoder := func(r io.Reader) (io.Reader, error) { return r, nil }
+	hasher := func() hash.Hash { return sha256.New() }
+
+	pw := NewPackWriter(drainPutter, encoder, hasher, pc)
+
+	for i := 0; i < 3; i++ {
+		mac := objects.RandomMAC()
+		require.NoError(t, pw.WriteBlob(resources.RT_CHUNK, versioning.FromString("1.0.0"), mac, []byte("payload"), 0))
+	}
+
+	require.NoError(t, pw.Finalize())
+	require.Greater(t, pw.Footer.Count, uint32(0))
+}
+
+// TestPackWriterFinalizeEmpty calls Finalize without writing any blobs;
+// serializeIndex's per-record loop is skipped and only the footer is written.
+func TestPackWriterFinalizeEmpty(t *testing.T) {
+	pc := newPackingCache(t)
+
+	encoder := func(r io.Reader) (io.Reader, error) { return r, nil }
+	hasher := func() hash.Hash { return sha256.New() }
+
+	pw := NewPackWriter(drainPutter, encoder, hasher, pc)
+	require.NoError(t, pw.Finalize())
+}
+
+// failingEncoderOnNthCall lets us inject an encoder failure on a specific
+// invocation. Used to hit the encoder-error branch of serializeIndex /
+// serializeFooter.
+type failingEncoderOnNthCall struct {
+	failAt int
+	called int
+	mu     sync.Mutex
+}
+
+func (f *failingEncoderOnNthCall) encode(r io.Reader) (io.Reader, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called++
+	if f.called == f.failAt {
+		return nil, errors.New("forced encoder failure")
+	}
+	return r, nil
+}
+
+// TestPackWriterSerializeIndexEncoderError makes the encoder fail when
+// serializeIndex calls it (WriteBlob's encoder = 1st, serializeIndex = 2nd).
+func TestPackWriterSerializeIndexEncoderError(t *testing.T) {
+	pc := newPackingCache(t)
+
+	fe := &failingEncoderOnNthCall{failAt: 2}
+	hasher := func() hash.Hash { return sha256.New() }
+
+	pw := NewPackWriter(drainPutter, fe.encode, hasher, pc)
+
+	mac := objects.RandomMAC()
+	require.NoError(t, pw.WriteBlob(resources.RT_CHUNK, versioning.FromString("1.0.0"), mac, []byte("x"), 0))
+	require.Error(t, pw.Finalize())
+}
+
+// TestPackWriterSerializeFooterEncoderError makes the encoder fail on the
+// third call (WriteBlob = 1, serializeIndex = 2, serializeFooter = 3).
+func TestPackWriterSerializeFooterEncoderError(t *testing.T) {
+	pc := newPackingCache(t)
+
+	fe := &failingEncoderOnNthCall{failAt: 3}
+	hasher := func() hash.Hash { return sha256.New() }
+
+	pw := NewPackWriter(drainPutter, fe.encode, hasher, pc)
+
+	mac := objects.RandomMAC()
+	require.NoError(t, pw.WriteBlob(resources.RT_CHUNK, versioning.FromString("1.0.0"), mac, []byte("x"), 0))
+	require.Error(t, pw.Finalize())
+}


### PR DESCRIPTION
## Summary
- `packer_internal_test.go` — exercises `AddPadding` for negative, zero and positive sizes
- `packwriter_finalize_test.go` — drives `PackWriter.WriteBlob` → `Finalize` end-to-end with a Reader-draining putter, plus encoder-failure injection to hit `serializeIndex` and `serializeFooter` error branches
- Pure additive tests; no source changes

## Test plan
- [x] \`go test ./repository/packer/\` — 79 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)