### PR TITLE
compression: add zstd as a selectable algorithm

### DIFF
--- a/compression/compression.go
+++ b/compression/compression.go
@@ -6,8 +6,11 @@ import (
 	"io"
 	"sync"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 )
+
+const DEFAULT_COMPRESSION_ALGORITHM = "LZ4"
 
 type Configuration struct {
 	Algorithm  string `json:"algorithm"`
@@ -19,14 +22,8 @@ type Configuration struct {
 }
 
 func NewDefaultConfiguration() *Configuration {
-	return &Configuration{
-		Algorithm:  "LZ4",
-		Level:      int(lz4.Level9),
-		WindowSize: -1,
-		ChunkSize:  -1,
-		BlockSize:  -1,
-		EnableCRC:  false,
-	}
+	configuration, _ := LookupDefaultConfiguration(DEFAULT_COMPRESSION_ALGORITHM)
+	return configuration
 }
 
 func LookupDefaultConfiguration(algorithm string) (*Configuration, error) {
@@ -49,8 +46,17 @@ func LookupDefaultConfiguration(algorithm string) (*Configuration, error) {
 			BlockSize:  -1,
 			EnableCRC:  false,
 		}, nil
+	case "ZSTD":
+		return &Configuration{
+			Algorithm:  "ZSTD",
+			Level:      int(zstd.SpeedDefault),
+			WindowSize: -1,
+			ChunkSize:  -1,
+			BlockSize:  -1,
+			EnableCRC:  false,
+		}, nil
 	default:
-		return nil, fmt.Errorf("unknown hashing algorithm: %s", algorithm)
+		return nil, fmt.Errorf("unknown compression algorithm: %s", algorithm)
 	}
 }
 
@@ -58,6 +64,7 @@ func DeflateStream(name string, r io.Reader) (io.Reader, error) {
 	m := map[string]func(io.Reader) (io.Reader, error){
 		"GZIP": DeflateGzipStream,
 		"LZ4":  DeflateLZ4Stream,
+		"ZSTD": DeflateZstdStream,
 	}
 	if fn, exists := m[name]; exists {
 		return fn(r)
@@ -94,6 +101,32 @@ func DeflateLZ4Stream(r io.Reader) (io.Reader, error) {
 	return pr, nil
 }
 
+func DeflateZstdStream(r io.Reader) (io.Reader, error) {
+	pr, pw := io.Pipe()
+	go func() {
+		zw, err := zstd.NewWriter(pw)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+
+		if _, err := io.Copy(zw, r); err != nil {
+			zw.Close()
+			pw.CloseWithError(err)
+			return
+		}
+
+		// Close writes the final frame, so it can't be deferred
+		// past pw.Close() or the reader sees a truncated stream.
+		if err := zw.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.Close()
+	}()
+	return pr, nil
+}
+
 type readCloserInternal struct {
 	input  io.Closer
 	reader io.ReadCloser
@@ -106,6 +139,7 @@ func InflateStream(name string, r io.ReadCloser) (io.ReadCloser, error) {
 	m := map[string]func(io.ReadCloser) (io.ReadCloser, error){
 		"GZIP": InflateGzipStream,
 		"LZ4":  InflateLZ4Stream,
+		"ZSTD": InflateZstdStream,
 	}
 	if fn, exists := m[name]; exists {
 		or, err := fn(r)
@@ -155,6 +189,25 @@ func InflateLZ4Stream(r io.ReadCloser) (io.ReadCloser, error) {
 		if err != nil {
 			pw.CloseWithError(err)
 		}
+	}()
+	return pr, nil
+}
+
+func InflateZstdStream(r io.ReadCloser) (io.ReadCloser, error) {
+	zr, err := zstd.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		defer zr.Close()
+
+		if _, err := io.Copy(pw, zr.IOReadCloser()); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.Close()
 	}()
 	return pr, nil
 }

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	cprss "github.com/PlakarKorp/kloset/compression"
+	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -53,11 +54,24 @@ func TestLookupDefaultConfiguration(t *testing.T) {
 		require.False(t, cfg.EnableCRC)
 	})
 
+	t.Run("CheckZSTDDefaults", func(t *testing.T) {
+		cfg, err := cprss.LookupDefaultConfiguration("ZSTD")
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.Equal(t, "ZSTD", cfg.Algorithm)
+		require.Equal(t, int(zstd.SpeedDefault), cfg.Level)
+		require.Equal(t, -1, cfg.WindowSize)
+		require.Equal(t, -1, cfg.ChunkSize)
+		require.Equal(t, -1, cfg.BlockSize)
+		require.False(t, cfg.EnableCRC)
+	})
+
 	t.Run("CheckUnknownAlgorithm", func(t *testing.T) {
 		cfg, err := cprss.LookupDefaultConfiguration("UNKNOWN")
 
 		require.Nil(t, cfg)
-		require.EqualError(t, err, "unknown hashing algorithm: UNKNOWN")
+		require.EqualError(t, err, "unknown compression algorithm: UNKNOWN")
 	})
 }
 
@@ -78,6 +92,10 @@ func compressDataForTest(t *testing.T, algorithm string, data []byte) []byte {
 		writer = gzip.NewWriter(&compressedData)
 	case "LZ4":
 		writer = lz4.NewWriter(&compressedData)
+	case "ZSTD":
+		w, err := zstd.NewWriter(&compressedData)
+		require.NoError(t, err)
+		writer = w
 	default:
 		require.FailNow(t, "unsupported algorithm", "algorithm=%s", algorithm)
 	}
@@ -104,6 +122,11 @@ func decompressDataForTest(t *testing.T, algorithm string, r io.Reader) []byte {
 	case "LZ4":
 		reader = lz4.NewReader(r)
 		closer = nil
+	case "ZSTD":
+		zr, err := zstd.NewReader(r)
+		require.NoError(t, err)
+		reader = zr.IOReadCloser()
+		closer = zr.IOReadCloser()
 	default:
 		require.FailNow(t, "unsupported algorithm", "algorithm=%s", algorithm)
 	}
@@ -311,6 +334,18 @@ func TestDeflateStream(t *testing.T) {
 		require.Equal(t, data, decompressedData)
 	})
 
