### PR TITLE
packer_seq: RT_OBJECTS should be pinned.

### DIFF
--- a/repository/packer/packer_seq.go
+++ b/repository/packer/packer_seq.go
@@ -228,7 +228,7 @@ func (mgr *seqPackerManager) Put(hint int, Type resources.Type, mac objects.MAC,
 
 	var i int
 	switch {
-	case Type != resources.RT_OBJECT && Type != resources.RT_CHUNK:
+	case Type != resources.RT_CHUNK:
 		i = mgr.nChan - 1
 	case hint == -1:
 		i = randv2.IntN(mgr.nChan - 1)


### PR DESCRIPTION
* It's not that they should be pinned it's mostly that we don't want them alongside RT_CHUNK. It's in the way for the GLACIER support (aka only the RT_CHUNK packfiles can be kept on cold storage only, the rest needs to have a hot copy).