### PR TITLE
snapshot: Fix a data race on the import scan counters

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -355,9 +355,9 @@ func (snap *Builder) importerJob(sourceCtx *sourceContext) error {
 	snap.emitter.Info("snapshot.import.start", map[string]any{})
 	defer func() {
 		snap.emitter.Info("snapshot.import.done", map[string]any{
-			"nfiles": stats.nfiles,
-			"ndirs":  stats.ndirs,
-			"size":   stats.size,
+			"nfiles": atomic.LoadUint64(&stats.nfiles),
+			"ndirs":  atomic.LoadUint64(&stats.ndirs),
+			"size":   atomic.LoadUint64(&stats.size),
 		})
 	}()
 

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -1,6 +1,7 @@
 package snapshot
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -235,6 +236,13 @@ func (snap *Builder) importSource(imp importer.Importer, sourceCtx *sourceContex
 		ctx = snap.AppContext()
 	)
 
+	// Scoped to this source so we can unblock our own workers on the way
+	// out without disturbing the rest of the backup. Importers are only
+	// required to close records on success; on the error path we cancel
+	// instead of trusting them to.
+	workerCtx, stopWorkers := context.WithCancel(ctx)
+	defer stopWorkers()
+
 	var results chan *connectors.Result
 	if (imp.Flags() & location.FLAG_NEEDACK) != 0 {
 		results = make(chan *connectors.Result, size)
@@ -246,8 +254,8 @@ func (snap *Builder) importSource(imp importer.Importer, sourceCtx *sourceContex
 		wg.Go(func() error {
 			for {
 				select {
-				case <-ctx.Done():
-					return ctx.Err()
+				case <-workerCtx.Done():
+					return workerCtx.Err()
 
 				case record, ok := <-records:
 					if !ok {
@@ -288,8 +296,18 @@ func (snap *Builder) importSource(imp importer.Importer, sourceCtx *sourceContex
 
 			// we also need to drain records if we were canceled
 			// otherwise importers may hang if they tried to send
-			// before handling cancellation
-			for range records {
+			// before handling cancellation.
+			//
+			// Stop once it's drained rather than once it's closed: a
+			// failing importer may return without ever closing it, and
+			// blocking here would keep errch open forever.
+			for drained := false; !drained; {
+				select {
+				case _, ok := <-records:
+					drained = !ok
+				default:
+					drained = true
+				}
 			}
 		}
 
@@ -306,15 +324,24 @@ func (snap *Builder) importSource(imp importer.Importer, sourceCtx *sourceContex
 			// workers.
 		}
 	}
+
+	// Always wait for the workers, even when the importer failed: they
+	// keep writing to stats and to sourceCtx until they stop, and our
+	// caller reads stats as soon as we return.
+	//
+	// On success the importer has closed records, so the workers are
+	// already on their way out. On failure it may not have, so cancel
+	// them rather than wait for a close that may never come.
+	if importerErr != nil {
+		stopWorkers()
+	}
+	workerErr := <-errch
+
 	if importerErr != nil {
 		return importerErr
 	}
 
-	if err := <-errch; err != nil {
-		return err
-	}
-
-	return nil
+	return workerErr
 }
 
 func (snap *Builder) importerJob(sourceCtx *sourceContext) error {

--- a/snapshot/backup_test.go
+++ b/snapshot/backup_test.go
@@ -1,14 +1,19 @@
 package snapshot_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
 	ptesting "github.com/PlakarKorp/kloset/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -142,4 +147,51 @@ func TestBackupEmptyScan(t *testing.T) {
 
 	summary := snap.Header.GetSource(0).Summary
 	require.Equal(t, summary.Below.Directories, uint64(0))
+}
+
+// rudeImporter fails without closing the records channel, leaving records
+// buffered behind it. Closing records is only a convention that in-tree
+// importers happen to follow, so the backup has to cancel its workers
+// rather than wait on a close that may never come.
+type rudeImporter struct{ *ptesting.MockImporter }
+
+func (rudeImporter) Import(ctx context.Context, records chan<- *connectors.Record, results <-chan *connectors.Result) error {
+	// Leave more records queued than the workers can retire before we
+	// return, so anything waiting on a close of records stays parked.
+	for i := range 256 {
+		f := ptesting.NewMockFile(fmt.Sprintf("f%d", i), 0644, "hello world!\n")
+		select {
+		case records <- f.ScanResult():
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return errors.New("importer gave up")
+}
+
+func TestBackupImporterErrorWithoutClose(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	builder, err := snapshot.Create(repo, repository.DefaultType, "", objects.NilMac,
+		&snapshot.BuilderOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { builder.Close() })
+
+	base, err := ptesting.NewMockImporter(repo.AppContext(), &connectors.Options{},
+		"mock", map[string]string{"location": "mock://place"})
+	require.NoError(t, err)
+
+	src, err := snapshot.NewSource(repo.AppContext(),
+		rudeImporter{base.(*ptesting.MockImporter)})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- builder.Backup(src) }()
+
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "importer gave up")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Backup hung after the importer failed without closing records")
+	}
 }


### PR DESCRIPTION
`plakar pkg create`'s tests fail under `-race` on a deliberately bad connector, and the race is ours: `importSource` returns as soon as the importer errors, without waiting for the workers it started. They go on writing to `stats` while `importerJob` reads it in a deferred `snapshot.import.done`. Same family as #507 — an early exit on a bad source leaving something behind — found by the same tests.

The fix is to wait for the workers on every path out. That can't just be an unconditional `<-errch`: closing `records` is a convention the in-tree importers happen to follow, not part of the `Importer` interface, and third-party connectors are separate modules. So on the error path we cancel a source-scoped context instead of trusting a close that may never come, and the existing cancellation drain becomes non-blocking for the same reason — otherwise a rude importer keeps `errch` open forever and the wait deadlocks.

While here, read the counters with `atomic.LoadUint64`. They're written with `atomic.AddUint64`, so the plain reads were wrong on their own terms.

The test covers the awkward case rather than the original one: an importer that fails without closing `records`. It passes against the old code — which never waited at all — so it guards the new wait, not the old bug. The original race is covered by plakar's `TestPkgCreateExecuteFailsOnBadConnector` under `-race`, verified against this branch via a `go mod` replace.

Unrelated, but noticed while running the full suite: `TestPlatarPackerManager_RunAndWait` fails under `-race` on `main` as well. Looks like the residue `1ade68a9` left on purpose, not something this touches.
