### PR TITLE
ci: exclude testing/ from Codecov coverage reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "testing/**/*"


### PR DESCRIPTION
## Summary
Adds a \`codecov.yml\` that ignores \`testing/**\` so test-helper code does not skew the project coverage number reported by Codecov.

\`testing/\` exists to support other packages' tests; its own line coverage is just an artefact of which helpers happened to be exercised. Excluding it keeps the dashboard focused on production code.

The PR doesn't touch \`go test\` — local coverage runs are unaffected; only Codecov's report/PR comments change.

## Test plan
- [x] After merge, the next Codecov upload should drop \`testing/\` from the file list and recompute the project total

🤖 Generated with [Claude Code](https://claude.com/claude-code)