### PR TITLE
locate: add -group-by option

### DIFF
--- a/locate/dataset_test.go
+++ b/locate/dataset_test.go
@@ -1,0 +1,394 @@
+package locate_test
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	loc "github.com/PlakarKorp/kloset/locate"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- ItemFilters helpers --------------------------------------------------
+
+func TestHasDataClass(t *testing.T) {
+	cases := []struct {
+		name   string
+		it     loc.ItemFilters
+		class  string
+		expect bool
+	}{
+		{"empty input matches", loc.ItemFilters{DataClasses: []string{"pii"}}, "", true},
+		{"missing class", loc.ItemFilters{DataClasses: []string{"pii"}}, "phi", false},
+		{"present class", loc.ItemFilters{DataClasses: []string{"pii", "phi"}}, "phi", true},
+		{"nil classes", loc.ItemFilters{}, "pii", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expect, tc.it.HasDataClass(tc.class))
+		})
+	}
+}
+
+func TestHasDataClasses(t *testing.T) {
+	it := loc.ItemFilters{DataClasses: []string{"pii", "phi"}}
+	require.True(t, it.HasDataClasses(nil), "no classes requested ⇒ match")
+	require.True(t, it.HasDataClasses([]string{}), "empty classes requested ⇒ match")
+	require.True(t, it.HasDataClasses([]string{"phi"}), "any-match semantics: present")
+	require.True(t, it.HasDataClasses([]string{"phi", "secret"}), "any-match: at least one present")
+	require.False(t, it.HasDataClasses([]string{"secret"}), "all absent ⇒ no match")
+	require.False(t, loc.ItemFilters{}.HasDataClasses([]string{"pii"}), "nil item classes ⇒ no match")
+}
+
+// ---- Options & flag plumbing ----------------------------------------------
+
+func TestWithDataset(t *testing.T) {
+	got := loc.NewDefaultLocateOptions(loc.WithDataset("customers"))
+	require.Equal(t, "customers", got.Filters.Dataset)
+}
+
+func TestWithDataClassAppends(t *testing.T) {
+	got := loc.NewDefaultLocateOptions(loc.WithDataClass("pii"), loc.WithDataClass("phi"))
+	require.Equal(t, []string{"pii", "phi"}, got.Filters.DataClasses)
+}
+
+func TestEmptyConsidersDatasetAndDataClass(t *testing.T) {
+	lo := &loc.LocateOptions{}
+	require.True(t, lo.Empty())
+
+	lo.Filters.Dataset = "customers"
+	require.False(t, lo.Empty())
+	lo.Filters.Dataset = ""
+
+	lo.Filters.DataClasses = []string{"pii"}
+	require.False(t, lo.Empty())
+}
+
+func TestInstallLocateFlagsDataset(t *testing.T) {
+	lo := &loc.LocateOptions{}
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	lo.InstallLocateFlags(fs)
+	require.NoError(t, fs.Parse([]string{"-dataset", "customers"}))
+	require.Equal(t, "customers", lo.Filters.Dataset)
+}
+
+func TestInstallLocateFlagsDataClassRepeatAndCSV(t *testing.T) {
+	lo := &loc.LocateOptions{}
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	lo.InstallLocateFlags(fs)
+	require.NoError(t, fs.Parse([]string{
+		"-data-class", "pii",
+		"-data-class", "phi,secret",
+	}))
+	require.Equal(t, []string{"pii", "phi", "secret"}, lo.Filters.DataClasses)
+}
+
+func TestInstallLocateFlagsDataClassIgnoresBlanks(t *testing.T) {
+	lo := &loc.LocateOptions{}
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	lo.InstallLocateFlags(fs)
+	require.NoError(t, fs.Parse([]string{"-data-class", " , pii ,  "}))
+	require.Equal(t, []string{"pii"}, lo.Filters.DataClasses)
+}
+
+func TestInstallLocateFlagsGroupByDataset(t *testing.T) {
+	lo := &loc.LocateOptions{}
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	lo.InstallLocateFlags(fs)
+	require.NoError(t, fs.Parse([]string{"-group-by", "dataset"}))
+	require.Equal(t, loc.GroupByDataset, lo.GroupBy)
+}
+
+func TestInstallLocateFlagsGroupByDataClass(t *testing.T) {
+	lo := &loc.LocateOptions{}
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	lo.InstallLocateFlags(fs)
+	require.NoError(t, fs.Parse([]string{"-group-by", "data-class"}))
+	require.Equal(t, loc.GroupByDataClass, lo.GroupBy)
+}
+
+// ---- Filtering behaviour --------------------------------------------------
+
+func TestMatchesFilterDataset(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Dataset: "customers"}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Dataset: "orders"}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{}},
+	}
+	lo := &loc.LocateOptions{Filters: loc.LocateFilters{Dataset: "customers"}}
+	kept, _ := lo.Match(items, now)
+	require.Len(t, kept, 1)
+	require.Contains(t, kept, mac(1))
+}
+
+// Dataset is single-valued: empty filter is a no-op, non-empty filter matches
+// exactly and rejects items whose dataset is unset.
+func TestMatchesFilterDatasetEmptyOnItem(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Dataset: ""}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Dataset: "customers"}},
+	}
+	// no filter ⇒ both kept
+	kept, _ := (&loc.LocateOptions{}).Match(items, now)
+	require.Len(t, kept, 2)
+	// filter on a specific dataset ⇒ only that item
+	kept, _ = (&loc.LocateOptions{Filters: loc.LocateFilters{Dataset: "customers"}}).Match(items, now)
+	require.Len(t, kept, 1)
+	require.Contains(t, kept, mac(2))
+}
+
+// -data-class is any-match across the requested classes (matches if the item
+// has any one of them), mirroring -origin and -type. AND across classes is
+// not supported, by design — match the existing convention.
+func TestMatchesFilterDataClassAnyMatch(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{DataClasses: []string{"pii"}}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{DataClasses: []string{"phi", "secret"}}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{DataClasses: []string{"public"}}},
+		{ItemID: mac(4), Timestamp: now.Add(-4 * time.Hour), Filters: loc.ItemFilters{}}, // no classes
+	}
+
+	// single class
+	kept, _ := (&loc.LocateOptions{Filters: loc.LocateFilters{DataClasses: []string{"phi"}}}).Match(items, now)
+	require.Len(t, kept, 1)
+	require.Contains(t, kept, mac(2))
+
+	// two classes ⇒ items 1 and 2 match (any-match)
+	kept, _ = (&loc.LocateOptions{Filters: loc.LocateFilters{DataClasses: []string{"pii", "phi"}}}).Match(items, now)
+	require.Len(t, kept, 2)
+	require.Contains(t, kept, mac(1))
+	require.Contains(t, kept, mac(2))
+
+	// class no one carries
+	kept, _ = (&loc.LocateOptions{Filters: loc.LocateFilters{DataClasses: []string{"nope"}}}).Match(items, now)
+	require.Empty(t, kept)
+}
+
+// Combined Dataset + DataClasses are intersected with each other and with
+// the rest of the filters (perimeter, tag, ...).
+func TestMatchesFilterDatasetAndDataClassCombined(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour),
+			Filters: loc.ItemFilters{Dataset: "customers", DataClasses: []string{"pii"}, Perimeter: "foo"}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour),
+			Filters: loc.ItemFilters{Dataset: "customers", DataClasses: []string{"public"}, Perimeter: "foo"}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour),
+			Filters: loc.ItemFilters{Dataset: "orders", DataClasses: []string{"pii"}, Perimeter: "foo"}},
+		{ItemID: mac(4), Timestamp: now.Add(-4 * time.Hour),
+			Filters: loc.ItemFilters{Dataset: "customers", DataClasses: []string{"pii"}, Perimeter: "other"}},
+	}
+	lo := &loc.LocateOptions{Filters: loc.LocateFilters{
+		Dataset:     "customers",
+		DataClasses: []string{"pii"},
+		Perimeter:   "foo",
+	}}
+	kept, _ := lo.Match(items, now)
+	require.Len(t, kept, 1)
+	require.Contains(t, kept, mac(1))
+}
+
+// ---- Grouping behaviour ---------------------------------------------------
+
+// -group-by dataset is single-valued: each snapshot lands in exactly one
+// bucket; retention runs independently in each.
+func TestMatchGroupByDataset(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(0x11), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Dataset: "customers"}},
+		{ItemID: mac(0x12), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Dataset: "customers"}},
+		{ItemID: mac(0x21), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{Dataset: "orders"}},
+		{ItemID: mac(0x22), Timestamp: now.Add(-4 * time.Hour), Filters: loc.ItemFilters{Dataset: "orders"}},
+	}
+	periods := loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}}
+
+	flat, _ := (&loc.LocateOptions{Periods: periods}).Match(items, now)
+	require.Len(t, flat, 1, "without -group-by, retention keeps only the global newest")
+	require.Contains(t, flat, mac(0x11))
+
+	grouped, reasons := (&loc.LocateOptions{Periods: periods, GroupBy: loc.GroupByDataset}).Match(items, now)
+	require.Len(t, grouped, 2)
+	require.Contains(t, grouped, mac(0x11))
+	require.Contains(t, grouped, mac(0x21))
+	require.Equal(t, "delete", reasons[mac(0x12)].Action)
+	require.Equal(t, "delete", reasons[mac(0x22)].Action)
+}
+
+// Items without a Dataset fall into the empty "" bucket together.
+func TestMatchGroupByDatasetEmptyBucket(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{Dataset: "customers"}},
+	}
+	lo := &loc.LocateOptions{
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+		GroupBy: loc.GroupByDataset,
+	}
+	kept, _ := lo.Match(items, now)
+	require.Len(t, kept, 2)
+	require.Contains(t, kept, mac(1)) // newest of "" bucket
+	require.Contains(t, kept, mac(3)) // alone in "customers"
+	require.NotContains(t, kept, mac(2))
+}
+
+// -group-by data-class is multi-valued: an item with multiple data classes
+// participates in every group it belongs to (fan-out).
+func TestMatchGroupByDataClassFanout(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		// newest in both pii and phi
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"pii", "phi"}}},
+		// older pii
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"pii"}}},
+		// older phi
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"phi"}}},
+	}
+	lo := &loc.LocateOptions{
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+		GroupBy: loc.GroupByDataClass,
+	}
+	kept, reasons := lo.Match(items, now)
+	require.Contains(t, kept, mac(1))
+	require.NotContains(t, kept, mac(2))
+	require.NotContains(t, kept, mac(3))
+	require.Equal(t, "keep", reasons[mac(1)].Action)
+	require.Equal(t, "delete", reasons[mac(2)].Action)
+	require.Equal(t, "delete", reasons[mac(3)].Action)
+}
+
+// Fan-out keep-wins: an item dropped in one class but kept in another ends
+// up "keep" in the flattened result.
+func TestMatchGroupByDataClassKeepWins(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		// newest in pii on day -1, also tagged phi
+		{ItemID: mac(1), Timestamp: now.Add(-1 * 24 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"pii", "phi"}}},
+		// in pii only, same day → loses in pii under item 1
+		{ItemID: mac(2), Timestamp: now.Add(-1*24*time.Hour - 1*time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"pii"}}},
+		// alone in its own phi day
+		{ItemID: mac(3), Timestamp: now.Add(-2 * 24 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"phi"}}},
+	}
+	lo := &loc.LocateOptions{
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 3, Cap: 1}},
+		GroupBy: loc.GroupByDataClass,
+	}
+	kept, reasons := lo.Match(items, now)
+	require.Contains(t, kept, mac(1))
+	require.NotContains(t, kept, mac(2))
+	require.Contains(t, kept, mac(3))
+	require.Equal(t, "keep", reasons[mac(1)].Action)
+	require.Equal(t, "delete", reasons[mac(2)].Action)
+	require.Equal(t, "keep", reasons[mac(3)].Action)
+}
+
+// Items with no data class fall into the "" bucket together when
+// grouping by data-class.
+func TestMatchGroupByDataClassNoClassesBucket(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{DataClasses: []string{"pii"}}},
+	}
+	lo := &loc.LocateOptions{
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+		GroupBy: loc.GroupByDataClass,
+	}
+	kept, _ := lo.Match(items, now)
+	require.Len(t, kept, 2)
+	require.Contains(t, kept, mac(1)) // newest of "" bucket
+	require.Contains(t, kept, mac(3))
+	require.NotContains(t, kept, mac(2))
+}
+
+// Filter-then-group-then-retain ordering must hold for the new keys.
+func TestMatchFiltersFirstThenGroupByDataset(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		// kept by perimeter filter
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour),
+			Filters: loc.ItemFilters{Dataset: "customers", Perimeter: "foo"}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour),
+			Filters: loc.ItemFilters{Dataset: "orders", Perimeter: "foo"}},
+		// dropped by perimeter filter (would otherwise be newest of "customers")
+		{ItemID: mac(3), Timestamp: now,
+			Filters: loc.ItemFilters{Dataset: "customers", Perimeter: "other"}},
+	}
+	lo := &loc.LocateOptions{
+		Filters: loc.LocateFilters{Perimeter: "foo"},
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+		GroupBy: loc.GroupByDataset,
+	}
+	kept, _ := lo.Match(items, now)
+	require.Len(t, kept, 2)
+	require.Contains(t, kept, mac(1))
+	require.Contains(t, kept, mac(2))
+	require.NotContains(t, kept, mac(3), "filter must run before grouping")
+}
+
+// Combine -data-class filter with -group-by data-class: filter narrows
+// the universe, then grouping/retention runs only over the survivors and
+// only over the classes that still appear.
+func TestMatchFilterDataClassThenGroupByDataClass(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		// matches the pii filter; also belongs to phi
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"pii", "phi"}}},
+		// matches the pii filter, pii only
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"pii"}}},
+		// dropped by filter
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour),
+			Filters: loc.ItemFilters{DataClasses: []string{"public"}}},
+	}
+	lo := &loc.LocateOptions{
+		Filters: loc.LocateFilters{DataClasses: []string{"pii"}},
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+		GroupBy: loc.GroupByDataClass,
+	}
+	kept, _ := lo.Match(items, now)
+	// item 1 wins both pii and phi groups (newest); item 2 capped out in pii;
+	// item 3 filtered out.
+	require.Len(t, kept, 1)
+	require.Contains(t, kept, mac(1))
+}
+
+// Without periods, group-by dataset/data-class is a no-op (all filtered
+// items kept) — same property already covered for the other keys.
+func TestMatchGroupByDatasetNoOpWithoutPeriods(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Dataset: "customers"}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Dataset: "orders"}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{}},
+	}
+	flat, _ := (&loc.LocateOptions{}).Match(items, now)
+	grouped, _ := (&loc.LocateOptions{GroupBy: loc.GroupByDataset}).Match(items, now)
+	require.Equal(t, flat, grouped)
+	require.Len(t, grouped, 3)
+}
+
+func TestMatchGroupByDataClassNoOpWithoutPeriods(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{DataClasses: []string{"pii"}}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{DataClasses: []string{"phi"}}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{}},
+	}
+	flat, _ := (&loc.LocateOptions{}).Match(items, now)
+	grouped, _ := (&loc.LocateOptions{GroupBy: loc.GroupByDataClass}).Match(items, now)
+	require.Equal(t, flat, grouped)
+	require.Len(t, grouped, 3)
+}

