### PR TITLE
PoolpOrg/add missing header fields

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+
 ignore:
   - "testing/**/*"
   - "testing/*"

--- a/snapshot/header/header.go
+++ b/snapshot/header/header.go
@@ -89,6 +89,8 @@ type Header struct {
 	Perimeter       string             `msgpack:"perimeter" json:"perimeter"`
 	Job             string             `msgpack:"job" json:"job"`
 	Replicas        uint32             `msgpack:"replicas" json:"replicas"`
+	Dataset         string             `msgpack:"dataset" json:"dataset"`
+	DataClasses     []string           `msgpack:"data_classes" json:"data_classes"`
 	Classifications []Classification   `msgpack:"classifications" json:"classifications"`
 	Tags            []string           `msgpack:"tags" json:"tags"`
 	Context         []KeyValue         `msgpack:"context" json:"context"`
@@ -106,6 +108,7 @@ func NewHeader(name string, identifier objects.MAC) *Header {
 		Perimeter:       "default",
 		Job:             "default",
 		Replicas:        1,
+		DataClasses:     []string{},
 		Classifications: []Classification{},
 		Tags:            []string{},
 


### PR DESCRIPTION
dataset header field allows providing a generic dataset identifier to identify a snapshot, could be a sourceId in control plane, the UUID of a specific dataset in a different system, generic field that can be used specifically by different wrapping applications.

data classes header field allows attaching ... data classes to a snapshot, this is different from category (ie; category=system, data_classes=["finance", "health"], ...)

This is in the blocking path of control plane, please review and approve timely