### PR TITLE
fix: rename WithPerWednsdayCap to WithPerWednesdayCap

### DIFF
--- a/locate/locate.go
+++ b/locate/locate.go
@@ -255,7 +255,7 @@ func WithPerYearCap(n int) Option   { return func(p *LocateOptions) { p.Periods.
 
 func WithPerMondayCap(n int) Option   { return func(p *LocateOptions) { p.Periods.Monday.Cap = n } }
 func WithPerTuesdayCap(n int) Option  { return func(p *LocateOptions) { p.Periods.Tuesday.Cap = n } }
-func WithPerWednsdayCap(n int) Option { return func(p *LocateOptions) { p.Periods.Wednesday.Cap = n } }
+func WithPerWednesdayCap(n int) Option { return func(p *LocateOptions) { p.Periods.Wednesday.Cap = n } }
 func WithPerThursdayCap(n int) Option { return func(p *LocateOptions) { p.Periods.Thursday.Cap = n } }
 func WithPerFridayCap(n int) Option   { return func(p *LocateOptions) { p.Periods.Friday.Cap = n } }
 func WithPerSaturdayCap(n int) Option { return func(p *LocateOptions) { p.Periods.Saturday.Cap = n } }

--- a/locate/locate_test.go
+++ b/locate/locate_test.go
@@ -152,7 +152,7 @@ func TestWithCapOptions(t *testing.T) {
 
 		loc.WithPerMondayCap(1)(lo)
 		loc.WithPerTuesdayCap(2)(lo)
-		loc.WithPerWednsdayCap(3)(lo)
+		loc.WithPerWednesdayCap(3)(lo)
 		loc.WithPerThursdayCap(4)(lo)
 		loc.WithPerFridayCap(5)(lo)
 		loc.WithPerSaturdayCap(6)(lo)
@@ -258,7 +258,7 @@ func TestLocateOptionsHasPeriods(t *testing.T) {
 			{name: "Year", apply: loc.WithPerYearCap(1)},
 			{name: "Monday", apply: loc.WithPerMondayCap(1)},
 			{name: "Tuesday", apply: loc.WithPerTuesdayCap(1)},
-			{name: "Wednesday", apply: loc.WithPerWednsdayCap(1)},
+			{name: "Wednesday", apply: loc.WithPerWednesdayCap(1)},
 			{name: "Thursday", apply: loc.WithPerThursdayCap(1)},
 			{name: "Friday", apply: loc.WithPerFridayCap(1)},
 			{name: "Saturday", apply: loc.WithPerSaturdayCap(1)},


### PR DESCRIPTION
Fixes a typo in the function name — `Wednsd` → `Wednesd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)