### PR TITLE
test(repository): raise coverage from 66.6% to 85.3%

### DIFF
--- a/repository/coverage2_test.go
+++ b/repository/coverage2_test.go
@@ -1,0 +1,290 @@
+package repository_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/caching"
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/hashing"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/resources"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/stretchr/testify/require"
+)
+
+// newStateCache returns a fresh caching.StateCache (an SQLState, the same
+// backend repository.New uses for its own state) in a temporary directory,
+// cleaned up at the end of the test.
+func newStateCache(t *testing.T) caching.StateCache {
+	t.Helper()
+	tmp, err := os.MkdirTemp("", "kloset-statecache-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmp) })
+
+	sc, err := caching.NewSQLState(tmp, false)
+	require.NoError(t, err)
+	return sc
+}
+
+// TestRebuildStateWithCacheEmpty drives RebuildStateWithCache against a fresh
+// repository with an empty external cache. There are no remote states yet, so
+// the function should walk every branch (no missing, no outdated) and succeed.
+func TestRebuildStateWithCacheEmpty(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+	require.NoError(t, repo.RebuildStateWithCache(newStateCache(t)))
+}
+
+// TestRebuildStateWithCacheAfterBackup exercises the "missing states" branch of
+// RebuildStateWithCache: a backup writes a remote state that the fresh external
+// cache does not know about, so the function must fetch, topo-sort and merge it.
+func TestRebuildStateWithCacheAfterBackup(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	files := []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/rebuild.txt", 0644, strings.Repeat("rebuild ", 64)),
+	}
+	_ = ptesting.GenerateSnapshot(t, repo, files)
+
+	// A brand-new cache has none of the remote states -> exercises the
+	// missingStates / TopoSort / MergeState loop.
+	require.NoError(t, repo.RebuildStateWithCache(newStateCache(t)))
+
+	// At least one snapshot must be visible after the rebuild.
+	var count int
+	for _, err := range repo.ListSnapshots() {
+		require.NoError(t, err)
+		count++
+	}
+	require.Greater(t, count, 0)
+}
+
+// TestRebuildStateWithCacheOutdated exercises the "outdated states" deletion
+// branch: the external cache contains a state MAC that is absent from the
+// remote store, so RebuildStateWithCache must delete it locally.
+func TestRebuildStateWithCacheOutdated(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	sc := newStateCache(t)
+	// Seed the cache with a bogus state that does not exist remotely.
+	require.NoError(t, sc.PutState(objects.MAC{0xDE, 0xAD, 0xBE, 0xEF}, []byte("stale")))
+
+	require.NoError(t, repo.RebuildStateWithCache(sc))
+}
+
+// TestGetStateNotFound confirms GetState surfaces an error for a MAC that was
+// never written.
+func TestGetStateNotFound(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+	_, _, err := repo.GetState(objects.MAC{0x01, 0x02, 0x03, 0x04})
+	require.Error(t, err)
+}
+
+// TestGetStateCorrupt writes raw garbage to the state slot via the underlying
+// store and confirms GetState fails to deserialize it.
+func TestGetStateCorrupt(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	// Write raw, non-deserializable bytes straight into the state slot via the
+	// store handle so GetState's read path encounters invalid content.
+	badMac := objects.MAC{0x99}
+	store := repo.Store()
+	_, err := store.Put(repo.AppContext(), storage.StorageResourceState, badMac, bytes.NewReader([]byte("not a valid serialized state")))
+	require.NoError(t, err)
+
+	_, _, err = repo.GetState(badMac)
+	require.Error(t, err)
+}
+
+// TestGetPackfileCorrupt writes invalid bytes into a packfile slot and confirms
+// GetPackfile returns an error rather than panicking.
+func TestGetPackfileCorrupt(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	mac := objects.MAC{0xAB, 0xCD}
+	store := repo.Store()
+	_, err := store.Put(repo.AppContext(), storage.StorageResourcePackfile, mac, bytes.NewReader([]byte("not a packfile")))
+	require.NoError(t, err)
+
+	_, err = repo.GetPackfile(mac)
+	require.Error(t, err)
+}
+
+// TestDeleteSnapshotAfterBackup runs the full DeleteSnapshot path against a
+// real snapshot: it derives a delta state, colours the snapshot resource,
+// serializes it and writes a new state.
+func TestDeleteSnapshotAfterBackup(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	files := []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/gone.txt", 0644, "delete this snapshot"),
+	}
+	snap := ptesting.GenerateSnapshot(t, repo, files)
+	require.NotNil(t, snap)
+
+	require.NoError(t, repo.DeleteSnapshot(snap.Header.Identifier))
+	require.NoError(t, repo.RebuildState())
+
+	var deleted int
+	for range repo.ListDeletedSnapShots() {
+		deleted++
+	}
+	require.GreaterOrEqual(t, deleted, 1)
+}
+
+// TestNewWithCorruptConfig exercises the storage.Deserialize error branch of
+// repository.New by handing it bytes that are not a valid wrapped config.
+func TestNewWithCorruptConfig(t *testing.T) {
+	ctx := ptesting.GenerateContext(t, nil, nil)
+
+	tmpCacheDir, err := os.MkdirTemp("", "tmp_cache_badcfg")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpCacheDir) })
+	ctx.CacheDir = tmpCacheDir
+
+	st, err := storage.New(ctx, map[string]string{"location": "mock:///badcfg"})
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	_, err = repository.New(ctx, nil, st, []byte("totally not a config"))
+	require.Error(t, err)
+}
+
+// TestNewNoRebuildWithCorruptConfig is the NewNoRebuild analogue of the above.
+func TestNewNoRebuildWithCorruptConfig(t *testing.T) {
+	ctx := ptesting.GenerateContext(t, nil, nil)
+
+	tmpCacheDir, err := os.MkdirTemp("", "tmp_cache_badcfg2")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpCacheDir) })
+	ctx.CacheDir = tmpCacheDir
+
+	st, err := storage.New(ctx, map[string]string{"location": "mock:///badcfg2"})
+	require.NoError(t, err)
+
+	_, err = repository.NewNoRebuild(ctx, nil, st, []byte("garbage config bytes"), false)
+	require.Error(t, err)
+}
+
+// TestNewNoRebuildReadonlyCache walks the readonlyCache=true branch of
+// NewNoRebuild with a valid config.
+func TestNewNoRebuildReadonlyCache(t *testing.T) {
+	ctx := ptesting.GenerateContext(t, nil, nil)
+
+	tmpCacheDir, err := os.MkdirTemp("", "tmp_cache_ro")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpCacheDir) })
+	ctx.CacheDir = tmpCacheDir
+
+	st, err := storage.New(ctx, map[string]string{"location": "mock:///ro"})
+	require.NoError(t, err)
+
+	config := storage.NewConfiguration()
+	config.Compression = nil
+	config.Encryption = nil
+	hasher := hashing.GetHasher(hashing.DEFAULT_HASHING_ALGORITHM)
+
+	serialized, err := config.ToBytes()
+	require.NoError(t, err)
+
+	wrappedRd, err := storage.Serialize(hasher, resources.RT_CONFIG, versioning.GetCurrentVersion(resources.RT_CONFIG), bytes.NewReader(serialized))
+	require.NoError(t, err)
+	wrapped, err := io.ReadAll(wrappedRd)
+	require.NoError(t, err)
+
+	require.NoError(t, st.Create(ctx, wrapped))
+
+	repo, err := repository.NewNoRebuild(ctx, nil, st, wrapped, true)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+}
+
+// TestGetObjectContentMultiChunk backs up a large file so its content spans
+// many chunks, then reads the whole object back and verifies the bytes match
+// the original payload. This drives the multi-range accumulation logic in
+// GetObjectContent.
+func TestGetObjectContentMultiChunk(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	// Large, varied payload to force the chunker to emit several chunks.
+	var sb strings.Builder
+	for i := 0; i < 20000; i++ {
+		sb.WriteString("the quick brown fox jumps over the lazy dog ")
+	}
+	payload := sb.String()
+
+	files := []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/big.txt", 0644, payload),
+	}
+	snap := ptesting.GenerateSnapshot(t, repo, files)
+	require.NotNil(t, snap)
+
+	fs, err := snap.Filesystem()
+	require.NoError(t, err)
+
+	entry, err := fs.GetEntry("/big.txt")
+	require.NoError(t, err)
+	require.NotNil(t, entry.ResolvedObject)
+
+	obj := entry.ResolvedObject
+	var totalLen uint32
+	for _, c := range obj.Chunks {
+		totalLen += c.Length
+	}
+
+	collected := make([]byte, 0, totalLen)
+	for data, gErr := range repo.GetObjectContent(obj, 0, totalLen+1) {
+		require.NoError(t, gErr)
+		collected = append(collected, data...)
+	}
+	require.Equal(t, payload, string(collected))
+}
+
+// TestGetObjectContentStartOffset reads an object starting from a non-zero
+// chunk index, exercising the `start` parameter handling.
+func TestGetObjectContentStartOffset(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	var sb strings.Builder
+	for i := 0; i < 20000; i++ {
+		sb.WriteString("offset content payload data block ")
+	}
+
+	files := []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/offset.txt", 0644, sb.String()),
+	}
+	snap := ptesting.GenerateSnapshot(t, repo, files)
+
+	fs, err := snap.Filesystem()
+	require.NoError(t, err)
+	entry, err := fs.GetEntry("/offset.txt")
+	require.NoError(t, err)
+	obj := entry.ResolvedObject
+	require.NotNil(t, obj)
+
+	if len(obj.Chunks) < 2 {
+		t.Skip("payload did not produce multiple chunks; chunker tuning changed")
+	}
+
+	var totalLen uint32
+	for _, c := range obj.Chunks {
+		totalLen += c.Length
+	}
+
+	// Reading from chunk index 1 must yield fewer bytes than the whole object.
+	collected := make([]byte, 0)
+	for data, gErr := range repo.GetObjectContent(obj, 1, totalLen+1) {
+		require.NoError(t, gErr)
+		collected = append(collected, data...)
+	}
+	require.Less(t, len(collected), int(totalLen))
+}

