### PR TITLE
Update sqlite.go

### DIFF
--- a/caching/sqlite/sqlite.go
+++ b/caching/sqlite/sqlite.go
@@ -59,7 +59,7 @@ func New(dir, name string, opts *Options) (*SQLiteCache, error) {
 			"&_pragma=synchronous(OFF)" +
 			"&_pragma=temp_store(MEMORY)" +
 			"&_pragma=mmap_size(0)" +
-			"&_pragma=cache_size(-20000)" +
+			"&_pragma=cache_size(-2000)" +
 			"&_pragma=busy_timeout(5000)"
 
 		// If ro and the file does not exist, we need to open the db rw close it


### PR DESCRIPTION
reduce cache_size, the default recommended value by SQLite is -2000 and it turns out to be produce similar performances with a considerable memory usage drop:

baseline:
- timing: 244s on first run, 229s on second
- Peak RSS: 2.5G on first, 3.1 on second

with this:
- timing: 242s on first run, 230s on second 
- Peak RSS: 1.8G on first, 2.3G on second