### PR TITLE
location: rename FLAG_STREAM as FLAG_SIDEEFFECTS

### DIFF
--- a/location/location.go
+++ b/location/location.go
@@ -10,12 +10,17 @@ import (
 type Flags uint32
 
 const (
-	FLAG_LOCALFS Flags = 1 << iota // all: dealing with a file (or dir) on the local fs
-	FLAG_FILE                      // storage: kloset is in a single file
-	FLAG_STREAM                    // importer: cannot call Import() more than once
-	FLAG_NEEDACK                   // importer: cares about acknowledgments in Import()
-	FLAG_NOMERGE                   // importer: cannot merge those in a single snapshot (multidir support)
-	FLAG_EXPORTXATTR               // exporter: please send extended attributes during Export()
+	FLAG_LOCALFS     Flags = 1 << iota // all: dealing with a file (or dir) on the local fs
+	FLAG_FILE                          // storage: kloset is in a single file
+	FLAG_SIDEEFFECTS                   // importer: has side effects, don't compute statistics
+	FLAG_NEEDACK                       // importer: cares about acknowledgments in Import()
+	FLAG_NOMERGE                       // importer: cannot merge those in a single snapshot (multidir support)
+	FLAG_EXPORTXATTR                   // exporter: send extended attributes during Export()
+
+	// compat:
+
+	// Deprecated: name for FLAG_SIDEEFFECTS
+	FLAG_STREAM = FLAG_SIDEEFFECTS
 )
 
 var ErrUnknownFlag = errors.New("unknown flag")
@@ -119,8 +124,8 @@ func ParseFlag(name string) (Flags, error) {
 		return FLAG_LOCALFS, nil
 	case "file":
 		return FLAG_FILE, nil
-	case "stream":
-		return FLAG_STREAM, nil
+	case "sideeffects", "stream":
+		return FLAG_SIDEEFFECTS, nil
 	case "needack":
 		return FLAG_NEEDACK, nil
 	case "nomerge":


### PR DESCRIPTION
stream was a bad name, as it doesn't really imply the fact that it's not safe to call the importer twice to gather some statistics.

Strictly speaking, all integrations have side effects, even just a network connection is, but it conveys better the idea of "spooky action at a distance" happening.

For backward compatibility, add an alias for FLAG_STREAM to FLAG_SIDEEFFECTS and also make ParseFlag accept the new name.