### PR TITLE
platar: Fix early exit handling.

### DIFF
--- a/repository/packer/platar.go
+++ b/repository/packer/platar.go
@@ -129,6 +129,12 @@ func (mgr *platarPackerManager) Wait() {
 }
 
 func (mgr *platarPackerManager) InsertIfNotPresent(Type resources.Type, mac objects.MAC) (bool, error) {
+	select {
+	case <-mgr.closing:
+		return false, ErrShutdown
+	default:
+	}
+
 	// XXX: This is not atomic, as such it leaves a possibility of missed dedup (unlikely though). Needs to be fixed by using a batch.
 	has, err := mgr.packingCache.HasBlob(Type, mac)
 	if err != nil {
@@ -163,5 +169,11 @@ func (mgr *platarPackerManager) Put(_ int, Type resources.Type, mac objects.MAC,
 }
 
 func (mgr *platarPackerManager) Exists(Type resources.Type, mac objects.MAC) (bool, error) {
+	select {
+	case <-mgr.closing:
+		return false, ErrShutdown
+	default:
+	}
+
 	return mgr.packingCache.HasBlob(Type, mac)
 }


### PR DESCRIPTION
* The fix in 1ade68a9b8deedc8cb1f88df2cf29dca03847261 was incomplete. Since platar uses a scanCache for dedupplication purpose, we also need to apply the same early exist in existence testing function otherwise we are using an already closed cache!

* Found by plakar's pkg create tests ! It would randomly fail on a test that exists early due to a bad source.