### PR TITLE
backup: Reduce the number of GetBlobs.

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -824,15 +824,13 @@ func (snap *Builder) computeContent(idx int, chunker *chunkers.Chunker, cachedPa
 	}
 
 	if cachedPath != nil && cachedPath.ObjectMAC != (objects.MAC{}) {
-		if snap.repository.BlobExists(resources.RT_OBJECT, cachedPath.ObjectMAC) {
-			return &contentMeta{
-				ObjectMAC:   cachedPath.ObjectMAC,
-				Size:        cachedPath.FileInfo.Size(),
-				Chunks:      cachedPath.Chunks,
-				Entropy:     cachedPath.Entropy,
-				ContentType: cachedPath.ContentType,
-			}, nil
-		}
+		return &contentMeta{
+			ObjectMAC:   cachedPath.ObjectMAC,
+			Size:        cachedPath.FileInfo.Size(),
+			Chunks:      cachedPath.Chunks,
+			Entropy:     cachedPath.Entropy,
+			ContentType: cachedPath.ContentType,
+		}, nil
 	}
 
 	obj, objMAC, dataSize, err := snap.chunkify(idx, chunker, record.Pathname, record.Reader, record.IsXattr)
@@ -856,7 +854,7 @@ func (snap *Builder) writeDirectoryEntry(idx int, sourceCtx *sourceContext, cach
 	dirEntry := vfs.NewEntry(path.Dir(record.Pathname), record)
 	var dirEntryMAC objects.MAC
 
-	if cachedPath != nil && snap.repository.BlobExists(resources.RT_VFS_ENTRY, cachedPath.MAC) {
+	if cachedPath != nil {
 		dirEntryMAC = cachedPath.MAC
 		serialized, err := dirEntry.ToBytes()
 		if err != nil {
@@ -897,7 +895,7 @@ func (snap *Builder) writeFileEntry(idx int, sourceCtx *sourceContext, meta *con
 	var serializedFileEntry []byte
 	var err error
 
-	if cachedPath != nil && snap.repository.BlobExists(resources.RT_VFS_ENTRY, cachedPath.MAC) {
+	if cachedPath != nil {
 		fileEntryMAC = cachedPath.MAC
 		if fileEntry.Object == (objects.MAC{}) && cachedPath.ObjectMAC != (objects.MAC{}) {
 			fileEntry.Object = cachedPath.ObjectMAC


### PR DESCRIPTION
* When getting an object out of the cache it's not needed to recheck that it exists in the repo. This used to be true because the vfs cache was local and so it could be lying (repo changed due to another user). Now that we base the vfs cache on a previous snapshot we know _by definition_ that  the object exists and so BlobExists will always be true.

* BlobExists is a "slow" function and is the hottest path of them all, reducing its usage is always a win.

* On a non changing backup this divides by 4 the number of calls we emit to the state cache.

* This is a scary diff, I've been sitting on it for a while, so this needs to get some extra considerations from reviewers.