--- a/repository/coverage3_test.go
+++ b/repository/coverage3_test.go
@@ -1,0 +1,93 @@
+package repository_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/resources"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetLockCorrupt writes raw garbage to a lock slot and confirms GetLock
+// returns the deserialize error rather than a valid lock.
+func TestGetLockCorrupt(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	lockID := objects.MAC{0x5A, 0x5A}
+	_, err := repo.Store().Put(repo.AppContext(), storage.StorageResourceLock, lockID, bytes.NewReader([]byte("not a lock")))
+	require.NoError(t, err)
+
+	_, err = repo.GetLock(lockID)
+	require.Error(t, err)
+}
+
+// TestPutBlobDedup writes the same blob twice through PutBlob. The second call
+// hits the InsertIfNotPresent "already present" short-circuit.
+func TestPutBlobDedup(t *testing.T) {
+	_, writer, _, _ := makeWriter(t)
+
+	mac := objects.MAC{0x01, 0x02}
+	require.NoError(t, writer.PutBlob(resources.RT_CHUNK, mac, []byte("payload"), false))
+	// Same MAC again -> dedup branch.
+	require.NoError(t, writer.PutBlob(resources.RT_CHUNK, mac, []byte("payload"), false))
+}
+
+// TestPutBlobWithHintDedup is the hinted variant of TestPutBlobDedup.
+func TestPutBlobWithHintDedup(t *testing.T) {
+	_, writer, _, _ := makeWriter(t)
+
+	mac := objects.MAC{0x03, 0x04}
+	require.NoError(t, writer.PutBlobWithHint(0, resources.RT_CHUNK, mac, []byte("hinted"), true))
+	require.NoError(t, writer.PutBlobWithHint(0, resources.RT_CHUNK, mac, []byte("hinted"), true))
+}
+
+// TestPutBlobIfNotExistsWithHintExisting exercises the BlobExists()==true
+// short-circuit of PutBlobIfNotExistsWithHint: after the blob is committed to
+// the repository state, a second insert-if-not-exists must early-return.
+func TestPutBlobIfNotExistsWithHintExisting(t *testing.T) {
+	_, writer, _, snapshotID := makeWriter(t)
+
+	mac := objects.MAC{0x05, 0x06}
+	require.NoError(t, writer.PutBlobIfNotExistsWithHint(0, resources.RT_CHUNK, mac, []byte("data"), true))
+	// Calling again while still in the packer/delta state takes the
+	// already-exists path.
+	require.NoError(t, writer.PutBlobIfNotExistsWithHint(0, resources.RT_CHUNK, mac, []byte("data"), true))
+
+	require.NoError(t, writer.CommitTransaction(snapshotID))
+}
+
+// TestNewRepositoryWriterOnDiskPackfiles exercises the on-disk packfile
+// constructor branch of newRepositoryWriter by passing a non-empty
+// packfileTmpDir.
+func TestNewRepositoryWriterOnDiskPackfiles(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	tmpDir := t.TempDir()
+	snapshotID := objects.MAC{0x70}
+	scanCache, err := repo.AppContext().GetCache().Scan(snapshotID)
+	require.NoError(t, err)
+
+	writer := repo.NewRepositoryWriter(scanCache, snapshotID, repository.DefaultType, tmpDir)
+	require.NotNil(t, writer)
+
+	// Write a blob so the on-disk packfile machinery actually runs.
+	require.NoError(t, writer.PutBlob(resources.RT_CHUNK, objects.MAC{0x71}, []byte("on-disk packfile data"), false))
+	require.NoError(t, writer.CommitTransaction(snapshotID))
+}
+
+// TestNewRepositoryWriterPtarType exercises the PtarType branch of
+// newRepositoryWriter.
+func TestNewRepositoryWriterPtarType(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	snapshotID := objects.MAC{0x80}
+	scanCache, err := repo.AppContext().GetCache().Scan(snapshotID)
+	require.NoError(t, err)
+
+	writer := repo.NewRepositoryWriter(scanCache, snapshotID, repository.PtarType, "")
+	require.NotNil(t, writer)
+}

