### PR TITLE
feat(snapshot): defer ErrNotReadable to file Open instead of VFS construction

### DIFF
--- a/snapshot/filesystem.go
+++ b/snapshot/filesystem.go
@@ -1,23 +1,12 @@
 package snapshot
 
 import (
-	"github.com/PlakarKorp/kloset/connectors/storage"
-	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot/vfs"
 )
 
 func (s *Snapshot) Filesystem() (*vfs.Filesystem, error) {
 	if s.filesystem != nil {
 		return s.filesystem, nil
-	}
-
-	mode, err := s.repository.Store().Mode(s.AppContext())
-	if err != nil {
-		return nil, err
-	}
-
-	if mode&storage.ModeRead == 0 {
-		return nil, repository.ErrNotReadable
 	}
 
 	didx, err := s.DirPack()
@@ -38,15 +27,6 @@ func (s *Snapshot) Filesystem() (*vfs.Filesystem, error) {
 func (s *Snapshot) FilesystemWithCache() (*vfs.Filesystem, error) {
 	if s.filesystem != nil {
 		return s.filesystem, nil
-	}
-
-	mode, err := s.repository.Store().Mode(s.AppContext())
-	if err != nil {
-		return nil, err
-	}
-
-	if mode&storage.ModeRead == 0 {
-		return nil, repository.ErrNotReadable
 	}
 
 	didx, err := s.DirPack()

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/iterator"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
@@ -193,6 +194,15 @@ func (e *Entry) Open(fs *Filesystem) (fs.File, error) {
 		}
 
 		e.ResolvedObject = obj
+	}
+
+	mode, err := fs.repo.Store().Mode(fs.repo.AppContext())
+	if err != nil {
+		return nil, err
+	}
+
+	if mode&storage.ModeRead == 0 {
+		return nil, repository.ErrNotReadable
 	}
 
 	return &vfile{


### PR DESCRIPTION
## Summary

A read-only repository — e.g. one backed by a Glacier store that can't
serve content synchronously — can still build and traverse its VFS. Only
reading a file's bytes requires `ModeRead`.

Previously `Snapshot.Filesystem()` and `FilesystemWithCache()` rejected a
not-readable repo up front, so even listing or walking it failed. This
moves the `ModeRead` / `ErrNotReadable` check out of those constructors
and into `Entry.Open()`, so traversal works and `ErrNotReadable` surfaces
only when a file's content is actually fetched.

## What changed

- `snapshot/vfs/entry.go` — `Entry.Open()` now checks the store mode and
  returns `repository.ErrNotReadable` when `ModeRead` is unset.
- `snapshot/filesystem.go` — the equivalent checks in `Filesystem()` and
  `FilesystemWithCache()` are removed (along with the now-unused imports).

## Test

`go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)