### PR TITLE
feat: wire dataset and data-classes to the builder

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -69,6 +69,8 @@ type BuilderOptions struct {
 	Environment     string
 	Perimeter       string
 	Job             string
+	Dataset         string
+	DataClasses     []string
 	NoCheckpoint    bool
 	NoCommit        bool
 	NoXattr         bool

--- a/snapshot/builder.go
+++ b/snapshot/builder.go
@@ -101,6 +101,8 @@ func newBuilder(appContext *kcontext.KContext, identifier objects.MAC, builderOp
 	snap.Header.Environment = builderOptions.Environment
 	snap.Header.Perimeter = builderOptions.Perimeter
 	snap.Header.Job = builderOptions.Job
+	snap.Header.Dataset = builderOptions.Dataset
+	snap.Header.DataClasses = append(snap.Header.DataClasses, builderOptions.DataClasses...)
 
 	return snap, nil
 }

--- a/snapshot/builder_test.go
+++ b/snapshot/builder_test.go
@@ -1,0 +1,46 @@
+package snapshot_test
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilderOptionsDatasetAndDataClasses(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	builder, err := snapshot.Create(repo, repository.DefaultType, "", objects.NilMac, &snapshot.BuilderOptions{
+		Name:         "dataset-test",
+		Dataset:      "a1b2c3d4-0000-0000-0000-000000000001",
+		DataClasses:  []string{"pii", "phi"},
+		NoCheckpoint: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, builder)
+	err = builder.Close()
+	require.NoError(t, err)
+
+	require.Equal(t, "a1b2c3d4-0000-0000-0000-000000000001", builder.Header.Dataset)
+	require.Equal(t, []string{"pii", "phi"}, builder.Header.DataClasses)
+}
+
+func TestBuilderOptionsDataClassesDefault(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	builder, err := snapshot.Create(repo, repository.DefaultType, "", objects.NilMac, &snapshot.BuilderOptions{
+		Name:         "dataset-default-test",
+		NoCheckpoint: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, builder)
+	err = builder.Close()
+	require.NoError(t, err)
+
+	require.Equal(t, "", builder.Header.Dataset)
+	require.NotNil(t, builder.Header.DataClasses)
+	require.Empty(t, builder.Header.DataClasses)
+}


### PR DESCRIPTION
In order to support our intended use case, we would like to use the new Dataset locator when performing the prune operation.

Wire the dataset locator to the snapshot. Also take the opportunity to wire the data classes.