### PR TITLE
snapshot: validate vfs entries and keep export within the restore tree

### DIFF
--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -134,6 +134,12 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 			}
 			i++
 
+			// a rejected entry arrives as (nil, err); skip it before deref.
+			if err != nil {
+				emitter.PathError(entrypath, err)
+				return nil
+			}
+
 			// path.Clean will not remove ".." elements if the path is not
 			// absolute.  so, let's make it absolute, clean it for good
 			// hygiene, then strip prefix and make sure it's still absolute.

--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"fmt"
 	"io"
+	iofs "io/fs"
 	"os"
 	"path"
 	"strings"
@@ -37,6 +38,20 @@ func (c *countingReadCloser) Read(p []byte) (int, error) {
 
 func (c *countingReadCloser) Close() error {
 	return c.rd.Close()
+}
+
+// symlinkAncestor returns the closest ancestor of entrypath present in
+// symlinks. Keys and entrypath must be clean absolute paths.
+func symlinkAncestor(symlinks map[string]struct{}, entrypath string) (string, bool) {
+	if len(symlinks) == 0 {
+		return "", false
+	}
+	for parent := path.Dir(entrypath); parent != "/" && parent != "."; parent = path.Dir(parent) {
+		if _, ok := symlinks[parent]; ok {
+			return parent, true
+		}
+	}
+	return "", false
 }
 
 type ExportOptions struct {
@@ -125,6 +140,11 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 				})
 		}
 
