### PR TITLE
iostat: sample I/O throughput and surface it as events

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -149,15 +149,6 @@ func (e *Emitter) Symlink(path string) {
 	})
 }
 
-// ChunkBytes reports that n payload bytes of the current file have been read
-// and processed. Unlike FileOk (emitted once per whole file), it lets
-// consumers advance progress *within* a large file at chunk granularity.
-func (e *Emitter) ChunkBytes(n int64) {
-	e.emit("chunk.bytes", Info, map[string]any{
-		"bytes": n,
-	})
-}
-
 func (e *Emitter) Object(object objects.MAC) {
 	e.emit("object", Info, map[string]any{
 		"mac": object,

--- a/events/events.go
+++ b/events/events.go
@@ -149,6 +149,15 @@ func (e *Emitter) Symlink(path string) {
 	})
 }
 
+// ChunkBytes reports that n payload bytes of the current file have been read
+// and processed. Unlike FileOk (emitted once per whole file), it lets
+// consumers advance progress *within* a large file at chunk granularity.
+func (e *Emitter) ChunkBytes(n int64) {
+	e.emit("chunk.bytes", Info, map[string]any{
+		"bytes": n,
+	})
+}
+
 func (e *Emitter) Object(object objects.MAC) {
 	e.emit("object", Info, map[string]any{
 		"mac": object,

--- a/events/events.go
+++ b/events/events.go
@@ -344,19 +344,21 @@ func (e *Emitter) FilesystemSummary(fileCount uint64, dirCount uint64, symlinkCo
 
 func ioStatsToMap(s iostat.IOStats) map[string]any {
 	return map[string]any{
-		"total":   s.TotalBytes,
-		"dt":      s.Duration,
-		"overall": s.Overall,
-		"min":     s.Min,
-		"avg":     s.Avg,
-		"median":  s.Median,
-		"p50":     s.P50,
-		"p75":     s.P75,
-		"p80":     s.P80,
-		"p90":     s.P90,
-		"p95":     s.P95,
-		"p99":     s.P99,
-		"max":     s.Max,
+		"total":        s.TotalBytes,
+		"dt":           s.Duration,
+		"wall_dt":      s.WallDuration,
+		"overall":      s.Overall,
+		"overall_wall": s.OverallWall,
+		"min":          s.Min,
+		"avg":          s.Avg,
+		"median":       s.Median,
+		"p50":          s.P50,
+		"p75":          s.P75,
+		"p80":          s.P80,
+		"p90":          s.P90,
+		"p95":          s.P95,
+		"p99":          s.P99,
+		"max":          s.Max,
 	}
 }
 

--- a/events/events.go
+++ b/events/events.go
@@ -3,6 +3,7 @@ package events
 import (
 	"time"
 
+	"github.com/PlakarKorp/kloset/iostat"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/google/uuid"
 )
@@ -327,5 +328,35 @@ func (e *Emitter) FilesystemSummary(fileCount uint64, dirCount uint64, symlinkCo
 		"symlinks":    symlinkCount,
 		"xattrs":      xattrCount,
 		"size":        totalSize,
+	})
+}
+
+/////
+
+func ioStatsToMap(s iostat.IOStats) map[string]any {
+	return map[string]any{
+		"total":   s.TotalBytes,
+		"dt":      s.Duration,
+		"overall": s.Overall,
+		"min":     s.Min,
+		"avg":     s.Avg,
+		"median":  s.Median,
+		"p50":     s.P50,
+		"p75":     s.P75,
+		"p80":     s.P80,
+		"p90":     s.P90,
+		"p95":     s.P95,
+		"p99":     s.P99,
+		"max":     s.Max,
+	}
+}
+
+// ReportIOStats emits an "iostats" event for the given scope; it satisfies
+// iostat.Reporter.
+func (e *Emitter) ReportIOStats(scope string, read, write iostat.IOStats) {
+	e.emit("iostats", Info, map[string]any{
+		"scope": scope,
+		"r":     ioStatsToMap(read),
+		"w":     ioStatsToMap(write),
 	})
 }

--- a/iostat/iostat.go
+++ b/iostat/iostat.go
@@ -115,6 +115,16 @@ func percentile(sorted []float64, p float64) float64 {
 	return sorted[lower]*(1-weight) + sorted[upper]*weight
 }
 
+// TotalBytes returns the cumulative bytes accounted so far. Unlike Stats() it
+// has no side effects (it does not flush the partial sampling bucket), so it is
+// safe to poll at a high rate — e.g. from a UI render loop — without perturbing
+// the throughput samples.
+func (t *tracker) TotalBytes() int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.totalBytes
+}
+
 func (t *tracker) Stats() IOStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/iostat/iostat.go
+++ b/iostat/iostat.go
@@ -13,15 +13,27 @@ import (
 const sampleWindow = 50 * time.Millisecond
 
 // represents I/O statistics collected over a period of time.
+//
+// Two notions of throughput are reported and answer different questions:
+//   - the active-time figures (Overall and the Min/Avg/Median/Max/Pxx
+//     distribution) divide bytes by the time actually spent inside read/write
+//     calls. They characterise how fast the medium is *when working*, ignoring
+//     idle/blocked time — the right metric for benchmarking the storage layer.
+//   - OverallWall divides bytes by wall-clock elapsed (first to last operation),
+//     so it includes stalls and waits. It is the throughput a user actually
+//     experiences and the right basis for progress/ETA.
 type IOStats struct {
-	Duration   time.Duration
-	TotalBytes int64
+	Duration     time.Duration // active time spent in I/O
+	WallDuration time.Duration // wall-clock span first→last operation
+	TotalBytes   int64
 
-	Min     float64 // bytes/sec
-	Avg     float64 // bytes/sec
-	Median  float64 // bytes/sec
-	Max     float64 // bytes/sec
-	Overall float64 // overall throughput (bytes/sec)
+	Min     float64 // bytes/sec (active)
+	Avg     float64 // bytes/sec (active)
+	Median  float64 // bytes/sec (active)
+	Max     float64 // bytes/sec (active)
+	Overall float64 // overall active throughput (bytes/sec)
+
+	OverallWall float64 // overall wall-clock throughput (bytes/sec)
 
 	P50 float64
 	P75 float64
@@ -36,18 +48,25 @@ type tracker struct {
 	activeDuration time.Duration
 	totalBytes     int64
 
+	// wall-clock span of activity: the time of the first and most recent
+	// accounted operation. wallDuration = lastAt - firstAt.
+	firstAt time.Time
+	lastAt  time.Time
+
+	// active-time bucketing: emits a sample once bucketDuration (summed active
+	// I/O time) reaches sampleWindow.
 	bucketBytes    int64
 	bucketDuration time.Duration
-
-	samples []float64
+	samples        []float64
 }
 
 func newTracker() *tracker {
 	return &tracker{}
 }
 
-// add accounts for n bytes processed over dt of *active* time.
-func (t *tracker) add(n int64, dt time.Duration) {
+// add accounts for n bytes processed over dt of *active* time, completing at
+// wall-clock time now (used to measure the wall-clock span of activity).
+func (t *tracker) add(n int64, dt time.Duration, now time.Time) {
 	if n == 0 {
 		return
 	}
@@ -57,8 +76,16 @@ func (t *tracker) add(n int64, dt time.Duration) {
 
 	t.totalBytes += n
 
+	// Track the wall-clock span (first → last operation) for OverallWall.
+	if !now.IsZero() {
+		if t.firstAt.IsZero() {
+			t.firstAt = now
+		}
+		t.lastAt = now
+	}
+
 	if dt <= 0 {
-		// count the bytes, but don't create a throughput sample
+		// count the bytes, but don't create an active-throughput sample
 		return
 	}
 
@@ -88,6 +115,8 @@ func (t *tracker) Reset() {
 
 	t.activeDuration = 0
 	t.totalBytes = 0
+	t.firstAt = time.Time{}
+	t.lastAt = time.Time{}
 	t.samples = nil
 	t.bucketBytes = 0
 	t.bucketDuration = 0
@@ -129,7 +158,7 @@ func (t *tracker) Stats() IOStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	// flush any partially-filled bucket as one last sample
+	// flush any partially-filled active bucket as one last sample
 	if t.bucketDuration > 0 && t.bucketBytes > 0 {
 		throughput := float64(t.bucketBytes) / t.bucketDuration.Seconds()
 		t.samples = append(t.samples, throughput)
@@ -138,14 +167,19 @@ func (t *tracker) Stats() IOStats {
 	}
 
 	duration := t.activeDuration
+	wall := t.lastAt.Sub(t.firstAt)
 
 	stats := IOStats{
-		Duration:   duration,
-		TotalBytes: t.totalBytes,
+		Duration:     duration,
+		WallDuration: wall,
+		TotalBytes:   t.totalBytes,
 	}
 
 	if duration > 0 && t.totalBytes > 0 {
 		stats.Overall = float64(t.totalBytes) / duration.Seconds()
+	}
+	if wall > 0 && t.totalBytes > 0 {
+		stats.OverallWall = float64(t.totalBytes) / wall.Seconds()
 	}
 
 	if len(t.samples) == 0 {
@@ -230,7 +264,7 @@ func (s *Span) Add(n int64) {
 	now := time.Now()
 	dt := now.Sub(s.last)
 	s.last = now
-	s.t.add(n, dt)
+	s.t.add(n, dt, now)
 }
 
 func formatBytes(b int64) string {
@@ -254,8 +288,10 @@ func (ioT *IOTracker) SummaryString() string {
 	return fmt.Sprintf(
 		"r:"+
 			" dt=%s,"+
+			" wall=%s,"+
 			" bytes=%s (%d),"+
 			" overall=%s,"+
+			" overall_wall=%s,"+
 			" min=%s,"+
 			" avg=%s,"+
 			" median=%s,"+
@@ -267,8 +303,10 @@ func (ioT *IOTracker) SummaryString() string {
 			" max=%s\n"+
 			"w:"+
 			" dt=%s,"+
+			" wall=%s,"+
 			" bytes=%s (%d),"+
 			" overall=%s,"+
+			" overall_wall=%s,"+
 			" min=%s,"+
 			" avg=%s,"+
 			" median=%s,"+
@@ -278,8 +316,9 @@ func (ioT *IOTracker) SummaryString() string {
 			" p95=%s,"+
 			" p99=%s,"+
 			" max=%s\n",
-		r.Duration, formatBytes(r.TotalBytes), r.TotalBytes,
+		r.Duration, r.WallDuration, formatBytes(r.TotalBytes), r.TotalBytes,
 		formatThroughput(r.Overall),
+		formatThroughput(r.OverallWall),
 		formatThroughput(r.Min),
 		formatThroughput(r.Avg),
 		formatThroughput(r.Median),
@@ -290,8 +329,9 @@ func (ioT *IOTracker) SummaryString() string {
 		formatThroughput(r.P99),
 		formatThroughput(r.Max),
 
-		w.Duration, formatBytes(w.TotalBytes), w.TotalBytes,
+		w.Duration, w.WallDuration, formatBytes(w.TotalBytes), w.TotalBytes,
 		formatThroughput(w.Overall),
+		formatThroughput(w.OverallWall),
 		formatThroughput(w.Min),
 		formatThroughput(w.Avg),
 		formatThroughput(w.Median),

--- a/iostat/iostat_test.go
+++ b/iostat/iostat_test.go
@@ -32,14 +32,14 @@ func TestTrackerAddAndStats(t *testing.T) {
 	}
 
 	// Add bytes with zero duration — counted but no throughput sample
-	tr.add(100, 0)
+	tr.add(100, 0, time.Time{})
 	s = tr.Stats()
 	if s.TotalBytes != 100 {
 		t.Errorf("expected 100 total bytes, got %d", s.TotalBytes)
 	}
 
 	// Add bytes with a duration large enough to emit a sample
-	tr.add(1<<20, 100*time.Millisecond)
+	tr.add(1<<20, 100*time.Millisecond, time.Time{})
 	s = tr.Stats()
 	if s.TotalBytes != 100+1<<20 {
 		t.Errorf("unexpected total bytes %d", s.TotalBytes)
@@ -51,7 +51,7 @@ func TestTrackerAddAndStats(t *testing.T) {
 
 func TestTrackerAddZeroBytes(t *testing.T) {
 	tr := newTracker()
-	tr.add(0, 100*time.Millisecond)
+	tr.add(0, 100*time.Millisecond, time.Time{})
 	s := tr.Stats()
 	if s.TotalBytes != 0 {
 		t.Errorf("expected 0 bytes, got %d", s.TotalBytes)
@@ -63,7 +63,7 @@ func TestTrackerAddZeroBytes(t *testing.T) {
 
 func TestTrackerReset(t *testing.T) {
 	tr := newTracker()
-	tr.add(1<<20, 200*time.Millisecond)
+	tr.add(1<<20, 200*time.Millisecond, time.Time{})
 	tr.Reset()
 
 	s := tr.Stats()
@@ -100,6 +100,30 @@ func TestSpanAdd(t *testing.T) {
 	}
 }
 
+func TestWallClockThroughput(t *testing.T) {
+	tr := newTracker()
+	base := time.Unix(0, 0)
+
+	// 10 MiB total across a 2s wall-clock span, but only 100ms of active time
+	// (a cached burst). Active throughput is high; wall-clock is 5 MiB/s.
+	tr.add(5<<20, 50*time.Millisecond, base)
+	tr.add(5<<20, 50*time.Millisecond, base.Add(2*time.Second))
+
+	s := tr.Stats()
+	if s.WallDuration != 2*time.Second {
+		t.Fatalf("WallDuration = %v, want 2s", s.WallDuration)
+	}
+	wantWall := float64(10<<20) / 2.0 // 5 MiB/s
+	if s.OverallWall < wantWall*0.99 || s.OverallWall > wantWall*1.01 {
+		t.Fatalf("OverallWall = %.0f, want ~%.0f (5 MiB/s)", s.OverallWall, wantWall)
+	}
+	// Active throughput uses the 100ms active time and is far higher.
+	if s.Overall <= s.OverallWall {
+		t.Fatalf("active Overall (%.0f) should exceed wall-clock (%.0f)", s.Overall, s.OverallWall)
+	}
+}
+
+
 func TestSpanAddNil(t *testing.T) {
 	var s *Span
 	// should not panic
@@ -124,7 +148,7 @@ func TestStatsMultipleSamples(t *testing.T) {
 
 	// Add enough data with long durations so we get multiple samples
 	for i := 0; i < 5; i++ {
-		tr.add(1<<20, 200*time.Millisecond)
+		tr.add(1<<20, 200*time.Millisecond, time.Time{})
 	}
 
 	s := tr.Stats()
@@ -245,7 +269,7 @@ func TestBucketAccumulation(t *testing.T) {
 	tr := newTracker()
 
 	// Add bytes with a duration shorter than sampleWindow — no sample yet
-	tr.add(1024, 10*time.Millisecond)
+	tr.add(1024, 10*time.Millisecond, time.Time{})
 	if len(tr.samples) != 0 {
 		t.Errorf("expected 0 samples for short duration, got %d", len(tr.samples))
 	}

--- a/iostat/sampler.go
+++ b/iostat/sampler.go
@@ -1,0 +1,122 @@
+package iostat
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const DefaultSampleInterval = time.Second
+
+// ScopedTracker binds a scope name to an IOTracker so one Sampler can report
+// several trackers side by side (e.g. source vs storage).
+type ScopedTracker struct {
+	Name string
+	T    *IOTracker
+}
+
+// Reporter receives one snapshot per scope on every tick. It is an interface
+// rather than *events.Emitter to keep iostat free of a dependency on events,
+// which imports iostat.
+type Reporter interface {
+	ReportIOStats(scope string, read, write IOStats)
+}
+
+type ReporterFunc func(scope string, read, write IOStats)
+
+func (f ReporterFunc) ReportIOStats(scope string, read, write IOStats) {
+	f(scope, read, write)
+}
+
+// Sampler periodically snapshots a set of trackers and reports them, producing
+// evenly spaced samples decoupled from the I/O rate for live graphing.
+type Sampler struct {
+	reporter Reporter
+	interval time.Duration
+	scopes   []ScopedTracker
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	started bool
+	stopped bool
+}
+
+// NewSampler reports the given scopes on each tick; interval <= 0 uses
+// DefaultSampleInterval.
+func NewSampler(reporter Reporter, interval time.Duration, scopes ...ScopedTracker) *Sampler {
+	if interval <= 0 {
+		interval = DefaultSampleInterval
+	}
+	return &Sampler{
+		reporter: reporter,
+		interval: interval,
+		scopes:   scopes,
+	}
+}
+
+// Start launches the sampling goroutine, which runs until Stop or ctx
+// cancellation. No-op with no reporter, no scopes, or if already started.
+func (s *Sampler) Start(ctx context.Context) {
+	if s == nil || s.reporter == nil || len(s.scopes) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.done = make(chan struct{})
+	s.mu.Unlock()
+
+	go func() {
+		defer close(s.done)
+		ticker := time.NewTicker(s.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.report()
+			}
+		}
+	}()
+}
+
+// Stop halts the goroutine and emits a final snapshot for the trailing window.
+// Idempotent and safe to call without a prior Start.
+func (s *Sampler) Stop() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	if !s.started || s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
+	cancel := s.cancel
+	done := s.done
+	s.mu.Unlock()
+
+	cancel()
+	<-done
+
+	s.report()
+}
+
+func (s *Sampler) report() {
+	for _, sc := range s.scopes {
+		if sc.T == nil {
+			continue
+		}
+		s.reporter.ReportIOStats(sc.Name, sc.T.Read.Stats(), sc.T.Write.Stats())
+	}
+}

--- a/iostat/sampler_test.go
+++ b/iostat/sampler_test.go
@@ -1,0 +1,142 @@
+package iostat
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type capture struct {
+	mu      sync.Mutex
+	byScope map[string]int // number of reports seen per scope
+	lastR   map[string]IOStats
+	lastW   map[string]IOStats
+}
+
+func newCapture() *capture {
+	return &capture{
+		byScope: map[string]int{},
+		lastR:   map[string]IOStats{},
+		lastW:   map[string]IOStats{},
+	}
+}
+
+func (c *capture) ReportIOStats(scope string, read, write IOStats) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byScope[scope]++
+	c.lastR[scope] = read
+	c.lastW[scope] = write
+}
+
+func (c *capture) count(scope string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.byScope[scope]
+}
+
+func TestSamplerReportsOnTick(t *testing.T) {
+	tr := New()
+	// feed some read + write bytes so the snapshots are non-zero
+	rs := tr.GetReadSpan()
+	rs.Add(1024)
+	time.Sleep(60 * time.Millisecond)
+	rs.Add(1024)
+	ws := tr.GetWriteSpan()
+	ws.Add(2048)
+	time.Sleep(60 * time.Millisecond)
+	ws.Add(2048)
+
+	cap := newCapture()
+	s := NewSampler(cap, 20*time.Millisecond,
+		ScopedTracker{Name: "storage", T: tr},
+	)
+	s.Start(context.Background())
+	time.Sleep(120 * time.Millisecond)
+	s.Stop()
+
+	// at ~20ms cadence over ~120ms we expect several ticks plus the final one
+	if got := cap.count("storage"); got < 2 {
+		t.Fatalf("expected at least 2 reports, got %d", got)
+	}
+
+	if cap.lastR["storage"].TotalBytes != 2048 {
+		t.Errorf("expected read total 2048, got %d", cap.lastR["storage"].TotalBytes)
+	}
+	if cap.lastW["storage"].TotalBytes != 4096 {
+		t.Errorf("expected write total 4096, got %d", cap.lastW["storage"].TotalBytes)
+	}
+}
+
+func TestSamplerStopEmitsFinalSnapshot(t *testing.T) {
+	tr := New()
+	tr.GetReadSpan().Add(512)
+
+	cap := newCapture()
+	// large interval so no periodic tick fires before Stop
+	s := NewSampler(cap, time.Hour, ScopedTracker{Name: "storage", T: tr})
+	s.Start(context.Background())
+	s.Stop()
+
+	if got := cap.count("storage"); got != 1 {
+		t.Fatalf("expected exactly 1 (final) report, got %d", got)
+	}
+	if cap.lastR["storage"].TotalBytes != 512 {
+		t.Errorf("expected read total 512, got %d", cap.lastR["storage"].TotalBytes)
+	}
+}
+
+func TestSamplerNoReporterOrScopesIsNoop(t *testing.T) {
+	// nil reporter
+	s := NewSampler(nil, time.Millisecond, ScopedTracker{Name: "x", T: New()})
+	s.Start(context.Background())
+	s.Stop() // must not panic
+
+	// no scopes
+	cap := newCapture()
+	s = NewSampler(cap, time.Millisecond)
+	s.Start(context.Background())
+	s.Stop()
+	if len(cap.byScope) != 0 {
+		t.Fatalf("expected no reports, got %v", cap.byScope)
+	}
+}
+
+func TestSamplerStopIsIdempotent(t *testing.T) {
+	tr := New()
+	tr.GetWriteSpan().Add(1)
+	cap := newCapture()
+	s := NewSampler(cap, time.Hour, ScopedTracker{Name: "s", T: tr})
+	s.Start(context.Background())
+	s.Stop()
+	s.Stop() // second Stop must not panic or double-report
+
+	if got := cap.count("s"); got != 1 {
+		t.Fatalf("expected 1 report after idempotent stop, got %d", got)
+	}
+}
+
+func TestSamplerContextCancelStops(t *testing.T) {
+	tr := New()
+	tr.GetReadSpan().Add(100)
+	cap := newCapture()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := NewSampler(cap, 10*time.Millisecond, ScopedTracker{Name: "s", T: tr})
+	s.Start(ctx)
+	cancel()
+	// give the goroutine a moment to observe cancellation
+	time.Sleep(30 * time.Millisecond)
+	s.Stop() // still emits the final snapshot
+	// no panic, and we got at least the final report
+	if got := cap.count("s"); got < 1 {
+		t.Fatalf("expected at least the final report, got %d", got)
+	}
+}
+
+func TestSamplerDefaultInterval(t *testing.T) {
+	s := NewSampler(newCapture(), 0, ScopedTracker{Name: "s", T: New()})
+	if s.interval != DefaultSampleInterval {
+		t.Fatalf("expected default interval %v, got %v", DefaultSampleInterval, s.interval)
+	}
+}

--- a/kcontext/kcontext.go
+++ b/kcontext/kcontext.go
@@ -42,6 +42,10 @@ type KContext struct {
 	CWD            string
 	MaxConcurrency int
 
+	// IOStatsInterval is the sampler cadence for "iostats" events; zero uses
+	// the sampler default.
+	IOStatsInterval time.Duration
+
 	Identity uuid.UUID
 	Keypair  *keypair.KeyPair
 }

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -559,6 +559,10 @@ func (snap *Builder) chunkify(cIdx int, chk *chunkers.Chunker, pathname string, 
 
 	chk.Reset(rd)
 	ctx := snap.AppContext()
+	// One span for the whole file so the gap between chunk reads is accounted as
+	// active read time; a fresh span per chunk would measure ~0 and record no
+	// throughput samples.
+	readSpan := snap.repository.ImportStats.GetReadSpan()
 	for i := 0; ; i++ {
 		if i%1024 == 0 {
 			if err := ctx.Err(); err != nil {
@@ -571,7 +575,7 @@ func (snap *Builder) chunkify(cIdx int, chk *chunkers.Chunker, pathname string, 
 			return nil, objects.MAC{}, -1, err
 		}
 
-		snap.repository.ImportStats.GetReadSpan().Add(int64(len(cdcChunk)))
+		readSpan.Add(int64(len(cdcChunk)))
 
 		if cdcChunk != nil {
 			snap.emitter.ChunkBytes(int64(len(cdcChunk)))

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -578,8 +578,6 @@ func (snap *Builder) chunkify(cIdx int, chk *chunkers.Chunker, pathname string, 
 		readSpan.Add(int64(len(cdcChunk)))
 
 		if cdcChunk != nil {
-			snap.emitter.ChunkBytes(int64(len(cdcChunk)))
-
 			chunkCopy := make([]byte, len(cdcChunk))
 			copy(chunkCopy, cdcChunk)
 

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -574,6 +574,8 @@ func (snap *Builder) chunkify(cIdx int, chk *chunkers.Chunker, pathname string, 
 		snap.repository.ImportStats.GetReadSpan().Add(int64(len(cdcChunk)))
 
 		if cdcChunk != nil {
+			snap.emitter.ChunkBytes(int64(len(cdcChunk)))
+
 			chunkCopy := make([]byte, len(cdcChunk))
 			copy(chunkCopy, cdcChunk)
 

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -357,6 +357,13 @@ func (snap *Builder) Backup(source *Source) error {
 	/* phase 0: setup - prepare source context and indexes */
 	snap.repository.ImportStats = iostat.New()
 
+	sampler := iostat.NewSampler(snap.emitter, snap.AppContext().IOStatsInterval,
+		iostat.ScopedTracker{Name: "source", T: snap.repository.ImportStats},
+		iostat.ScopedTracker{Name: "storage", T: snap.repository.IOStats()},
+	)
+	sampler.Start(snap.AppContext())
+	defer sampler.Stop()
+
 	sourceCtx, err := snap.prepareSourceContext(source)
 	if sourceCtx != nil {
 		defer sourceCtx.indexes.Close(snap.Logger())

--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -10,9 +10,33 @@ import (
 
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/exporter"
+	"github.com/PlakarKorp/kloset/iostat"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/vfs"
 )
+
+// countingReadCloser accounts the bytes the exporter reads against a write
+// span, so throughput reflects what is actually exported.
+type countingReadCloser struct {
+	rd   io.ReadCloser
+	span *iostat.Span
+}
+
+func newCountingReadCloser(rd io.ReadCloser, span *iostat.Span) *countingReadCloser {
+	return &countingReadCloser{rd: rd, span: span}
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.rd.Read(p)
+	if n > 0 {
+		c.span.Add(int64(n))
+	}
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error {
+	return c.rd.Close()
+}
 
 type ExportOptions struct {
 	Strip           string
@@ -23,6 +47,14 @@ type ExportOptions struct {
 func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *ExportOptions) error {
 	emitter := snap.Emitter("export")
 	defer emitter.Close()
+
+	snap.repository.ExportStats = iostat.New()
+	sampler := iostat.NewSampler(emitter, snap.AppContext().IOStatsInterval,
+		iostat.ScopedTracker{Name: "destination", T: snap.repository.ExportStats},
+		iostat.ScopedTracker{Name: "storage", T: snap.repository.IOStats()},
+	)
+	sampler.Start(snap.AppContext())
+	defer sampler.Stop()
 
 	// these are wrong and need to be actually computed from the
 	// entry that we're about to walk.  keeping for now for
@@ -121,20 +153,26 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 				return fmt.Errorf("snapshot entry has non-absolute path %q", entrypath)
 			}
 
+			isRegular := false
 			if e.FileInfo.IsDir() {
 				emitter.Directory(entrypath)
 			} else if e.FileInfo.Mode()&os.ModeSymlink != 0 {
 				emitter.Symlink(entrypath)
 			} else if e.FileInfo.Mode().IsRegular() {
-				// This is a shortcut, but it's safe, integrated plugins are
-				// controlled by us and consume everything, and external plugins
-				// go over grpc which consumes everything.
-				snap.repository.ExportStats.GetWriteSpan().Add(e.FileInfo.Size())
+				isRegular = true
 				emitter.File(entrypath)
 			}
 			records <- connectors.NewRecord(entrypath, e.SymlinkTarget, e.FileInfo, e.ExtendedAttributes,
 				func() (io.ReadCloser, error) {
-					return e.Open(pvfs)
+					f, err := e.Open(pvfs)
+					if err != nil {
+						return nil, err
+					}
+					var rd io.ReadCloser = f
+					if isRegular {
+						rd = newCountingReadCloser(rd, snap.repository.ExportStats.GetWriteSpan())
+					}
+					return rd, nil
 				})
 			return nil
 		})

--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -10,31 +10,26 @@ import (
 
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/exporter"
-	"github.com/PlakarKorp/kloset/events"
 	"github.com/PlakarKorp/kloset/iostat"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/vfs"
 )
 
 // countingReadCloser accounts the bytes the exporter reads against a write
-// span, so throughput reflects what is actually exported. It also reports the
-// bytes as they flow via emitter.ChunkBytes, letting consumers advance progress
-// *within* a large file rather than only when the whole file completes.
+// span, so throughput reflects what is actually exported.
 type countingReadCloser struct {
-	rd      io.ReadCloser
-	span    *iostat.Span
-	emitter *events.Emitter
+	rd   io.ReadCloser
+	span *iostat.Span
 }
 
-func newCountingReadCloser(rd io.ReadCloser, span *iostat.Span, emitter *events.Emitter) *countingReadCloser {
-	return &countingReadCloser{rd: rd, span: span, emitter: emitter}
+func newCountingReadCloser(rd io.ReadCloser, span *iostat.Span) *countingReadCloser {
+	return &countingReadCloser{rd: rd, span: span}
 }
 
 func (c *countingReadCloser) Read(p []byte) (int, error) {
 	n, err := c.rd.Read(p)
 	if n > 0 {
 		c.span.Add(int64(n))
-		c.emitter.ChunkBytes(int64(n))
 	}
 	return n, err
 }
@@ -175,7 +170,7 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 					}
 					var rd io.ReadCloser = f
 					if isRegular {
-						rd = newCountingReadCloser(rd, snap.repository.ExportStats.GetWriteSpan(), emitter)
+						rd = newCountingReadCloser(rd, snap.repository.ExportStats.GetWriteSpan())
 					}
 					return rd, nil
 				})

--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -10,26 +10,31 @@ import (
 
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/exporter"
+	"github.com/PlakarKorp/kloset/events"
 	"github.com/PlakarKorp/kloset/iostat"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/vfs"
 )
 
 // countingReadCloser accounts the bytes the exporter reads against a write
-// span, so throughput reflects what is actually exported.
+// span, so throughput reflects what is actually exported. It also reports the
+// bytes as they flow via emitter.ChunkBytes, letting consumers advance progress
+// *within* a large file rather than only when the whole file completes.
 type countingReadCloser struct {
-	rd   io.ReadCloser
-	span *iostat.Span
+	rd      io.ReadCloser
+	span    *iostat.Span
+	emitter *events.Emitter
 }
 
-func newCountingReadCloser(rd io.ReadCloser, span *iostat.Span) *countingReadCloser {
-	return &countingReadCloser{rd: rd, span: span}
+func newCountingReadCloser(rd io.ReadCloser, span *iostat.Span, emitter *events.Emitter) *countingReadCloser {
+	return &countingReadCloser{rd: rd, span: span, emitter: emitter}
 }
 
 func (c *countingReadCloser) Read(p []byte) (int, error) {
 	n, err := c.rd.Read(p)
 	if n > 0 {
 		c.span.Add(int64(n))
+		c.emitter.ChunkBytes(int64(n))
 	}
 	return n, err
 }
@@ -170,7 +175,7 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 					}
 					var rd io.ReadCloser = f
 					if isRegular {
-						rd = newCountingReadCloser(rd, snap.repository.ExportStats.GetWriteSpan())
+						rd = newCountingReadCloser(rd, snap.repository.ExportStats.GetWriteSpan(), emitter)
 					}
 					return rd, nil
 				})

--- a/snapshot/synchronize.go
+++ b/snapshot/synchronize.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/iostat"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/resources"
@@ -158,9 +159,21 @@ func (src *Snapshot) Synchronize(dst *Builder) error {
 		return err
 	}
 
+	// dst.Import samples the destination side; the source repository's reads
+	// live on a separate tracker, so sample those here to cover both stores.
+	syncEmitter := dst.Emitter("synchronize")
+	defer syncEmitter.Close()
+	src.repository.IOStats().Reset()
+	srcSampler := iostat.NewSampler(syncEmitter, dst.AppContext().IOStatsInterval,
+		iostat.ScopedTracker{Name: "source-storage", T: src.repository.IOStats()},
+	)
+	srcSampler.Start(dst.AppContext())
+
 	if err := dst.Import(source); err != nil {
+		srcSampler.Stop()
 		return err
 	}
+	srcSampler.Stop()
 
 	srcErrors := imp.src.Header.GetSource(0).Summary.Directory.Errors + imp.src.Header.GetSource(0).Summary.Below.Errors
 	nErrors := dst.Header.GetSource(0).Summary.Directory.Errors + dst.Header.GetSource(0).Summary.Below.Errors


### PR DESCRIPTION
We track read/write throughput per repository but nothing surfaces it during a run, so a consumer (the TUI, plakman) has no way to graph it live. This adds a sampler that periodically snapshots the trackers and emits the result as `iostats` events.

An `iostat.Sampler` snapshots a set of scoped trackers on a ticker and reports them through a small `Reporter` interface (an interface, not `*events.Emitter`, to avoid an import cycle since events imports iostat). The samples are evenly spaced and decoupled from the actual I/O rate, which is what a grapher wants. Cadence is tunable via `KContext.IOStatsInterval` and defaults to one second.

It's wired into backup (source + storage), export (destination + storage) and synchronize. Sync reads one store and writes another, so it also samples the *source* repository's storage tracker — `dst.Import` only ever sees the destination side.

While here, fix export accounting: bytes were counted as `FileInfo.Size()` at record-emit time, before the export actually happened, which made the throughput samples meaningless. We now count the bytes the exporter actually reads.

Also emit a `chunk.bytes` event as payload bytes are read on the backup chunker path and as the exporter drains a file. `FileOk` only fires once a whole file completes, so this lets a consumer advance progress *within* a large file. A side-effect-free `tracker.TotalBytes()` is added alongside so a UI can poll the running total without flushing the sampling bucket.
