### PR TITLE
ci: also ignore top-level testing/*.go files in Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - "testing/**/*"
+  - "testing/*"


### PR DESCRIPTION
## Summary
The previous \`testing/**/*\` glob matched files in subdirectories (\`testing/state/foo.go\`, \`testing/fileinfo/foo.go\`) but **not** files directly inside \`testing/\` (\`testing/backend.go\`, \`testing/repository.go\`, etc.).

Codecov's API confirms 8 testing helper files are still in the report:

\`\`\`
testing/backend.go
testing/classifier.go
testing/context.go
testing/exporter.go
testing/importer.go
testing/repository.go
testing/snapshot.go
testing/storage.go
\`\`\`

These all sit at 0% local coverage (they're driven by tests in other packages with their own \`_test.go\` files) and drag the project number down.

Adds \`"testing/*"\` alongside \`"testing/**/*"\` so both the directory and its immediate children are excluded.

## Test plan
- [x] After merge, the next Codecov upload should drop the 8 \`testing/*.go\` files. Expected impact: project coverage rises from 71.43% to ~74%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)