### PR TITLE
Poolp org/tui progress bus

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -46,6 +46,21 @@ func (eb *EventsBUS) Listen() <-chan *Event {
 	return eb.c
 }
 
+// Publish injects an event onto the bus, dropping it if nobody listens.
+func (eb *EventsBUS) Publish(e *Event) {
+	if eb.c == nil {
+		return
+	}
+	eb.c <- e
+}
+
+// Forward republishes every event from this bus onto dst until this bus closes.
+func (eb *EventsBUS) Forward(dst *EventsBUS) {
+	for e := range eb.Listen() {
+		dst.Publish(e)
+	}
+}
+
 const (
 	Info  = "info"
 	Warn  = "warn"

--- a/snapshot/synchronize.go
+++ b/snapshot/synchronize.go
@@ -139,6 +139,9 @@ func (src *Snapshot) Synchronize(dst *Builder) error {
 		src:    src,
 	}
 
+	// grab the summary before dst.Header aliases it and nils Sources.
+	srcSummary := src.Header.GetSource(0).Summary
+
 	dst.Header = src.Header
 	dst.Header.Sources = nil
 
@@ -159,11 +162,25 @@ func (src *Snapshot) Synchronize(dst *Builder) error {
 		return err
 	}
 
+	// Import labels its events "backup"; relabel to "synchronize".
+	syncEmitter := dst.Emitter("synchronize")
+	dst.emitter = syncEmitter
+	defer syncEmitter.Close()
+
+	// the total is known up front, so publish it like backup/export do.
+	dst.emitter.FilesystemSummary(
+		srcSummary.Directory.Files+srcSummary.Below.Files,
+		srcSummary.Directory.Directories+srcSummary.Below.Directories,
+		srcSummary.Directory.Symlinks+srcSummary.Below.Symlinks,
+		0,
+		srcSummary.Directory.Size+srcSummary.Below.Size,
+	)
+
 	// dst.Import samples the destination side; the source repository's reads
 	// live on a separate tracker, so sample those here to cover both stores.
-	syncEmitter := dst.Emitter("synchronize")
-	defer syncEmitter.Close()
+	// Reset both per snapshot so they stay in step across snapshots.
 	src.repository.IOStats().Reset()
+	dst.repository.IOStats().Reset()
 	srcSampler := iostat.NewSampler(syncEmitter, dst.AppContext().IOStatsInterval,
 		iostat.ScopedTracker{Name: "source-storage", T: src.repository.IOStats()},
 	)


### PR DESCRIPTION
reworked after discussion with math:

- provide two new EventsBUS methods needed for TUI handling of "nested" commands (sync which does multiple internal backups or check which does multiple checks)
- while at it fix an issue with statistics reported by sync, these were not properly tracked which didnt show as we dont plug a TUI on sync yet but become apparent with my work in plakar.