+	t.Run("DispatchZSTD", func(t *testing.T) {
+		data := []byte("hello zstd")
+
+		compressedReader, err := cprss.DeflateStream("ZSTD", bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedData := decompressDataForTest(t, "ZSTD", compressedReader)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
 	t.Run("PartialReadOnGZIPData", func(t *testing.T) {
 		data := bytes.Repeat([]byte("hello gzip"), 128)
 
@@ -406,6 +441,20 @@ func TestInflateStream(t *testing.T) {
 		require.Equal(t, data, decompressedData)
 	})
 
+	t.Run("DispatchZSTD", func(t *testing.T) {
+		data := []byte("hello zstd")
+		compressedData := compressDataForTest(t, "ZSTD", data)
+
+		decompressedReader, err := cprss.InflateStream("ZSTD", io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
 	t.Run("PartialReadOnGZIPData", func(t *testing.T) {
 		data := bytes.Repeat([]byte("hello gzip"), 128)
 		compressedData := compressDataForTest(t, "GZIP", data)
@@ -460,7 +509,7 @@ func TestInflateStream(t *testing.T) {
 func TestInflateStreamCloseClosesUnderlyingReader(t *testing.T) {
 	// readCloserInternal.Close() closes both the inflated stream and the
 	// caller-supplied input reader. Verify both happen.
-	for _, algo := range []string{"GZIP", "LZ4"} {
+	for _, algo := range []string{"GZIP", "LZ4", "ZSTD"} {
 		t.Run(algo, func(t *testing.T) {
 			compressed := compressDataForTest(t, algo, []byte("payload"))
 			inputClosed := false
@@ -530,5 +579,91 @@ func TestLargeData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, decompressedData)
 		require.Equal(t, data, decompressedData)
+	})
+}
+
+func TestDeflateZstdStream(t *testing.T) {
+	t.Run("CompressData", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello zstd"), 128)
+
+		compressedReader, err := cprss.DeflateZstdStream(bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedData := decompressDataForTest(t, "ZSTD", compressedReader)
+		require.NotEmpty(t, decompressedData)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("CompressEmptyData", func(t *testing.T) {
+		data := []byte{}
+
+		compressedReader, err := cprss.DeflateZstdStream(bytes.NewReader(data))
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		decompressedData := decompressDataForTest(t, "ZSTD", compressedReader)
+		require.Empty(t, decompressedData)
+	})
+
+	t.Run("Fails_IfSourceReaderFails", func(t *testing.T) {
+		compressedReader, err := cprss.DeflateZstdStream(&errorReader{})
+		require.NoError(t, err)
+		require.NotNil(t, compressedReader)
+
+		_, err = io.ReadAll(compressedReader)
+		require.Error(t, err)
+	})
+}
+
+func TestInflateZstdStream(t *testing.T) {
+	t.Run("DecompressData", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello zstd"), 128)
+		compressedData := compressDataForTest(t, "ZSTD", data)
+
+		decompressedReader, err := cprss.InflateZstdStream(io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.Equal(t, data, decompressedData)
+	})
+
+	t.Run("DecompressEmptyData", func(t *testing.T) {
+		data := []byte{}
+		compressedData := compressDataForTest(t, "ZSTD", data)
+
+		decompressedReader, err := cprss.InflateZstdStream(io.NopCloser(bytes.NewReader(compressedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		decompressedData, err := io.ReadAll(decompressedReader)
+		require.NoError(t, err)
+		require.Empty(t, decompressedData)
+	})
+
+	t.Run("FailsOnTruncatedFrame", func(t *testing.T) {
+		data := bytes.Repeat([]byte("hello zstd"), 1024)
+		compressedData := compressDataForTest(t, "ZSTD", data)
+		truncatedData := compressedData[:len(compressedData)-4]
+
+		decompressedReader, err := cprss.InflateZstdStream(io.NopCloser(bytes.NewReader(truncatedData)))
+		require.NoError(t, err)
+		require.NotNil(t, decompressedReader)
+
+		_, err = io.ReadAll(decompressedReader)
+		require.Error(t, err)
+	})
+
+	t.Run("FailsOnGarbageInput", func(t *testing.T) {
+		decompressedReader, err := cprss.InflateZstdStream(io.NopCloser(bytes.NewReader([]byte("not zstd at all"))))
+		if err != nil {
+			require.Nil(t, decompressedReader)
+			return
+		}
+
+		_, err = io.ReadAll(decompressedReader)
+		require.Error(t, err)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/golang/snappy v1.0.0
 	github.com/google/uuid v1.6.0
+	github.com/klauspost/compress v1.18.0
 	github.com/nickball/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
 	github.com/pierrec/lz4/v4 v4.1.28
 	github.com/stretchr/testify v1.11.1
@@ -43,7 +44,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jstemmer/go-junit-report/v2 v2.1.0 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect


### PR DESCRIPTION
LZ4 and GZIP are the only algorithms a kloset can be created with.  Add zstd
as a third, so a repository can trade some throughput for a better ratio where
that's the useful side of the tradeoff.

DeflateStream and InflateStream dispatch on the algorithm name recorded in the
kloset configuration, so a case in each map plus an entry in
LookupDefaultConfiguration is all it takes — nothing changes on the format or
versioning side, and an existing zstd repository reads back on its own.  The
default stays LZ4, so this is opt-in and existing repositories are untouched.

The implementation is klauspost/compress, which pebble already pulls in, so
this only promotes it to a direct dependency and keeps the tree cgo-free and
cross-compilable.

One wrinkle worth a look: the zstd writer's Close writes the final frame, so
unlike the LZ4 and GZIP paths it can't be deferred past pw.Close() — the reader
would see a truncated stream.  Same reason the inflate side goes through
IOReadCloser().

While here, NewDefaultConfiguration now goes through LookupDefaultConfiguration
the way hashing does, and the error string that still said "hashing algorithm"
is fixed.
