### PR TITLE
ci: actually propagate tests failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,10 +32,11 @@ jobs:
       id: gotest
       continue-on-error: true
       run: |
-        go install github.com/jstemmer/go-junit-report/v2@latest
         set -o pipefail
-        go test -v -coverprofile=coverage.out -covermode=atomic -timeout 1m -json ./... \
-          | "$(go env GOPATH)/bin/go-junit-report" -parser gojson -set-exit-code > junit.xml
+        set +e # disable errexit
+        go install github.com/jstemmer/go-junit-report/v2@latest && \
+            (go test -v -coverprofile=coverage.out -covermode=atomic -timeout 1m -json ./... \
+            | "$(go env GOPATH)/bin/go-junit-report" -parser gojson -set-exit-code > junit.xml)
         status=$?
         echo "test_exit=$status" >> "$GITHUB_OUTPUT"
         exit $status


### PR DESCRIPTION
`run` is executed in an environment where `errexit` is set, so if the tests fail, we don't get the chance to execute the rest of the script.

while here, catch the failure also if `go install` fails.