### PR TITLE
snapshot: add no-ignore importer capability

### DIFF
--- a/location/location.go
+++ b/location/location.go
@@ -10,12 +10,13 @@ import (
 type Flags uint32
 
 const (
-	FLAG_LOCALFS Flags = 1 << iota // all: dealing with a file (or dir) on the local fs
-	FLAG_FILE                      // storage: kloset is in a single file
-	FLAG_STREAM                    // importer: cannot call Import() more than once
-	FLAG_NEEDACK                   // importer: cares about acknowledgments in Import()
-	FLAG_NOMERGE                   // importer: cannot merge those in a single snapshot (multidir support)
-	FLAG_EXPORTXATTR               // exporter: please send extended attributes during Export()
+	FLAG_LOCALFS     Flags = 1 << iota // all: dealing with a file (or dir) on the local fs
+	FLAG_FILE                          // storage: kloset is in a single file
+	FLAG_STREAM                        // importer: cannot call Import() more than once
+	FLAG_NEEDACK                       // importer: cares about acknowledgments in Import()
+	FLAG_NOMERGE                       // importer: cannot merge those in a single snapshot (multidir support)
+	FLAG_EXPORTXATTR                   // exporter: please send extended attributes during Export()
+	FLAG_NOIGNORE                      // importer: exclude rules do not apply
 )
 
 var ErrUnknownFlag = errors.New("unknown flag")
@@ -127,6 +128,8 @@ func ParseFlag(name string) (Flags, error) {
 		return FLAG_NOMERGE, nil
 	case "exportxattr":
 		return FLAG_EXPORTXATTR, nil
+	case "noignore":
+		return FLAG_NOIGNORE, nil
 	default:
 		return 0, ErrUnknownFlag
 	}

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -42,6 +42,10 @@ func TestParseFlag(t *testing.T) {
 			wantFlag: location.FLAG_NOMERGE,
 		},
 		{
+			input:    "noignore",
+			wantFlag: location.FLAG_NOIGNORE,
+		},
+		{
 			input:    "unknown",
 			wantFlag: 0,
 			wantErr:  location.ErrUnknownFlag,

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -82,6 +82,8 @@ var (
 	ErrOutOfRange = errors.New("out of range")
 )
 
+const ignoreDisabledWarning = "ignoring exclude rules for importer %q"
+
 func (sourceCtx *sourceContext) batchRecordEntry(kind scanlog.EntryKind, pathname string, ctype string, mac objects.MAC, serializedEntry []byte, serializedSummary []byte) error {
 	sourceCtx.vfsEntLock.Lock()
 	defer sourceCtx.vfsEntLock.Unlock()
@@ -208,6 +210,11 @@ func (snap *Builder) processRecord(idx int, sourceCtx *sourceContext, record *co
 }
 
 func (snap *Builder) importSource(imp importer.Importer, sourceCtx *sourceContext, stats *scanStats) error {
+	applyExcludes := imp.Flags()&location.FLAG_NOIGNORE == 0
+	if !applyExcludes && len(sourceCtx.source.excludes.Rules) != 0 {
+		snap.Logger().Warn(ignoreDisabledWarning, imp.Type())
+	}
+
 	if sourceCtx.vfsCache != nil {
 		// Memory wise the cache has a small footprint so we can safely go a bit
 		// big here. The 64 figure was chosen empirically after various tests.
@@ -260,7 +267,7 @@ func (snap *Builder) importSource(imp importer.Importer, sourceCtx *sourceContex
 							snap.emitter.PathError(record.Pathname, record.Err)
 							sourceCtx.recordError(idx, record.Pathname, record.Err)
 
-						} else if !snap.skipExcludedPathname(sourceCtx, record) {
+						} else if !applyExcludes || !snap.skipExcludedPathname(sourceCtx, record) {
 							snap.emitter.Path(record.Pathname)
 							if err := snap.processRecord(idx, sourceCtx, record, stats, ck); err != nil {
 								sourceCtx.recordError(idx, record.Pathname, err)

--- a/snapshot/backup_noignore_test.go
+++ b/snapshot/backup_noignore_test.go
@@ -1,0 +1,68 @@
+package snapshot_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/location"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/stretchr/testify/require"
+)
+
+type noIgnoreImporter struct {
+	*ptesting.MockImporter
+}
+
+func (imp *noIgnoreImporter) Flags() location.Flags {
+	return location.FLAG_NOIGNORE
+}
+
+func TestBackupNoIgnoreImporterKeepsExcludedEntries(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	var logs bytes.Buffer
+	repo.Logger().SetOutput(&logs)
+
+	builder, err := snapshot.Create(repo, repository.DefaultType, "", objects.NilMac, &snapshot.BuilderOptions{
+		Name: "noignore-test",
+	})
+	require.NoError(t, err)
+
+	baseImporter, err := ptesting.NewMockImporter(repo.AppContext(), &connectors.Options{},
+		"mock", map[string]string{"location": "mock://place"})
+	require.NoError(t, err)
+	baseImporter.(*ptesting.MockImporter).SetFiles([]ptesting.MockFile{
+		ptesting.NewMockFile("keep.tmp", 0644, "payload"),
+	})
+
+	source, err := snapshot.NewSource(repo.AppContext(), &noIgnoreImporter{
+		MockImporter: baseImporter.(*ptesting.MockImporter),
+	})
+	require.NoError(t, err)
+	require.NoError(t, source.SetExcludes([]string{"*.tmp"}))
+
+	require.NoError(t, builder.Backup(source))
+	require.NoError(t, builder.Commit())
+	require.NoError(t, builder.Close())
+	require.NoError(t, builder.Repository().RebuildState())
+
+	loaded, err := snapshot.Load(repo, builder.Header.Identifier)
+	require.NoError(t, err)
+	defer loaded.Close()
+
+	filesystem, err := loaded.Filesystem()
+	require.NoError(t, err)
+
+	found := false
+	for pathname, err := range filesystem.Pathnames() {
+		require.NoError(t, err)
+		found = found || strings.HasSuffix(pathname, "keep.tmp")
+	}
+	require.True(t, found, "FLAG_NOIGNORE importer should keep entries matching exclude rules")
+	require.Contains(t, logs.String(), "ignoring exclude rules")
+}


### PR DESCRIPTION
## Summary

- add an importer-specific `FLAG_NOIGNORE` capability and `noignore` parser token
- bypass exclude rules only for importers carrying that flag
- warn once when configured exclude rules are ignored

This follows the maintainer-recommended Kloset change described in https://github.com/PlakarKorp/plakar/pull/2307#issuecomment-5313344825. Importers without the flag, including SFTP, keep existing exclude behavior.

## Test verification (RED → GREEN)

With the bypass behavior reverted, the regression test fails:

```text
--- FAIL: TestBackupNoIgnoreImporterKeepsExcludedEntries (0.02s)
    Error: Should be true
    Messages: FLAG_NOIGNORE importer should keep entries matching exclude rules
FAIL github.com/PlakarKorp/kloset/snapshot
```

With the capability applied:

```text
ok github.com/PlakarKorp/kloset/location
ok github.com/PlakarKorp/kloset/snapshot
```

## Validation

- `go build -v ./...`
- `go test -v -coverprofile=coverage.out -covermode=atomic -timeout 1m ./...`
- `go vet ./...`
- changed-line coverage: 100% (7/7)