--- a/repository/coverage4_test.go
+++ b/repository/coverage4_test.go
@@ -1,0 +1,128 @@
+package repository_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/encryption"
+	"github.com/PlakarKorp/kloset/hashing"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/repository/state"
+	"github.com/PlakarKorp/kloset/resources"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetPackfileRangeMissing exercises the store.Get error branch of
+// GetPackfileRange: requesting a range from a packfile MAC that was never
+// written must surface an error rather than return data.
+func TestGetPackfileRangeMissing(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	loc := state.Location{
+		Packfile: objects.MAC{0xDE, 0xAD, 0xBE, 0xEF},
+		Offset:   0,
+		Length:   32,
+	}
+	_, err := repo.GetPackfileRange(loc)
+	require.Error(t, err)
+}
+
+// TestGetPackfileBlobMissing exercises the GetPackfileRange error propagation
+// inside GetPackfileBlob for an unknown packfile.
+func TestGetPackfileBlobMissing(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	loc := state.Location{
+		Packfile: objects.MAC{0xBA, 0xDB, 0xAD},
+		Offset:   0,
+		Length:   16,
+	}
+	_, err := repo.GetPackfileBlob(loc)
+	require.Error(t, err)
+}
+
+// TestInexistentBadLocation drives the storage.New error branch of Inexistent
+// by passing a store configuration with an unknown backend scheme.
+func TestInexistentBadLocation(t *testing.T) {
+	ctx := ptesting.GenerateRepository(t, nil, nil, nil).AppContext()
+
+	_, err := repository.Inexistent(ctx, map[string]string{
+		"location": "this-scheme-does-not-exist://nowhere",
+	})
+	require.Error(t, err)
+}
+
+// TestGetPackfileForBlobAfterBackup resolves a real blob location after a
+// backup, exercising the found branch of GetPackfileForBlob (the existing
+// tests only cover the not-found case).
+func TestGetPackfileForBlobAfterBackup(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	files := []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/lookup.txt", 0644, "find this blob's packfile"),
+	}
+	snap := ptesting.GenerateSnapshot(t, repo, files)
+	require.NotNil(t, repo)
+	require.NoError(t, repo.RebuildState())
+
+	fs, err := snap.Filesystem()
+	require.NoError(t, err)
+	entry, err := fs.GetEntry("/lookup.txt")
+	require.NoError(t, err)
+	require.NotNil(t, entry.ResolvedObject)
+	require.NotEmpty(t, entry.ResolvedObject.Chunks)
+
+	chunkMAC := entry.ResolvedObject.Chunks[0].ContentMAC
+	_, exists, err := repo.GetPackfileForBlob(resources.RT_CHUNK, chunkMAC)
+	require.NoError(t, err)
+	require.True(t, exists, "a chunk written during backup must resolve to a packfile")
+}
+
+// TestNewNoRebuildEncrypted exercises the secret != nil (MAC-hasher) branch of
+// NewNoRebuild by building an encrypted configuration and opening it with the
+// derived key.
+func TestNewNoRebuildEncrypted(t *testing.T) {
+	ctx := ptesting.GenerateContext(t, nil, nil)
+
+	tmpCacheDir, err := os.MkdirTemp("", "tmp_cache_enc")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpCacheDir) })
+	ctx.CacheDir = tmpCacheDir
+
+	st, err := storage.New(ctx, map[string]string{"location": "mock:///enc"})
+	require.NoError(t, err)
+
+	config := storage.NewConfiguration()
+	config.Compression = nil
+
+	passphrase := []byte("new-no-rebuild-encrypted-pass")
+	key, err := encryption.DeriveKey(config.Encryption.KDFParams, passphrase)
+	require.NoError(t, err)
+
+	canary, err := encryption.DeriveCanary(config.Encryption, key)
+	require.NoError(t, err)
+	config.Encryption.Canary = canary
+
+	hasher := hashing.GetMACHasher(storage.DEFAULT_HASHING_ALGORITHM, key)
+
+	serialized, err := config.ToBytes()
+	require.NoError(t, err)
+
+	wrappedRd, err := storage.Serialize(hasher, resources.RT_CONFIG, versioning.GetCurrentVersion(resources.RT_CONFIG), bytes.NewReader(serialized))
+	require.NoError(t, err)
+	wrapped, err := io.ReadAll(wrappedRd)
+	require.NoError(t, err)
+
+	require.NoError(t, st.Create(ctx, wrapped))
+
+	repo, err := repository.NewNoRebuild(ctx, key, st, wrapped, false)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+}

