### PR TITLE
fix(snapshot): emit correct events for symlinks during export

### DIFF
--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -68,15 +68,13 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 					emitter.FileError(ack.Record.Pathname, ack.Err)
 				}
 			} else if !ack.Record.IsXattr {
+				emitter.PathOk(ack.Record.Pathname)
 				if ack.Record.FileInfo.IsDir() {
 					emitter.DirectoryOk(ack.Record.Pathname, ack.Record.FileInfo)
-					emitter.PathOk(ack.Record.Pathname)
 				} else if ack.Record.FileInfo.Mode()&os.ModeSymlink != 0 {
 					emitter.SymlinkOk(ack.Record.Pathname)
-					emitter.PathOk(ack.Record.Pathname)
 				} else {
 					emitter.FileOk(ack.Record.Pathname, ack.Record.FileInfo)
-					emitter.PathOk(ack.Record.Pathname)
 				}
 			}
 		}

--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -59,16 +59,20 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 	go func() {
 		for ack := range results {
 			if ack.Err != nil {
+				emitter.PathError(ack.Record.Pathname, ack.Err)
 				if ack.Record.FileInfo.IsDir() {
-					emitter.PathError(ack.Record.Pathname, ack.Err)
 					emitter.DirectoryError(ack.Record.Pathname, ack.Err)
+				} else if ack.Record.FileInfo.Mode()&os.ModeSymlink != 0 {
+					emitter.SymlinkError(ack.Record.Pathname, ack.Err)
 				} else {
-					emitter.PathError(ack.Record.Pathname, ack.Err)
 					emitter.FileError(ack.Record.Pathname, ack.Err)
 				}
 			} else if !ack.Record.IsXattr {
 				if ack.Record.FileInfo.IsDir() {
 					emitter.DirectoryOk(ack.Record.Pathname, ack.Record.FileInfo)
+					emitter.PathOk(ack.Record.Pathname)
+				} else if ack.Record.FileInfo.Mode()&os.ModeSymlink != 0 {
+					emitter.SymlinkOk(ack.Record.Pathname)
 					emitter.PathOk(ack.Record.Pathname)
 				} else {
 					emitter.FileOk(ack.Record.Pathname, ack.Record.FileInfo)
@@ -121,6 +125,8 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 
 			if e.FileInfo.IsDir() {
 				emitter.Directory(entrypath)
+			} else if e.FileInfo.Mode()&os.ModeSymlink != 0 {
+				emitter.Symlink(entrypath)
 			} else if e.FileInfo.Mode().IsRegular() {
 				// This is a shortcut, but it's safe, integrated plugins are
 				// controlled by us and consume everything, and external plugins


### PR DESCRIPTION
## Summary

- In the results goroutine, symlinks were falling into the `FileOk`/`FileError` branches because they aren't directories. This caused `files.ok` to exceed `files.total` in live restore counters (the specific symptom reported in PlakarKorp/plakman#732).
- In the WalkDir goroutine, the `emitter.Symlink()` start event was never emitted for symlinks, so `symlinks.total` was never incremented during export.

Both are fixed by checking `Mode()&os.ModeSymlink != 0` and routing to `SymlinkOk`/`SymlinkError`/`Symlink` accordingly.

Closes PlakarKorp/plakman#732

🤖 Generated with [Claude Code](https://claude.com/claude-code)