### PR TITLE
test(testing/state): cover cache and store helpers to 100%

### DIFF
--- a/testing/state/cache_coverage_test.go
+++ b/testing/state/cache_coverage_test.go
@@ -1,0 +1,116 @@
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCacheStateLifecycle covers the state-handling methods on the cache:
+// PutState, HasState, GetState, GetStates, DelState, GetLatestState.
+func TestCacheStateLifecycle(t *testing.T) {
+	c := newCache()
+
+	// Empty cache.
+	latest, err := c.GetLatestState()
+	require.NoError(t, err)
+	require.Equal(t, objects.NilMac, latest)
+
+	id1 := objects.MAC{0x01}
+	id2 := objects.MAC{0x02}
+
+	require.NoError(t, c.PutState(id1, []byte("one")))
+	require.NoError(t, c.PutState(id2, []byte("two")))
+
+	has, err := c.HasState(id1)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	has, err = c.HasState(objects.MAC{0xFF})
+	require.NoError(t, err)
+	require.False(t, has)
+
+	data, err := c.GetState(id1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("one"), data)
+
+	data, err = c.GetState(objects.MAC{0xFF})
+	require.NoError(t, err)
+	require.Nil(t, data)
+
+	latest, err = c.GetLatestState()
+	require.NoError(t, err)
+	require.Equal(t, id2, latest)
+
+	all, err := c.GetStates()
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	require.NoError(t, c.DelState(id1))
+	has, err = c.HasState(id1)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	// Deleting a non-existent state is a no-op.
+	require.NoError(t, c.DelState(objects.MAC{0xCC}))
+}
+
+// TestCacheUnsupportedMethods exercises every cache method that simply
+// returns ErrUnsupported / nil, locking in their existence even though they
+// have no behaviour.
+func TestCacheUnsupportedMethods(t *testing.T) {
+	c := newCache()
+	require.ErrorIs(t, c.PutDelta(resources.RT_CHUNK, objects.MAC{}, objects.MAC{}, nil), errors.ErrUnsupported)
+	require.Nil(t, c.GetDelta(resources.RT_CHUNK, objects.MAC{}))
+	require.Nil(t, c.GetDeltasByType(resources.RT_CHUNK))
+	require.Nil(t, c.GetDeltas())
+	require.ErrorIs(t, c.DelDelta(resources.RT_CHUNK, objects.MAC{}, objects.MAC{}), errors.ErrUnsupported)
+	require.ErrorIs(t, c.PutColoured(resources.RT_CHUNK, objects.MAC{}, nil), errors.ErrUnsupported)
+	_, err := c.HasColoured(resources.RT_CHUNK, objects.MAC{})
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+	require.ErrorIs(t, c.DelColoured(resources.RT_CHUNK, objects.MAC{}), errors.ErrUnsupported)
+	require.Nil(t, c.GetColouredEntriesByType(resources.RT_CHUNK))
+	require.Nil(t, c.GetColouredEntries())
+	require.ErrorIs(t, c.PutPackfile(objects.MAC{}, nil), errors.ErrUnsupported)
+	require.ErrorIs(t, c.DelPackfile(objects.MAC{}), errors.ErrUnsupported)
+	_, err = c.HasPackfile(objects.MAC{})
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+	require.Nil(t, c.GetPackfiles())
+	require.ErrorIs(t, c.PutConfiguration("k", nil), errors.ErrUnsupported)
+	_, err = c.GetConfiguration("k")
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+	require.Nil(t, c.GetConfigurations())
+}
+
+// TestCacheBatch exercises the batch type returned by NewBatch.
+func TestCacheBatch(t *testing.T) {
+	c := newCache()
+	b := c.NewBatch()
+	require.NotNil(t, b)
+
+	require.ErrorIs(t, b.Put(nil, nil), errors.ErrUnsupported)
+	require.ErrorIs(t, b.PutDelta(resources.RT_CHUNK, objects.MAC{}, objects.MAC{}, nil), errors.ErrUnsupported)
+	require.Equal(t, uint32(0), b.Count())
+	require.NoError(t, b.Commit())
+	// batch.Close is unexported on the StateBatch interface, but the concrete
+	// type implements it — we exercise it via type assertion if available.
+	if closer, ok := b.(interface{ Close() error }); ok {
+		require.NoError(t, closer.Close())
+	}
+}
+
+// TestCachePutDeletedPanics asserts that PutDeleted panics ("nop") — locking
+// in the contract that this helper does not support deletions.
+func TestCachePutDeletedPanics(t *testing.T) {
+	c := newCache()
+	require.Panics(t, func() { _ = c.PutDeleted(0, objects.MAC{}, nil) })
+}
+
+// TestCacheGetDeletedEntriesPanics asserts that GetDeletedEntries panics.
+func TestCacheGetDeletedEntriesPanics(t *testing.T) {
+	c := newCache()
+	require.Panics(t, func() { _ = c.GetDeletedEntries() })
+}