--- a/repository/getobjectcontent2_test.go
+++ b/repository/getobjectcontent2_test.go
@@ -1,0 +1,69 @@
+package repository_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/snapshot"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetObjectContentAcrossPackfiles drives the packfile-boundary-crossing
+// path of GetObjectContent. Two separate backups each produce their own
+// packfile; we then assemble a synthetic object whose chunks reference real
+// chunk blobs from both files. Because the chunks live in different packfiles
+// (and at non-contiguous offsets), the iterator must flush one accumulated
+// range and start a new one — the branch that single-backup tests never hit.
+func TestGetObjectContentAcrossPackfiles(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	// First backup -> packfile A.
+	snapA := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/a.txt", 0644, strings.Repeat("alpha-block ", 128)),
+	})
+	// Second backup -> packfile B.
+	snapB := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/b.txt", 0644, strings.Repeat("bravo-block ", 128)),
+	})
+
+	require.NoError(t, repo.RebuildState())
+
+	chunkA := firstChunk(t, snapA, "/a.txt")
+	chunkB := firstChunk(t, snapB, "/b.txt")
+
+	// Build an object interleaving chunks from the two packfiles so the
+	// iterator crosses a packfile boundary mid-stream.
+	obj := &objects.Object{
+		Chunks: []objects.Chunk{chunkA, chunkB, chunkA},
+	}
+
+	var totalLen uint32
+	for _, c := range obj.Chunks {
+		totalLen += c.Length
+	}
+
+	var collected int
+	for data, err := range repo.GetObjectContent(obj, 0, totalLen+1) {
+		require.NoError(t, err)
+		collected += len(data)
+	}
+	require.Greater(t, collected, 0)
+}
+
+// firstChunk resolves a file in a snapshot and returns its first chunk.
+func firstChunk(t *testing.T, snap *snapshot.Snapshot, path string) objects.Chunk {
+	t.Helper()
+	fs, err := snap.Filesystem()
+	require.NoError(t, err)
+
+	entry, err := fs.GetEntry(path)
+	require.NoError(t, err)
+	require.NotNil(t, entry.ResolvedObject)
+	require.NotEmpty(t, entry.ResolvedObject.Chunks)
+
+	return entry.ResolvedObject.Chunks[0]
+}


