### PR TITLE
test(snapshot): quick-win coverage for verify/filesystem/search

### DIFF
--- a/snapshot/snapshot_quickwins_test.go
+++ b/snapshot/snapshot_quickwins_test.go
@@ -1,0 +1,122 @@
+package snapshot_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyMissingSignature drives Snapshot.Verify past the uuid.Nil early
+// return: with a non-nil identity identifier but no signature blob stored,
+// GetBlobBytes must fail and Verify must surface that error.
+func TestVerifyMissingSignature(t *testing.T) {
+	_, snap := generateSnapshot(t)
+	defer snap.Close()
+
+	// Attach a non-nil identity so Verify proceeds to fetch the signature
+	// blob, which does not exist for this unsigned snapshot.
+	snap.Header.Identity.Identifier = uuid.New()
+
+	ok, err := snap.Verify()
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
+// TestFilesystemWithCacheCached calls FilesystemWithCache twice; the second
+// call must hit the already-resolved early-return branch and return the same
+// instance.
+func TestFilesystemWithCacheCached(t *testing.T) {
+	_, snap := generateSnapshotWithFiles(t)
+	defer snap.Close()
+
+	fs1, err := snap.FilesystemWithCache()
+	require.NoError(t, err)
+	require.NotNil(t, fs1)
+
+	fs2, err := snap.FilesystemWithCache()
+	require.NoError(t, err)
+	require.Same(t, fs1, fs2, "second call should return the cached filesystem")
+}
+
+// TestFilesystemCachedSameInstance does the same for Filesystem(): the second
+// call returns the memoized instance.
+func TestFilesystemCachedSameInstance(t *testing.T) {
+	_, snap := generateSnapshotWithFiles(t)
+	defer snap.Close()
+
+	fs1, err := snap.Filesystem()
+	require.NoError(t, err)
+	require.NotNil(t, fs1)
+
+	fs2, err := snap.Filesystem()
+	require.NoError(t, err)
+	require.Same(t, fs1, fs2)
+}
+
+// TestSearchMimesWithNameFilter exercises the NameFilter branch *inside*
+// visitmimes (recursive + mimes + a name filter), which the plain mime test
+// does not reach.
+func TestSearchMimesWithNameFilter(t *testing.T) {
+	_, snap := generateSnapshotWithFiles(t)
+	defer snap.Close()
+
+	opts := &snapshot.SearchOpts{
+		Recursive:  true,
+		Mimes:      []string{"text/plain"},
+		NameFilter: "*.txt",
+	}
+	it, err := snap.Search(context.Background(), opts)
+	require.NoError(t, err)
+	require.NotNil(t, it)
+
+	for _, err := range it {
+		require.NoError(t, err)
+	}
+}
+
+// TestSearchMimesWithPrefixFilter drives the prefix-mismatch `continue` inside
+// visitmimes: a prefix that excludes the matched entries means the iterator
+// walks the index but yields nothing matching.
+func TestSearchMimesWithPrefixFilter(t *testing.T) {
+	_, snap := generateSnapshotWithFiles(t)
+	defer snap.Close()
+
+	opts := &snapshot.SearchOpts{
+		Recursive: true,
+		Mimes:     []string{"text/plain"},
+		Prefix:    "/nonexistent",
+	}
+	it, err := snap.Search(context.Background(), opts)
+	require.NoError(t, err)
+	require.NotNil(t, it)
+
+	count := 0
+	for _, err := range it {
+		require.NoError(t, err)
+		count++
+	}
+	require.Equal(t, 0, count, "no entry should match a prefix outside the tree")
+}
+
+// TestSearchMimesExactNameFilter hits the exact-match (path.Base == NameFilter)
+// arm of the NameFilter block inside visitmimes.
+func TestSearchMimesExactNameFilter(t *testing.T) {
+	_, snap := generateSnapshotWithFiles(t)
+	defer snap.Close()
+
+	opts := &snapshot.SearchOpts{
+		Recursive:  true,
+		Mimes:      []string{"text/plain"},
+		NameFilter: "readme.txt",
+	}
+	it, err := snap.Search(context.Background(), opts)
+	require.NoError(t, err)
+	require.NotNil(t, it)
+
+	for _, err := range it {
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
## Summary

Quick-win test coverage for the smaller files in the `snapshot` package — targets easily-reachable branches that needed no fault-injection machinery. Tests only, no production changes.

## What's covered

- **`Verify`** 20% → **50%** — attach a non-nil `Header.Identity.Identifier` to an unsigned snapshot so `Verify` proceeds past the `uuid.Nil` early return and the `GetBlobBytes` error path runs.
- **`FilesystemWithCache`** 72.7% → **81.8%** — call twice to hit the already-resolved cached early-return; same assertion added for `Filesystem`.
- **`visitmimes`** 51.1% → **71.1%** — drive `Search` with `Mimes` combined with a glob/exact `NameFilter` and a non-matching `Prefix`, reaching the inner name-filter and prefix-mismatch branches that the plain mime test skips.

Package total **75.4% → 76.1%**.

## Not covered (intentionally)

The remaining `Verify` branch (a successful `ed25519.Verify` over a real signature) needs a signed snapshot — that depends on the signing wiring that's parked post-beta (`verify_test.go` still has the disabled `_TestVerify`). Out of scope for a quick win.

## Test plan

- `go test ./snapshot/` — 71 passing
- `go vet ./snapshot/` — clean
- `go build ./...` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)