### PR TITLE
builder: Do not fail if we have a stale lock.

### DIFF
--- a/snapshot/builder.go
+++ b/snapshot/builder.go
@@ -282,6 +282,8 @@ func (snap *Builder) Lock() (chan bool, error) {
 				snap.repository.DeleteLock(snap.Header.Identifier)
 				return nil, err
 			}
+
+			continue
 		}
 
 		// There is an exclusive lock in place, we need to abort.


### PR DESCRIPTION
* If we find a stale lock and kick it out, we need to continue the loop not fallthrough.