### PR TITLE
packfile_disk: Switch timestamp to nanosecond.

### DIFF
--- a/packfile/packfile_disk.go
+++ b/packfile/packfile_disk.go
@@ -40,7 +40,7 @@ func NewPackfileOnDisk(tempDir string, hf HashFactory) (Packfile, error) {
 		bufferedWriter:  bufio.NewWriterSize(f, 1<<20),
 		totalHash:       hf(),
 		hf:              hf,
-		footerTimestamp: time.Now().Unix(),
+		footerTimestamp: time.Now().UnixNano(),
 	}
 	p.combinedWriter = io.MultiWriter(p.bufferedWriter, p.totalHash)
 


### PR DESCRIPTION
* The first packfile implementation was in-memory and used time.Now().UnixNano(), which lead consummers (maitenance in plakar especially) to deserialize those using time.Unix(0, val) aka expecting it to be nanoseconds epoch.

* This in turns mean that any comparison with that time will be false as it ends up being EPOCH basically.

* note on impact: This is used in detection of concurrent packfiles with maintenance which right now is totally blocked by locks so we are fine.