### PR DESCRIPTION
## Summary

Raises test coverage of the `repository` package from **66.6% to 85.3%** by adding targeted tests for the lowest-covered functions. No production code is changed — this is tests only. None of the tests touch the ECC work in flight on a separate branch.

All new tests rely only on the mock store (no extra fault-injection machinery).

## What's covered

- **`RebuildStateWithCache`** (was 0%) — empty-cache, missing-states (topo-sort/merge), and outdated-states (deletion) branches.
- **`GetObjectContent`** (47% → 74%) — the packfile-boundary-crossing path, driven by two separate backups plus a synthetic object that interleaves chunks from both packfiles.
- **`GetState` / `GetPackfile` / `GetLock`** — corrupt-bytes deserialize error paths.
- **`GetPackfileRange` / `GetPackfileBlob`** — missing-packfile error paths.
- **`New` / `NewNoRebuild`** — corrupt-config errors, readonly-cache, and encrypted (MAC-hasher) construction branches.
- **`GetPackfileForBlob`** — resolves a real blob location after a backup (found path).
- **`DeleteSnapshot`** — full delta-state path against a real snapshot.
- **`Inexistent`** — `storage.New` error branch on an unknown backend scheme.
- **`RepositoryWriter`** — `PutBlob` dedup short-circuits, on-disk packfile and `PtarType` writer construction.

## Test plan

- `go test ./repository/` — 134 passing
- `go vet ./repository/` — clean
- `go build ./...` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)