### PR TITLE
the tink-go project broke the interface for AESGCMSIV by removing

### DIFF
--- a/encryption/symmetric.go
+++ b/encryption/symmetric.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	chunkSize         = 64 * 1024 // Size of each chunk for encryption/decryption
-	DEFAULT_KDF       = "ARGON2ID"
-	AESGMSIV_OVERHEAD = subtle.AESGCMSIVNonceSize + aes.BlockSize
+	chunkSize          = 64 * 1024 // Size of each chunk for encryption/decryption
+	DEFAULT_KDF        = "ARGON2ID"
+	AESGCMSIVNonceSize = 12
+	AESGMSIV_OVERHEAD  = AESGCMSIVNonceSize + aes.BlockSize
 )
 
 type Configuration struct {


### PR DESCRIPTION
a constnat, but since its RFC defined we might as well define it ourselves