--- a/locate/groupby_test.go
+++ b/locate/groupby_test.go
@@ -1,0 +1,287 @@
+package locate_test
+
+import (
+	"testing"
+	"time"
+
+	loc "github.com/PlakarKorp/kloset/locate"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/stretchr/testify/require"
+)
+
+func mac(b byte) objects.MAC {
+	var m objects.MAC
+	m[0] = b
+	return m
+}
+
+func TestWithGroupBy(t *testing.T) {
+	got := loc.NewDefaultLocateOptions(loc.WithGroupBy(loc.GroupByName))
+	require.Equal(t, loc.GroupByName, got.GroupBy)
+}
+
+func TestEmptyConsidersGroupBy(t *testing.T) {
+	lo := &loc.LocateOptions{}
+	require.True(t, lo.Empty())
+	lo.GroupBy = loc.GroupByName
+	require.False(t, lo.Empty())
+}
+
+// Without periods, GroupBy must not change which items are kept: every filtered
+// item is still kept regardless of grouping.
+func TestMatchGroupByWithoutPeriodsIsNoOp(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Name: "a"}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Name: "b"}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{Name: "a"}},
+	}
+
+	flat, _ := (&loc.LocateOptions{}).Match(items, now)
+	grouped, _ := (&loc.LocateOptions{GroupBy: loc.GroupByName}).Match(items, now)
+	require.Equal(t, flat, grouped)
+	require.Len(t, grouped, 3)
+}
+
+// Filters apply first, then grouping, then per-group retention.
+func TestMatchGroupByFiltersFirst(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		// kept by filter, group=alpha
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour),
+			Filters: loc.ItemFilters{Name: "alpha", Perimeter: "foo", Tags: []string{"bar"}}},
+		// kept by filter, group=beta
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour),
+			Filters: loc.ItemFilters{Name: "beta", Perimeter: "foo", Tags: []string{"bar"}}},
+		// filtered out (wrong perimeter), would otherwise be newest in alpha
+		{ItemID: mac(3), Timestamp: now,
+			Filters: loc.ItemFilters{Name: "alpha", Perimeter: "other", Tags: []string{"bar"}}},
+		// filtered out (missing tag)
+		{ItemID: mac(4), Timestamp: now,
+			Filters: loc.ItemFilters{Name: "beta", Perimeter: "foo"}},
+	}
+
+	lo := &loc.LocateOptions{
+		Filters: loc.LocateFilters{Perimeter: "foo", Tags: []string{"bar"}},
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+		GroupBy: loc.GroupByName,
+	}
+	kept, _ := lo.Match(items, now)
+
+	require.Len(t, kept, 2)
+	require.Contains(t, kept, mac(1))
+	require.Contains(t, kept, mac(2))
+	require.NotContains(t, kept, mac(3))
+	require.NotContains(t, kept, mac(4))
+}
+
+// Retention runs independently per group, not over the merged set.
+func TestMatchGroupByRetentionIsPerGroup(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(0x11), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Name: "alpha"}},
+		{ItemID: mac(0x12), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Name: "alpha"}},
+		{ItemID: mac(0x21), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{Name: "beta"}},
+		{ItemID: mac(0x22), Timestamp: now.Add(-4 * time.Hour), Filters: loc.ItemFilters{Name: "beta"}},
+		{ItemID: mac(0x31), Timestamp: now.Add(-5 * time.Hour), Filters: loc.ItemFilters{Name: "gamma"}},
+	}
+	periods := loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}}
+
+	flat, _ := (&loc.LocateOptions{Periods: periods}).Match(items, now)
+	require.Len(t, flat, 1)
+	require.Contains(t, flat, mac(0x11))
+
+	grouped, reasons := (&loc.LocateOptions{Periods: periods, GroupBy: loc.GroupByName}).Match(items, now)
+	require.Len(t, grouped, 3)
+	require.Contains(t, grouped, mac(0x11)) // newest of alpha
+	require.Contains(t, grouped, mac(0x21)) // newest of beta
+	require.Contains(t, grouped, mac(0x31)) // alone in gamma
+
+	require.Equal(t, "keep", reasons[mac(0x11)].Action)
+	require.Equal(t, "keep", reasons[mac(0x21)].Action)
+	require.Equal(t, "keep", reasons[mac(0x31)].Action)
+	require.Equal(t, "delete", reasons[mac(0x12)].Action)
+	require.Equal(t, "delete", reasons[mac(0x22)].Action)
+}
+
+// Each non-multi-valued GroupBy key buckets correctly.
+func TestMatchGroupByEachKey(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	mk := func(id byte, f loc.ItemFilters) loc.Item {
+		return loc.Item{ItemID: mac(id), Timestamp: now.Add(-time.Duration(id) * time.Hour), Filters: f}
+	}
+
+	cases := []struct {
+		name string
+		key  loc.GroupByKey
+		a, b loc.ItemFilters
+	}{
+		{"name", loc.GroupByName, loc.ItemFilters{Name: "x"}, loc.ItemFilters{Name: "y"}},
+		{"category", loc.GroupByCategory, loc.ItemFilters{Category: "x"}, loc.ItemFilters{Category: "y"}},
+		{"environment", loc.GroupByEnvironment, loc.ItemFilters{Environment: "x"}, loc.ItemFilters{Environment: "y"}},
+		{"perimeter", loc.GroupByPerimeter, loc.ItemFilters{Perimeter: "x"}, loc.ItemFilters{Perimeter: "y"}},
+		{"job", loc.GroupByJob, loc.ItemFilters{Job: "x"}, loc.ItemFilters{Job: "y"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			items := []loc.Item{
+				mk(1, tc.a), mk(2, tc.a), // same group
+				mk(3, tc.b), mk(4, tc.b), // same group
+			}
+			lo := &loc.LocateOptions{
+				Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+				GroupBy: tc.key,
+			}
+			kept, _ := lo.Match(items, now)
+			require.Len(t, kept, 2)
+			require.Contains(t, kept, mac(1))
+			require.Contains(t, kept, mac(3))
+		})
+	}
+}
+
+// Items with multi-valued fields (tag, origin, type, root) fan out: they
+// participate in retention in every group they belong to, and keep wins
+// over delete in the flattened reasons.
+func TestMatchGroupByFanout(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		key   loc.GroupByKey
+		setup func(b byte, vals ...string) loc.Item
+	}{
+		{"tag", loc.GroupByTag, func(b byte, v ...string) loc.Item {
+			return loc.Item{ItemID: mac(b), Timestamp: now.Add(-time.Duration(b) * time.Hour),
+				Filters: loc.ItemFilters{Tags: v}}
+		}},
+		{"origin", loc.GroupByOrigin, func(b byte, v ...string) loc.Item {
+			return loc.Item{ItemID: mac(b), Timestamp: now.Add(-time.Duration(b) * time.Hour),
+				Filters: loc.ItemFilters{Origins: v}}
+		}},
+		{"type", loc.GroupByType, func(b byte, v ...string) loc.Item {
+			return loc.Item{ItemID: mac(b), Timestamp: now.Add(-time.Duration(b) * time.Hour),
+				Filters: loc.ItemFilters{Types: v}}
+		}},
+		{"root", loc.GroupByRoot, func(b byte, v ...string) loc.Item {
+			return loc.Item{ItemID: mac(b), Timestamp: now.Add(-time.Duration(b) * time.Hour),
+				Filters: loc.ItemFilters{Roots: v}}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			items := []loc.Item{
+				// newest, belongs to both groups
+				tc.setup(1, "red", "blue"),
+				// in red only, older
+				tc.setup(2, "red"),
+				// in blue only, oldest
+				tc.setup(3, "blue"),
+			}
+			lo := &loc.LocateOptions{
+				Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+				GroupBy: tc.key,
+			}
+			kept, reasons := lo.Match(items, now)
+
+			// item 1 is newest in both groups so it wins both buckets;
+			// items 2 and 3 are each capped out by item 1.
+			require.Contains(t, kept, mac(1))
+			require.NotContains(t, kept, mac(2))
+			require.NotContains(t, kept, mac(3))
+			require.Equal(t, "keep", reasons[mac(1)].Action)
+			require.Equal(t, "delete", reasons[mac(2)].Action)
+			require.Equal(t, "delete", reasons[mac(3)].Action)
+		})
+	}
+}
+
+// An item that is dropped in one fanout group but kept in another must end
+// up "keep" in the flattened result.
+func TestMatchGroupByFanoutKeepWins(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		// newest in red, also tagged blue
+		{ItemID: mac(1), Timestamp: now.Add(-1 * 24 * time.Hour),
+			Filters: loc.ItemFilters{Tags: []string{"red", "blue"}}},
+		// in red only, same day as 1 → loses the red bucket
+		{ItemID: mac(2), Timestamp: now.Add(-1*24*time.Hour - 1*time.Hour),
+			Filters: loc.ItemFilters{Tags: []string{"red"}}},
+		// alone in its own blue day
+		{ItemID: mac(3), Timestamp: now.Add(-2 * 24 * time.Hour),
+			Filters: loc.ItemFilters{Tags: []string{"blue"}}},
+	}
+	lo := &loc.LocateOptions{
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 3, Cap: 1}},
+		GroupBy: loc.GroupByTag,
+	}
+	kept, reasons := lo.Match(items, now)
+
+	require.Contains(t, kept, mac(1))
+	require.NotContains(t, kept, mac(2))
+	require.Contains(t, kept, mac(3))
+	require.Equal(t, "keep", reasons[mac(1)].Action)
+	require.Equal(t, "delete", reasons[mac(2)].Action)
+	require.Equal(t, "keep", reasons[mac(3)].Action)
+}
+
+// Items missing the grouping field fall into the empty "" group together.
+func TestMatchGroupByMissingFieldBucketsAsEmpty(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{}},
+		{ItemID: mac(3), Timestamp: now.Add(-3 * time.Hour), Filters: loc.ItemFilters{Name: "alpha"}},
+	}
+	lo := &loc.LocateOptions{
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+		GroupBy: loc.GroupByName,
+	}
+	kept, _ := lo.Match(items, now)
+
+	require.Len(t, kept, 2)
+	require.Contains(t, kept, mac(1)) // newest of "" bucket
+	require.Contains(t, kept, mac(3)) // alone in alpha
+	require.NotContains(t, kept, mac(2))
+}
+
+// Latest interacts with grouping at filter time: it only keeps one item
+// overall (the global newest), so retention then never sees the others.
+func TestMatchGroupByLatestStillGlobal(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Name: "alpha"}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Name: "beta"}},
+	}
+	lo := &loc.LocateOptions{
+		Filters: loc.LocateFilters{Latest: true},
+		GroupBy: loc.GroupByName,
+	}
+	kept, _ := lo.Match(items, now)
+	require.Len(t, kept, 1)
+	require.Contains(t, kept, mac(1))
+}
+
+func TestMatchGroupByEmptyInput(t *testing.T) {
+	lo := &loc.LocateOptions{GroupBy: loc.GroupByName,
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}}}
+	kept, reasons := lo.Match(nil, time.Now())
+	require.Empty(t, kept)
+	require.Empty(t, reasons)
+}
+
+func TestMatchGroupByUnknownKeyFallsBack(t *testing.T) {
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	items := []loc.Item{
+		{ItemID: mac(1), Timestamp: now.Add(-1 * time.Hour), Filters: loc.ItemFilters{Name: "alpha"}},
+		{ItemID: mac(2), Timestamp: now.Add(-2 * time.Hour), Filters: loc.ItemFilters{Name: "beta"}},
+	}
+	lo := &loc.LocateOptions{
+		GroupBy: loc.GroupByKey("not-a-key"),
+		Periods: loc.LocatePeriods{Day: loc.LocatePeriod{Keep: 1, Cap: 1}},
+	}
+	kept, _ := lo.Match(items, now)
+	require.Len(t, kept, 1)
+	require.Contains(t, kept, mac(1))
+}

