### PR TITLE
repository: delete several snapshots in one state write

### DIFF
--- a/repository/delete_snapshots_test.go
+++ b/repository/delete_snapshots_test.go
@@ -1,0 +1,85 @@
+package repository_test
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	ptesting "github.com/PlakarKorp/kloset/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteSnapshotsWritesASingleState is the reason DeleteSnapshots exists:
+// deleting N snapshots one by one derives and writes N delta states, while the
+// batch colours every snapshot into one delta state and writes it once.
+func TestDeleteSnapshotsWritesASingleState(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	ids := make([]objects.MAC, 0, 3)
+	for _, name := range []string{"/one.txt", "/two.txt", "/three.txt"} {
+		snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+			ptesting.NewMockDir("/"),
+			ptesting.NewMockFile(name, 0644, "content of "+name),
+		})
+		require.NotNil(t, snap)
+		ids = append(ids, snap.Header.Identifier)
+	}
+
+	before, err := repo.GetStates()
+	require.NoError(t, err)
+
+	require.NoError(t, repo.DeleteSnapshots(ids))
+
+	after, err := repo.GetStates()
+	require.NoError(t, err)
+	require.Len(t, after, len(before)+1, "the batch must write exactly one state")
+
+	require.NoError(t, repo.RebuildState())
+
+	deleted := make(map[objects.MAC]bool)
+	for id := range repo.ListDeletedSnapShots() {
+		deleted[id] = true
+	}
+	for _, id := range ids {
+		require.True(t, deleted[id], "snapshot %x must be deleted", id)
+	}
+}
+
+// TestDeleteSnapshotsEmptyWritesNothing keeps an empty list from writing a
+// state that colours nothing. The control plane builds the list from its own
+// records, so an empty list is a normal outcome, not an error.
+func TestDeleteSnapshotsEmptyWritesNothing(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	before, err := repo.GetStates()
+	require.NoError(t, err)
+
+	require.NoError(t, repo.DeleteSnapshots(nil))
+
+	after, err := repo.GetStates()
+	require.NoError(t, err)
+	require.Len(t, after, len(before))
+}
+
+// TestDeleteSnapshotsUnknownIDIsAccepted pins the behaviour the control plane
+// relies on: colouring a resource is an unconditional tombstone write, so an
+// identifier the repository never held is accepted and deletes nothing. A
+// stale list therefore cannot fail a batch.
+func TestDeleteSnapshotsUnknownIDIsAccepted(t *testing.T) {
+	repo := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("/"),
+		ptesting.NewMockFile("/kept.txt", 0644, "kept"),
+	})
+	require.NotNil(t, snap)
+
+	unknown := objects.MAC{0xDE, 0xAD, 0xBE, 0xEF}
+	require.NoError(t, repo.DeleteSnapshots([]objects.MAC{unknown}))
+	require.NoError(t, repo.RebuildState())
+
+	live := 0
+	for range repo.ListSnapshots() {
+		live++
+	}
+	require.Equal(t, 1, live, "the real snapshot must survive")
+}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -738,6 +738,19 @@ func (r *Repository) DeleteSnapshot(snapshotID objects.MAC) error {
 		r.Logger().Trace("repository", "DeleteSnapshot(%x): %s", snapshotID, time.Since(t0))
 	}()
 
+	return r.DeleteSnapshots([]objects.MAC{snapshotID})
+}
+
+func (r *Repository) DeleteSnapshots(snapshotIDs []objects.MAC) error {
+	t0 := time.Now()
+	defer func() {
+		r.Logger().Trace("repository", "DeleteSnapshots(%d): %s", len(snapshotIDs), time.Since(t0))
+	}()
+
+	if len(snapshotIDs) == 0 {
+		return nil
+	}
+
 	identifier := objects.RandomMAC()
 	sc, err := r.AppContext().GetCache().Scan(identifier)
 	if err != nil {
@@ -745,23 +758,19 @@ func (r *Repository) DeleteSnapshot(snapshotID objects.MAC) error {
 	}
 	deltaState := r.state.Derive(sc)
 
-	ret := deltaState.ColourResource(resources.RT_SNAPSHOT, snapshotID)
-	if ret != nil {
-		return ret
+	for _, snapshotID := range snapshotIDs {
+		if err := deltaState.ColourResource(resources.RT_SNAPSHOT, snapshotID); err != nil {
+			return err
+		}
 	}
 
 	buffer := &bytes.Buffer{}
-	err = deltaState.SerializeToStream(buffer)
-	if err != nil {
+	if err := deltaState.SerializeToStream(buffer); err != nil {
 		return err
 	}
 
 	mac := r.ComputeMAC(buffer.Bytes())
-	if err := r.PutState(mac, buffer); err != nil {
-		return err
-	}
-
-	return nil
+	return r.PutState(mac, buffer)
 }
 
 func (r *Repository) GetStates() ([]objects.MAC, error) {


### PR DESCRIPTION
## Summary

`DeleteSnapshot` derives a delta state, colours one snapshot and writes a state. Deleting N snapshots writes N states, and nothing ties them together: a crash halfway leaves part of the batch applied.

`DeleteSnapshots([]objects.MAC) error` colours every snapshot into one delta state and writes it once — one write instead of N, one outcome instead of N. `DeleteSnapshot` delegates to it, so there is a single implementation.

## Why we want it

The Plakar Control Plane is moving snapshot deletion from a retention rule evaluated on the agent to an explicit list built control-plane side, so a list can honour things the retention engine cannot see — a legal hold first of all. That caller knows the whole list up front, and it has to be able to state that a deletion either happened or did not: a partially applied deletion of held data is a compliance problem, not just untidiness.

It works today with N calls to `DeleteSnapshot`. This makes the batch atomic and cheap.

## Behaviour

- `DeleteSnapshots(nil)` writes nothing and returns nil.
- An identifier the repository never held is accepted and deletes nothing. Colouring is an unconditional tombstone write, so a caller working from its own records cannot fail a batch with a stale entry.
- `DeleteSnapshot` is unchanged for callers.

## Tests

`repository/delete_snapshots_test.go`:

- 3 snapshots deleted in one call add exactly one state, and all 3 show up in `ListDeletedSnapShots` after `RebuildState`.
- An empty list adds no state.
- An unknown identifier is accepted and the real snapshot survives.

`go test ./repository/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)