### PR TITLE
fix(snapshot): key xattr index by Xattr.ToPath() so attributes are retrievable

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -132,9 +132,10 @@ func (sourceCtx *sourceContext) recordXattr(idx int, record *connectors.Record, 
 	if err = sourceCtx.builder.repository.PutBlobIfNotExistsWithHint(idx, resources.RT_XATTR_ENTRY, mac, serialized, true); err != nil {
 		return nil
 	}
-	return sourceCtx.scanLog.PutPathMAC(scanlog.KindXattr, record.Pathname, mac)
-
-	//return sourceCtx.indexes.xattridx.Insert(xattr.ToPath(), serialized)
+	// Key the index by Xattr.ToPath() ("<path><name><sep>") so it matches the
+	// composed key Entry.Xattr looks up; keying by the bare pathname would make
+	// extended attributes unretrievable.
+	return sourceCtx.scanLog.PutPathMAC(scanlog.KindXattr, xattr.ToPath(), mac)
 }
 
 func (snapshot *Builder) skipExcludedPathname(sourceCtx *sourceContext, record *connectors.Record) bool {

--- a/snapshot/vfs/vfs_cover_test.go
+++ b/snapshot/vfs/vfs_cover_test.go
@@ -210,11 +210,10 @@ func TestGetEntryForBackupWithCache(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestXattrLookup exercises Entry.Xattr's btree lookup path. Note: the xattr
-// index is currently keyed by the bare record pathname (see buildXattrIndex in
-// snapshot/backup.go), whereas Entry.Xattr composes "<path><name><sep>", so a
-// lookup by attribute name does not match and returns ErrNotExist. We assert
-// that observed behaviour rather than a found value.
+// TestXattrLookup exercises Entry.Xattr's btree lookup path. The xattr index is
+// keyed by Xattr.ToPath() ("<path><name><sep>") on the write side (recordXattr
+// in snapshot/backup.go), matching the key Entry.Xattr composes, so an existing
+// attribute is retrievable and an unknown one returns ErrNotExist.
 func TestXattrLookup(t *testing.T) {
 	_, snap := generateRichSnapshot(t)
 	defer snap.Close()
@@ -225,11 +224,14 @@ func TestXattrLookup(t *testing.T) {
 	e, err := fs.GetEntry("/dir/file.txt")
 	require.NoError(t, err)
 
-	_, err = e.Xattr(fs, "user.comment")
-	require.Error(t, err)
+	rd, err := e.Xattr(fs, "user.comment")
+	require.NoError(t, err)
+	value, err := io.ReadAll(rd)
+	require.NoError(t, err)
+	require.Equal(t, "an xattr value", string(value))
 
 	_, err = e.Xattr(fs, "user.nope")
-	require.Error(t, err)
+	require.ErrorIs(t, err, iofs.ErrNotExist)
 }
 
 // TestErrorsIterator exercises the Errors iterator over a snapshot that


### PR DESCRIPTION
The xattr index was written keyed by the bare pathname but read by the composed `<path><name><sep>` key, so `Entry.Xattr` always returned `fs.ErrNotExist` — extended attributes were unretrievable.

`recordXattr` now keys the scanLog `KindXattr` entry by `xattr.ToPath()`, matching the key `Entry.Xattr` composes.

The xattr value blob is content-addressed (`ComputeMAC(xattr.ToBytes())`) and unchanged, so cross-snapshot dedup is preserved. The scanLog is per-backup scratch, so its key string has no dedup role.

`TestXattrLookup` now asserts the value is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)