--- a/locate/install.go
+++ b/locate/install.go
@@ -2,6 +2,7 @@ package locate
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 )
 
@@ -47,6 +48,19 @@ func (po *LocateOptions) installGenericFlags(flags *flag.FlagSet) {
 				}
 			}
 			return nil
+		})
+
+	flags.Func("group-by", "group results by key: name, category, environment, perimeter, job, tag, origin, type, root.",
+		func(v string) error {
+			switch k := GroupByKey(strings.TrimSpace(v)); k {
+			case GroupByNone, GroupByName, GroupByCategory, GroupByEnvironment,
+				GroupByPerimeter, GroupByJob, GroupByTag, GroupByOrigin,
+				GroupByType, GroupByRoot:
+				po.GroupBy = k
+				return nil
+			default:
+				return fmt.Errorf("invalid -group-by value %q", v)
+			}
 		})
 
 	flags.Func("tag", "filter by tag (repeat or comma-separated). All specified tags must be present.",

--- a/locate/install.go
+++ b/locate/install.go
@@ -15,7 +15,19 @@ func (po *LocateOptions) installGenericFlags(flags *flag.FlagSet) {
 	flags.StringVar(&po.Filters.Environment, "environment", "", "filter by environment")
 	flags.StringVar(&po.Filters.Perimeter, "perimeter", "", "filter by perimeter")
 	flags.StringVar(&po.Filters.Job, "job", "", "filter by job")
+	flags.StringVar(&po.Filters.Dataset, "dataset", "", "filter by dataset")
 	flags.BoolVar(&po.Filters.Latest, "latest", false, "consider only the latest matching item")
+
+	flags.Func("data-class", "filter by data class (repeat or comma-separated).",
+		func(v string) error {
+			for _, t := range strings.Split(v, ",") {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					po.Filters.DataClasses = append(po.Filters.DataClasses, t)
+				}
+			}
+			return nil
+		})
 
 	flags.Func("root", "filter by root (repeat).",
 		func(v string) error {
@@ -50,12 +62,12 @@ func (po *LocateOptions) installGenericFlags(flags *flag.FlagSet) {
 			return nil
 		})
 
-	flags.Func("group-by", "group results by key: name, category, environment, perimeter, job, tag, origin, type, root.",
+	flags.Func("group-by", "group results by key: name, category, environment, perimeter, job, dataset, data-class, tag, origin, type, root.",
 		func(v string) error {
 			switch k := GroupByKey(strings.TrimSpace(v)); k {
 			case GroupByNone, GroupByName, GroupByCategory, GroupByEnvironment,
-				GroupByPerimeter, GroupByJob, GroupByTag, GroupByOrigin,
-				GroupByType, GroupByRoot:
+				GroupByPerimeter, GroupByJob, GroupByDataset, GroupByDataClass,
+				GroupByTag, GroupByOrigin, GroupByType, GroupByRoot:
 				po.GroupBy = k
 				return nil
 			default:

--- a/locate/locate.go
+++ b/locate/locate.go
@@ -161,9 +161,25 @@ type LocatePeriods struct {
 	Sunday    LocatePeriod `json:"sunday,omitzero" yaml:"sunday,omitempty"`
 }
 
+type GroupByKey string
+
+const (
+	GroupByNone        GroupByKey = ""
+	GroupByName        GroupByKey = "name"
+	GroupByCategory    GroupByKey = "category"
+	GroupByEnvironment GroupByKey = "environment"
+	GroupByPerimeter   GroupByKey = "perimeter"
+	GroupByJob         GroupByKey = "job"
+	GroupByTag         GroupByKey = "tag"
+	GroupByOrigin      GroupByKey = "origin"
+	GroupByType        GroupByKey = "type"
+	GroupByRoot        GroupByKey = "root"
+)
+
 type LocateOptions struct {
 	Filters LocateFilters `json:"filters,omitzero" yaml:"filters,omitempty"`
 	Periods LocatePeriods `json:"periods,omitzero" yaml:"periods,omitempty"`
+	GroupBy GroupByKey    `json:"group_by,omitempty" yaml:"group_by,omitempty"`
 }
 
 func (lo *LocateOptions) HasPeriods() bool {
@@ -246,6 +262,9 @@ func WithID(id string) Option {
 	return func(p *LocateOptions) { p.Filters.IDs = append(p.Filters.IDs, id) }
 }
 func WithLatest(latest bool) Option { return func(p *LocateOptions) { p.Filters.Latest = latest } }
+func WithGroupBy(key GroupByKey) Option {
+	return func(p *LocateOptions) { p.GroupBy = key }
+}
 
 func (lo *LocateOptions) Matches(it Item) bool {
 	if len(lo.Filters.IDs) > 0 {
@@ -328,18 +347,80 @@ func (lo *LocateOptions) FilterAndSort(items []Item) []Item {
 
 func (lo *LocateOptions) Match(items []Item, now time.Time) (map[objects.MAC]struct{}, map[objects.MAC]Reason) {
 	now = now.UTC()
-
 	filtered := lo.FilterAndSort(items)
+
+	if lo.GroupBy == GroupByNone {
+		return lo.applyPeriods(filtered, now)
+	}
+
+	groups := make(map[string][]Item)
+	for _, it := range filtered {
+		for _, k := range lo.groupKeys(it) {
+			groups[k] = append(groups[k], it)
+		}
+	}
 
 	kept := make(map[objects.MAC]struct{}, len(filtered))
 	reasons := make(map[objects.MAC]Reason, len(filtered))
+	for _, gitems := range groups {
+		gk, gr := lo.applyPeriods(gitems, now)
+		for id := range gk {
+			kept[id] = struct{}{}
+		}
+		for id, r := range gr {
+			if prev, ok := reasons[id]; !ok || (prev.Action == "delete" && r.Action == "keep") {
+				reasons[id] = r
+			}
+		}
+	}
+	return kept, reasons
+}
 
-	// nothing matched, no need to go further
+func (lo *LocateOptions) groupKeys(it Item) []string {
+	switch lo.GroupBy {
+	case GroupByName:
+		return []string{it.Filters.Name}
+	case GroupByCategory:
+		return []string{it.Filters.Category}
+	case GroupByEnvironment:
+		return []string{it.Filters.Environment}
+	case GroupByPerimeter:
+		return []string{it.Filters.Perimeter}
+	case GroupByJob:
+		return []string{it.Filters.Job}
+	case GroupByTag:
+		if len(it.Filters.Tags) == 0 {
+			return []string{""}
+		}
+		return it.Filters.Tags
+	case GroupByOrigin:
+		if len(it.Filters.Origins) == 0 {
+			return []string{""}
+		}
+		return it.Filters.Origins
+	case GroupByType:
+		if len(it.Filters.Types) == 0 {
+			return []string{""}
+		}
+		return it.Filters.Types
+	case GroupByRoot:
+		if len(it.Filters.Roots) == 0 {
+			return []string{""}
+		}
+		return it.Filters.Roots
+	default:
+		return []string{""}
+	}
+}
+
+func (lo *LocateOptions) applyPeriods(filtered []Item, now time.Time) (map[objects.MAC]struct{}, map[objects.MAC]Reason) {
+	kept := make(map[objects.MAC]struct{}, len(filtered))
+	reasons := make(map[objects.MAC]Reason, len(filtered))
+
 	if len(filtered) == 0 {
 		return kept, reasons
 	}
 
-	// we won't group by periods
 	if !lo.HasPeriods() {
 		for _, s := range filtered {
 			id := s.ItemID
@@ -454,5 +535,6 @@ func (lo *LocateOptions) Empty() bool {
 		lo.Filters.Name == "" && lo.Filters.Category == "" && lo.Filters.Environment == "" &&
 		lo.Filters.Perimeter == "" && lo.Filters.Job == "" &&
 		len(lo.Filters.Tags) == 0 && len(lo.Filters.IDs) == 0 && len(lo.Filters.Roots) == 0 &&
-		lo.Filters.Before.IsZero() && lo.Filters.Since.IsZero() && !lo.Filters.Latest
+		lo.Filters.Before.IsZero() && lo.Filters.Since.IsZero() && !lo.Filters.Latest &&
+		lo.GroupBy == GroupByNone
 }

--- a/locate/locate.go
+++ b/locate/locate.go
@@ -32,10 +32,12 @@ type ItemFilters struct {
 	Environment string
 	Perimeter   string
 	Job         string
+	Dataset     string
 	Tags        []string
 	Types       []string
 	Origins     []string
 	Roots       []string
+	DataClasses []string
 }
 
 func (it *ItemFilters) HasTag(tag string) bool {
@@ -98,6 +100,30 @@ func (it ItemFilters) HasTypes(types []string) bool {
 	return false
 }
 
+func (it ItemFilters) HasDataClass(class string) bool {
+	if class == "" {
+		return true
+	}
+	for _, c := range it.DataClasses {
+		if c == class {
+			return true
+		}
+	}
+	return false
+}
+
+func (it ItemFilters) HasDataClasses(classes []string) bool {
+	if len(classes) == 0 {
+		return true
+	}
+	for _, c := range classes {
+		if it.HasDataClass(c) {
+			return true
+		}
+	}
+	return false
+}
+
 func (it ItemFilters) HasRoot(root string) bool {
 	if root == "" {
 		return true
@@ -134,14 +160,16 @@ type LocateFilters struct {
 	Environment string   `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Perimeter   string   `json:"perimeter,omitempty" yaml:"perimeter,omitempty"`
 	Job         string   `json:"job,omitempty" yaml:"job,omitempty"`
+	Dataset     string   `json:"dataset,omitempty" yaml:"dataset,omitempty"`
 	Tags        []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	IgnoreTags  []string `json:"ignore_tags,omitempty" yaml:"ignore_tags,omitempty"`
 
-	Latest  bool     `json:"latest,omitempty" yaml:"latest,omitempty"` // if true, consider only the latest matching item
-	IDs     []string `json:"ids,omitempty" yaml:"ids,omitempty"`
-	Types   []string `json:"types,omitempty" yaml:"types,omitempty"`
-	Origins []string `json:"origins,omitempty" yaml:"origins,omitempty"`
-	Roots   []string `json:"roots,omitempty" yaml:"roots,omitempty"`
+	Latest      bool     `json:"latest,omitempty" yaml:"latest,omitempty"` // if true, consider only the latest matching item
+	IDs         []string `json:"ids,omitempty" yaml:"ids,omitempty"`
+	Types       []string `json:"types,omitempty" yaml:"types,omitempty"`
+	Origins     []string `json:"origins,omitempty" yaml:"origins,omitempty"`
+	Roots       []string `json:"roots,omitempty" yaml:"roots,omitempty"`
+	DataClasses []string `json:"data_classes,omitempty" yaml:"data_classes,omitempty"`
 }
 
 type LocatePeriods struct {
@@ -170,6 +198,8 @@ const (
 	GroupByEnvironment GroupByKey = "environment"
 	GroupByPerimeter   GroupByKey = "perimeter"
 	GroupByJob         GroupByKey = "job"
+	GroupByDataset     GroupByKey = "dataset"
+	GroupByDataClass   GroupByKey = "data-class"
 	GroupByTag         GroupByKey = "tag"
 	GroupByOrigin      GroupByKey = "origin"
 	GroupByType        GroupByKey = "type"
@@ -252,6 +282,12 @@ func WithPerimeter(perimeter string) Option {
 func WithJob(job string) Option {
 	return func(p *LocateOptions) { p.Filters.Job = job }
 }
+func WithDataset(dataset string) Option {
+	return func(p *LocateOptions) { p.Filters.Dataset = dataset }
+}
+func WithDataClass(class string) Option {
+	return func(p *LocateOptions) { p.Filters.DataClasses = append(p.Filters.DataClasses, class) }
+}
 func WithTag(tag string) Option {
 	return func(p *LocateOptions) { p.Filters.Tags = append(p.Filters.Tags, tag) }
 }
@@ -302,6 +338,12 @@ func (lo *LocateOptions) Matches(it Item) bool {
 		return false
 	}
 	if lo.Filters.Job != "" && it.Filters.Job != lo.Filters.Job {
+		return false
+	}
+	if lo.Filters.Dataset != "" && it.Filters.Dataset != lo.Filters.Dataset {
+		return false
+	}
+	if !it.Filters.HasDataClasses(lo.Filters.DataClasses) {
 		return false
 	}
 	for _, tag := range lo.Filters.IgnoreTags {
@@ -388,6 +430,13 @@ func (lo *LocateOptions) groupKeys(it Item) []string {
 		return []string{it.Filters.Perimeter}
 	case GroupByJob:
 		return []string{it.Filters.Job}
+	case GroupByDataset:
+		return []string{it.Filters.Dataset}
+	case GroupByDataClass:
+		if len(it.Filters.DataClasses) == 0 {
+			return []string{""}
+		}
+		return it.Filters.DataClasses
 	case GroupByTag:
 		if len(it.Filters.Tags) == 0 {
 			return []string{""}
@@ -533,8 +582,9 @@ func (lo *LocateOptions) applyPeriods(filtered []Item, now time.Time) (map[objec
 func (lo *LocateOptions) Empty() bool {
 	return !lo.HasPeriods() &&
 		lo.Filters.Name == "" && lo.Filters.Category == "" && lo.Filters.Environment == "" &&
-		lo.Filters.Perimeter == "" && lo.Filters.Job == "" &&
+		lo.Filters.Perimeter == "" && lo.Filters.Job == "" && lo.Filters.Dataset == "" &&
 		len(lo.Filters.Tags) == 0 && len(lo.Filters.IDs) == 0 && len(lo.Filters.Roots) == 0 &&
+		len(lo.Filters.DataClasses) == 0 &&
 		lo.Filters.Before.IsZero() && lo.Filters.Since.IsZero() && !lo.Filters.Latest &&
 		lo.GroupBy == GroupByNone
 }

--- a/locate/snapshots.go
+++ b/locate/snapshots.go
@@ -106,10 +106,12 @@ func buildPolicyItems(repo *repository.Repository) []Item {
 					Environment: h.Environment,
 					Perimeter:   h.Perimeter,
 					Job:         h.Job,
+					Dataset:     h.Dataset,
 					Tags:        h.Tags,
 					Types:       types,
 					Origins:     origins,
 					Roots:       roots,
+					DataClasses: h.DataClasses,
 				},
 			}
 


### PR DESCRIPTION
## Summary

Adds a `-group-by` option to `LocateOptions`. Filtering runs first, then results are partitioned by the chosen key, then retention rules apply independently within each group.

Useful for retention policies like "keep the newest snapshot per name" — without `-group-by`, `-days 1 -per-day 1` keeps a single snapshot across the whole result; with `-group-by name`, it keeps the newest of each name.

Supported keys: `name`, `category`, `environment`, `perimeter`, `job`, `dataset`, `data-class`, `tag`, `origin`, `type`, `root`. Multi-valued keys (tag/origin/type/root/data-class) fan out: an item participates in every group it belongs to, and keep wins over delete when flattening.

Wired into all callers transparently via `opts.Match`. A small companion change in plakar's `prune` is needed so the parsed flag isn't dropped by `mergePolicyOptions` (PlakarKorp/plakar#2162).

### Commits

- `locate: add a -group-by option` — the core change
- `locate: extend filters and -group-by with dataset and data classes` — picks up the `Dataset`/`DataClasses` fields added in 4cf3d58b; adds `-dataset` and `-data-class` flags

## Test plan

- [x] `go test ./locate/` — covers no-op without periods, filter-then-group order, per-group retention vs flat retention, each single-valued key, fanout across multi-valued keys, keep-wins-over-delete on fanout, missing-field bucketing, `-latest` interaction, empty input, unknown key fallback; the dataset/data-class commit adds flag parsing, filtering, fan-out grouping and integration tests
- [x] `go test ./...` green
- [x] Exercised end-to-end against a real repo with `ls` and `prune -apply`