+		// emitted symlinks, to skip entries below them: an exporter can't tell
+		// from the record stream that a path component is a symlink. WalkDir
+		// yields parents before children, so a symlink is seen first.
+		symlinks := make(map[string]struct{})
+
 		i := 0
 		pvfs.WalkDir(pathname, func(entrypath string, e *vfs.Entry, err error) error {
 			if i%1000 == 0 {
@@ -162,10 +182,20 @@ func (snap *Snapshot) Export(exp exporter.Exporter, pathname string, opts *Expor
 				return fmt.Errorf("snapshot entry has non-absolute path %q", entrypath)
 			}
 
+			if parent, ok := symlinkAncestor(symlinks, entrypath); ok {
+				err := fmt.Errorf("snapshot entry %q lies below symlink %q", entrypath, parent)
+				emitter.PathError(entrypath, err)
+				if e.FileInfo.IsDir() {
+					return iofs.SkipDir // skip the whole subtree
+				}
+				return nil
+			}
+
 			isRegular := false
 			if e.FileInfo.IsDir() {
 				emitter.Directory(entrypath)
 			} else if e.FileInfo.Mode()&os.ModeSymlink != 0 {
+				symlinks[entrypath] = struct{}{}
 				emitter.Symlink(entrypath)
 			} else if e.FileInfo.Mode().IsRegular() {
 				isRegular = true

--- a/snapshot/export_symlink_test.go
+++ b/snapshot/export_symlink_test.go
@@ -1,0 +1,58 @@
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSymlinkAncestor(t *testing.T) {
+	t.Run("empty set never matches", func(t *testing.T) {
+		_, ok := symlinkAncestor(map[string]struct{}{}, "/link/child")
+		require.False(t, ok)
+	})
+
+	symlinks := map[string]struct{}{
+		"/link":            {},
+		"/deep/nested/lnk": {},
+	}
+
+	t.Run("direct child of symlink", func(t *testing.T) {
+		parent, ok := symlinkAncestor(symlinks, "/link/child")
+		require.True(t, ok)
+		require.Equal(t, "/link", parent)
+	})
+
+	t.Run("deep descendant of symlink", func(t *testing.T) {
+		parent, ok := symlinkAncestor(symlinks, "/link/a/b/c")
+		require.True(t, ok)
+		require.Equal(t, "/link", parent)
+	})
+
+	t.Run("nested symlink is caught", func(t *testing.T) {
+		parent, ok := symlinkAncestor(symlinks, "/deep/nested/lnk/evil")
+		require.True(t, ok)
+		require.Equal(t, "/deep/nested/lnk", parent)
+	})
+
+	// The symlink entry itself must still be exported -- it is a legitimate
+	// entry, and only things *below* it are refused.
+	t.Run("symlink itself is not its own ancestor", func(t *testing.T) {
+		_, ok := symlinkAncestor(symlinks, "/link")
+		require.False(t, ok)
+	})
+
+	t.Run("unrelated paths pass", func(t *testing.T) {
+		for _, p := range []string{"/etc/passwd", "/linkage/file", "/deep/nested/other", "/"} {
+			_, ok := symlinkAncestor(symlinks, p)
+			require.False(t, ok, "path %q should not be blocked", p)
+		}
+	})
+
+	// A sibling whose name merely shares a prefix with the symlink must not be
+	// caught by a sloppy string-prefix check.
+	t.Run("prefix sibling is not blocked", func(t *testing.T) {
+		_, ok := symlinkAncestor(symlinks, "/link2/file")
+		require.False(t, ok)
+	})
+}

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -70,6 +70,27 @@ func (e *Entry) HasObject() bool {
 	return e.Object != objects.MAC{}
 }
 
+var ErrMalformedEntry = errors.New("malformed vfs entry")
+
+func (e *Entry) validate() error {
+	name := e.FileInfo.Lname
+
+	// root is named "/"; the builder leaves its parent as "/" or "".
+	if name == "/" && (e.ParentPath == "/" || e.ParentPath == "") {
+		return nil
+	}
+
+	if name == "" || name == "." || name == ".." || strings.ContainsRune(name, '/') {
+		return fmt.Errorf("%w: bad name %q", ErrMalformedEntry, name)
+	}
+
+	if !path.IsAbs(e.ParentPath) || path.Clean(e.ParentPath) != e.ParentPath {
+		return fmt.Errorf("%w: bad parent path %q", ErrMalformedEntry, e.ParentPath)
+	}
+
+	return nil
+}
+
 // Return empty lists for nil slices.
 func (e *Entry) MarshalJSON() ([]byte, error) {
 	// Create an alias to avoid recursive MarshalJSON calls
@@ -124,8 +145,13 @@ func NewEntry(parentPath string, record *connectors.Record) *Entry {
 
 func EntryFromBytes(bytes []byte) (*Entry, error) {
 	entry := Entry{}
-	err := msgpack.Unmarshal(bytes, &entry)
-	return &entry, err
+	if err := msgpack.Unmarshal(bytes, &entry); err != nil {
+		return &entry, err
+	}
+	if err := entry.validate(); err != nil {
+		return nil, err
+	}
+	return &entry, nil
 }
 
 func (e *Entry) ToBytes() ([]byte, error) {
@@ -312,6 +338,18 @@ func (e *Entry) getdentsDirpack(fsc *Filesystem) (iter.Seq2[*Entry, error], erro
 			}
 			if _, err := io.ReadFull(rd, entry.MAC[:]); err != nil {
 				yield(nil, fmt.Errorf("failed to read entry mac: %w", err))
+				return
+			}
+
+			if err := entry.validate(); err != nil {
+				yield(nil, err)
+				return
+			}
+
+			// a dirpack lists one directory: every record is a direct child.
+			if entry.ParentPath != prefix {
+				yield(nil, fmt.Errorf("%w: entry %q claims parent %q in dirpack for %q",
+					ErrMalformedEntry, entry.FileInfo.Lname, entry.ParentPath, prefix))
 				return
 			}
 

--- a/snapshot/vfs/entry_dirpack_validate_test.go
+++ b/snapshot/vfs/entry_dirpack_validate_test.go
@@ -1,0 +1,128 @@
+package vfs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// encodeDirpackEntry frames an entry the way a dirpack object stores it:
+// a type byte, a size, the msgpack body, then the entry MAC.
+func encodeDirpackEntry(t *testing.T, e *Entry) []byte {
+	t.Helper()
+
+	body, err := msgpack.Marshal(e)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint8(0)))
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(len(body)+len(e.MAC))))
+	buf.Write(body)
+	buf.Write(e.MAC[:])
+	return buf.Bytes()
+}
+
+// decodeDirpackStream mirrors the decode loop in getdentsDirpack, including its
+// validation, so entry rejection can be exercised without standing up a whole
+// repository.  It must stay in sync with getdentsDirpack.
+func decodeDirpackStream(t *testing.T, prefix string, raw []byte) ([]*Entry, error) {
+	t.Helper()
+
+	rd := bytes.NewReader(raw)
+	var out []*Entry
+	for rd.Len() > 0 {
+		_, siz, err := readDirPackHdr(rd)
+		if err != nil {
+			return out, err
+		}
+
+		var entry Entry
+		lrd := &lentil{rd: rd, n: int64(siz - uint32(len(entry.MAC)))}
+		if err := msgpack.NewDecoder(lrd).Decode(&entry); err != nil {
+			return out, err
+		}
+		if _, err := rd.Read(entry.MAC[:]); err != nil {
+			return out, err
+		}
+
+		if err := entry.validate(); err != nil {
+			return out, err
+		}
+		if entry.ParentPath != prefix {
+			return out, ErrMalformedEntry
+		}
+		out = append(out, &entry)
+	}
+	return out, nil
+}
+
+type lentil struct {
+	rd *bytes.Reader
+	n  int64
+}
+
+func (l *lentil) Read(p []byte) (int, error) {
+	if l.n <= 0 {
+		return 0, nil
+	}
+	if int64(len(p)) > l.n {
+		p = p[:l.n]
+	}
+	n, err := l.rd.Read(p)
+	l.n -= int64(n)
+	return n, err
+}
+
+// A dirpack for the root directory that lists a symlink and then a file whose
+// parent is that symlink: the second entry must be rejected, since it is not a
+// direct child of the directory whose listing it appears in.
+func TestDirpackRejectsMismatchedParent(t *testing.T) {
+	symlink := &Entry{
+		ParentPath: "/",
+		FileInfo:   objects.FileInfo{Lname: "link", Lmode: 0777},
+	}
+	forged := &Entry{
+		ParentPath: "/link",
+		FileInfo:   objects.FileInfo{Lname: "child", Lmode: 0644},
+	}
+
+	raw := append(encodeDirpackEntry(t, symlink), encodeDirpackEntry(t, forged)...)
+
+	entries, err := decodeDirpackStream(t, "/", raw)
+	require.ErrorIs(t, err, ErrMalformedEntry,
+		"an entry claiming a parent other than the dirpack's directory must be rejected")
+	require.Len(t, entries, 1, "the legitimate symlink entry is still returned")
+	require.Equal(t, "/link", entries[0].Path())
+}
+
+// A name carrying a separator is rejected before it can be joined into a path.
+func TestDirpackRejectsSeparatorInName(t *testing.T) {
+	forged := &Entry{
+		ParentPath: "/",
+		FileInfo:   objects.FileInfo{Lname: "link/child", Lmode: 0644},
+	}
+
+	_, err := decodeDirpackStream(t, "/", encodeDirpackEntry(t, forged))
+	require.ErrorIs(t, err, ErrMalformedEntry)
+}
+
+// A well-formed listing decodes cleanly.
+func TestDirpackAcceptsWellFormedListing(t *testing.T) {
+	var raw []byte
+	for _, name := range []string{"a.txt", "b.txt", "subdir"} {
+		raw = append(raw, encodeDirpackEntry(t, &Entry{
+			ParentPath: "/data",
+			FileInfo:   objects.FileInfo{Lname: name, Lmode: 0644},
+		})...)
+	}
+
+	entries, err := decodeDirpackStream(t, "/data", raw)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	require.Equal(t, "/data/a.txt", entries[0].Path())
+	require.Equal(t, "/data/subdir", entries[2].Path())
+}

--- a/snapshot/vfs/entry_validate_test.go
+++ b/snapshot/vfs/entry_validate_test.go
@@ -1,0 +1,91 @@
+package vfs
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// Entries decoded from a repository must describe a path within the tree they
+// belong to.  These cover the malformed name and parent-path shapes validate
+// is meant to reject, alongside the legitimate ones it must accept.
+func TestEntryValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		parentPath string
+		lname      string
+		wantErr    bool
+	}{
+		{"plain file", "/etc", "passwd", false},
+		{"file at root", "/", "passwd", false},
+		{"root entry, empty parent", "", "/", false},
+		{"root entry, slash parent", "/", "/", false},
+		{"dotfile is fine", "/home/user", ".bashrc", false},
+		{"name with dots is fine", "/tmp", "..hidden", false},
+
+		{"separator in name", "/tmp", "link/child", true},
+		{"parent traversal name", "/tmp", "..", true},
+		{"current dir name", "/tmp", ".", true},
+		{"empty name", "/tmp", "", true},
+		{"absolute name", "/tmp", "/etc/passwd", true},
+		{"relative parent", "tmp", "file", true},
+		{"unclean parent", "/tmp/../etc", "passwd", true},
+		{"parent with trailing slash", "/tmp/", "file", true},
+		{"empty parent non-root name", "", "file", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Entry{
+				ParentPath: tc.parentPath,
+				FileInfo:   objects.FileInfo{Lname: tc.lname},
+			}
+			err := e.validate()
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrMalformedEntry)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// EntryFromBytes is the single funnel for entry deserialization, so the
+// validation has to bite there and not only in the explicit call.
+func TestEntryFromBytesRejectsMalformed(t *testing.T) {
+	malformed := &Entry{
+		ParentPath: "/",
+		FileInfo:   objects.FileInfo{Lname: "link/child"},
+	}
+	buf, err := msgpack.Marshal(malformed)
+	require.NoError(t, err)
+
+	_, err = EntryFromBytes(buf)
+	require.ErrorIs(t, err, ErrMalformedEntry)
+}
+
+func TestEntryFromBytesAcceptsWellFormed(t *testing.T) {
+	good := &Entry{
+		ParentPath: "/etc",
+		FileInfo:   objects.FileInfo{Lname: "passwd"},
+	}
+	buf, err := msgpack.Marshal(good)
+	require.NoError(t, err)
+
+	entry, err := EntryFromBytes(buf)
+	require.NoError(t, err)
+	require.Equal(t, "/etc/passwd", entry.Path())
+}
+
+// A well-formed name under a parent that happens to be a symlink passes
+// validate on its own: name and parent are both structurally fine.  This is why
+// the dirpack parent check and the export-side symlink guard exist in addition
+// to validate -- structural validation alone does not cover this case.
+func TestEntryPathValidUnderSymlinkParent(t *testing.T) {
+	e := &Entry{
+		ParentPath: "/link",
+		FileInfo:   objects.FileInfo{Lname: "child"},
+	}
+	require.NoError(t, e.validate())
+	require.Equal(t, "/link/child", e.Path())
+}


### PR DESCRIPTION
vfs entries decoded from a repository were used as-is when building paths during export.  Tighten this so entry paths are always well-formed and an export stays within the tree being restored.

Validate entries at decode time in EntryFromBytes and getdentsDirpack: names must be a single clean component, parent paths must be absolute and clean, and every record in a dirpack must be a direct child of the directory it lists.  On export, track emitted symlinks and skip any entry that would resolve underneath one, so a restore stays within the tree regardless of the exporter in use.

Decode-time rejection surfaces as (nil, err) in the export walk; handle that error rather than dereferencing the entry.