--- a/testing/state/store_coverage_test.go
+++ b/testing/state/store_coverage_test.go
@@ -1,0 +1,133 @@
+package state
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/kcontext"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStore constructs the in-memory fake state store registered by init().
+func newTestStore(t *testing.T) storage.Store {
+	t.Helper()
+	ctx := kcontext.NewKContext()
+	t.Cleanup(func() { ctx.Close() })
+	st, err := storage.New(ctx, map[string]string{"location": "fake+state://test"})
+	require.NoError(t, err)
+	return st
+}
+
+// TestStoreSimpleAccessors covers Type, Root, Origin, Size, Mode, Flags, Ping,
+// Create — all of which are trivial implementations on the fake state store.
+func TestStoreSimpleAccessors(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Create(ctx, nil))
+	require.NoError(t, s.Ping(ctx))
+	require.Equal(t, "fakestatebackend", s.Type())
+	require.Equal(t, "", s.Root())
+	require.Equal(t, "fake", s.Origin())
+
+	mode, err := s.Mode(ctx)
+	require.NoError(t, err)
+	require.NotZero(t, mode)
+
+	size, err := s.Size(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), size)
+
+	flags := s.Flags()
+	require.Equal(t, uint32(0), uint32(flags))
+
+	require.NoError(t, s.Close(ctx))
+}
+
+// TestStoreOpen exercises the Open method which returns ErrUnsupported.
+func TestStoreOpen(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Open(context.Background())
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+}
+
+// TestStorePutGetListState round-trips a state through Put / Get / List.
+func TestStorePutGetListState(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	mac := objects.MAC{0xAA}
+	payload := []byte("state payload")
+
+	n, err := s.Put(ctx, storage.StorageResourceState, mac, bytes.NewReader(payload))
+	require.NoError(t, err)
+	require.Equal(t, int64(len(payload)), n)
+
+	rc, err := s.Get(ctx, storage.StorageResourceState, mac, nil)
+	require.NoError(t, err)
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	require.Equal(t, payload, got)
+
+	macs, err := s.List(ctx, storage.StorageResourceState)
+	require.NoError(t, err)
+	require.Contains(t, macs, mac)
+}
+
+// TestStorePutUnsupported exercises the unsupported-resource branch of Put.
+func TestStorePutUnsupported(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Put(context.Background(), storage.StorageResourcePackfile, objects.MAC{}, bytes.NewReader(nil))
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+}
+
+// TestStoreGetUnsupported exercises the unsupported-resource branch of Get.
+func TestStoreGetUnsupported(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Get(context.Background(), storage.StorageResourcePackfile, objects.MAC{}, nil)
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+}
+
+// TestStoreListUnsupported exercises the unsupported-resource branch of List.
+func TestStoreListUnsupported(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.List(context.Background(), storage.StorageResourcePackfile)
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+}
+
+// TestStoreDeleteUnsupported exercises the unsupported-resource branch of
+// Delete. (The state branch panics by design, so we don't test it.)
+func TestStoreDeleteUnsupported(t *testing.T) {
+	s := newTestStore(t)
+	err := s.Delete(context.Background(), storage.StorageResourcePackfile, objects.MAC{})
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+}
+
+// errReader returns an error on every Read.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read fail") }
+
+// TestStorePutStateReadError exercises the io.ReadAll error branch of Put.
+func TestStorePutStateReadError(t *testing.T) {
+	s := newTestStore(t)
+	ctx := kcontext.NewKContext()
+	t.Cleanup(func() { ctx.Close() })
+
+	_, err := s.Put(ctx, storage.StorageResourceState, objects.MAC{0xEE}, errReader{})
+	require.Error(t, err)
+}
+
+// TestStoreDeleteStatePanics confirms the documented panic on state deletion.
+func TestStoreDeleteStatePanics(t *testing.T) {
+	s := newTestStore(t)
+	require.Panics(t, func() {
+		_ = s.Delete(context.Background(), storage.StorageResourceState, objects.MAC{})
+	})
+}


### PR DESCRIPTION
## Summary
Adds two test files exercising the in-memory state cache and the \`fake+state\` storage backend used by the testing/state helpers:

- \`cache_coverage_test.go\` — full state lifecycle (PutState / HasState / GetState / GetStates / DelState / GetLatestState), every \`ErrUnsupported\` stub, the NewBatch path, and the documented \`PutDeleted\` / \`GetDeletedEntries\` panics.
- \`store_coverage_test.go\` — \`Create\`, \`Open\`, \`Ping\`, \`Type\`, \`Root\`, \`Origin\`, \`Size\`, \`Mode\`, \`Flags\`, \`Close\`; the Put/Get/List happy state path; the unsupported-resource branches of Put/Get/List/Delete; the \`io.ReadAll\` error branch of Put; and the documented panic on Delete(state).

Lifts \`testing/state/\` statement coverage from **37.3% → 100%**.

## Test plan
- [x] \`go test ./testing/state/\` — 18 tests pass
- [x] \`go test ./...\` — full suite green
- [x] Pure additive tests; no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)