### PR TITLE
btree/filestore: add a on-disk btree.Storer implementation

### DIFF
--- a/btree/filestore/bench_test.go
+++ b/btree/filestore/bench_test.go
@@ -1,4 +1,4 @@
-package storage
+package filestore
 
 import (
 	"encoding/binary"

--- a/btree/filestore/bench_test.go
+++ b/btree/filestore/bench_test.go
@@ -1,0 +1,181 @@
+package storage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/btree"
+	"github.com/PlakarKorp/kloset/caching"
+	"github.com/PlakarKorp/kloset/objects"
+	"golang.org/x/sync/errgroup"
+)
+
+// order 50, string keys and MAC values mirror a real backup index;
+// building benchTrees of them concurrently mirrors
+// snapshot.Builder.makeBackupIndexes.
+const (
+	benchOrder   = 50
+	benchTrees   = 6
+	benchPerTree = 80_000
+)
+
+func benchKey(tree, i int) string {
+	return fmt.Sprintf("/some/realistic/looking/path/%03d/dir-%05d/file-%05d.dat", tree, i/100, i)
+}
+
+func benchMAC(i int) objects.MAC {
+	var m objects.MAC
+	binary.LittleEndian.PutUint64(m[:8], uint64(i))
+	return m
+}
+
+// dirSize sums the size of every file directly inside dir (includes
+// SQLite's -wal/-shm files).
+func dirSize(tb testing.TB, dir string) int64 {
+	tb.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	var total int64
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	return total
+}
+
+// buildFileStoreTrees and buildSQLiteTrees build benchTrees trees
+// concurrently and return them open, so callers can measure on-disk
+// size before Close deletes everything.
+func buildFileStoreTrees(dir string) ([]*btree.BTree[string, int, objects.MAC], error) {
+	trees := make([]*btree.BTree[string, int, objects.MAC], benchTrees)
+
+	g := errgroup.Group{}
+	for t := 0; t < benchTrees; t++ {
+		t := t
+		g.Go(func() error {
+			store, err := New[string, objects.MAC](dir, fmt.Sprintf("tree-%d", t))
+			if err != nil {
+				return err
+			}
+			tree, err := btree.New[string, int, objects.MAC](store, strings.Compare, benchOrder)
+			if err != nil {
+				return err
+			}
+			for i := 0; i < benchPerTree; i++ {
+				if err := tree.Insert(benchKey(t, i), benchMAC(i)); err != nil {
+					return err
+				}
+			}
+			trees[t] = tree
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return trees, nil
+}
+
+func buildSQLiteTrees(dir string) ([]*btree.BTree[string, int, objects.MAC], error) {
+	trees := make([]*btree.BTree[string, int, objects.MAC], benchTrees)
+
+	g := errgroup.Group{}
+	for t := 0; t < benchTrees; t++ {
+		t := t
+		g.Go(func() error {
+			store, err := caching.NewSQLiteDBStore[string, objects.MAC](dir, fmt.Sprintf("tree-%d.db", t))
+			if err != nil {
+				return err
+			}
+			tree, err := btree.New[string, int, objects.MAC](store, strings.Compare, benchOrder)
+			if err != nil {
+				return err
+			}
+			for i := 0; i < benchPerTree; i++ {
+				if err := tree.Insert(benchKey(t, i), benchMAC(i)); err != nil {
+					return err
+				}
+			}
+			trees[t] = tree
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return trees, nil
+}
+
+// runConcurrentBuild times the build only: disk accounting and Close
+// run with the timer stopped, so they land in disk-B/op rather than
+// ns/op.
+func runConcurrentBuild(b *testing.B, build func(dir string) ([]*btree.BTree[string, int, objects.MAC], error)) {
+	b.Helper()
+
+	var totalDiskBytes int64
+
+	for i := 0; i < b.N; i++ {
+		dir := b.TempDir()
+
+		trees, err := build(dir)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+		totalDiskBytes += dirSize(b, dir)
+		for _, tree := range trees {
+			if err := tree.Close(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StartTimer()
+	}
+
+	b.ReportMetric(float64(totalDiskBytes)/float64(b.N), "disk-B/op")
+}
+
+func BenchmarkConcurrentBuild_FileStore(b *testing.B) {
+	runConcurrentBuild(b, buildFileStoreTrees)
+}
+
+func BenchmarkConcurrentBuild_SQLite(b *testing.B) {
+	runConcurrentBuild(b, buildSQLiteTrees)
+}
+
+// TestConcurrentBuildDiskUsage reports wall time and on-disk footprint
+// for one build per backend, sampled before Close deletes everything.
+func TestConcurrentBuildDiskUsage(t *testing.T) {
+	measure := func(name string, build func(dir string) ([]*btree.BTree[string, int, objects.MAC], error)) {
+		dir := t.TempDir()
+
+		start := time.Now()
+		trees, err := build(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		elapsed := time.Since(start)
+
+		bytes := dirSize(t, dir)
+		for _, tree := range trees {
+			if err := tree.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		t.Logf("%s: %d trees x %d entries in %s, %d bytes on disk (%.1f bytes/entry)",
+			name, benchTrees, benchPerTree, elapsed, bytes, float64(bytes)/float64(benchTrees*benchPerTree))
+	}
+
+	measure("FileStore", buildFileStoreTrees)
+	measure("SQLite", buildSQLiteTrees)
+}

--- a/btree/filestore/filestore.go
+++ b/btree/filestore/filestore.go
@@ -1,8 +1,8 @@
-// Package storage provides an on-disk [btree.Storer] meant for backup
+// Package filestore provides an on-disk [btree.Storer] meant for backup
 // operations (i.e. heavy-write, almost no reads or updates).  It is
 // backed by a file containing only the concatenated msgpack-encoded
 // nodes.  An in-memory indexs maps the IDs to the record on disk.
-package storage
+package filestore
 
 import (
 	"fmt"

--- a/btree/filestore/filestore.go
+++ b/btree/filestore/filestore.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 
 	"github.com/PlakarKorp/kloset/btree"
 	"github.com/vmihailenco/msgpack/v5"
@@ -26,13 +25,10 @@ type FileStore[K any, V any] struct {
 	file *os.File
 	path string
 
-	// next free byte in the file, bump-allocated so that concurrent
-	// Put/Update calls can write in parallel without serializing on
-	// the mutex below.
-	offset atomic.Uint64
-
-	mu    sync.Mutex
-	index []record
+	mu     sync.Mutex
+	offset uint64
+	index  []record
+	free   []record // holes left behind by Update, reusable by write
 }
 
 // New creates a new FileStore backed by a file named name inside dir.
@@ -75,20 +71,42 @@ func (s *FileStore[K, V]) Get(ptr int) (*btree.Node[K, int, V], error) {
 	return node, nil
 }
 
-// write appends the encoded node to the file at a freshly reserved
-// offset and returns where it landed.
+// alloc does a first-fit scan of the free list for a hole that fits
+// length bytes, otherwise reserves some space at the end of the file.
+func (s *FileStore[K, V]) alloc(length uint32) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, r := range s.free {
+		if r.length >= length {
+			s.free[i] = s.free[len(s.free)-1]
+			s.free = s.free[:len(s.free)-1]
+			return r.offset
+		}
+	}
+
+	// cannot reuse a free block, append to the end of the file.
+	off := s.offset
+	s.offset += uint64(length)
+	return off
+}
+
+// write encodes node and stores it at a reused hole if the free list
+// has one big enough, or else at a freshly reserved offset, and
+// returns where it landed.
 func (s *FileStore[K, V]) write(node *btree.Node[K, int, V]) (record, error) {
 	buf, err := msgpack.Marshal(node)
 	if err != nil {
 		return record{}, err
 	}
+	length := uint32(len(buf))
 
-	off := s.offset.Add(uint64(len(buf))) - uint64(len(buf))
+	off := s.alloc(length)
 	if _, err := s.file.WriteAt(buf, int64(off)); err != nil {
 		return record{}, err
 	}
 
-	return record{offset: off, length: uint32(len(buf))}, nil
+	return record{offset: off, length: length}, nil
 }
 
 func (s *FileStore[K, V]) Update(ptr int, node *btree.Node[K, int, V]) error {
@@ -102,6 +120,7 @@ func (s *FileStore[K, V]) Update(ptr int, node *btree.Node[K, int, V]) error {
 	if ptr < 0 || ptr >= len(s.index) {
 		return fmt.Errorf("storage: no such node %d", ptr)
 	}
+	s.free = append(s.free, s.index[ptr])
 	s.index[ptr] = rec
 	return nil
 }

--- a/btree/filestore/filestore.go
+++ b/btree/filestore/filestore.go
@@ -1,0 +1,131 @@
+// Package storage provides an on-disk [btree.Storer] meant for backup
+// operations (i.e. heavy-write, almost no reads or updates).  It is
+// backed by a file containing only the concatenated msgpack-encoded
+// nodes.  An in-memory indexs maps the IDs to the record on disk.
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/PlakarKorp/kloset/btree"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type record struct {
+	offset uint64
+	length uint32
+}
+
+// FileStore implements btree.Storer[K, int, V] as a flat, append-only
+// heap file.
+type FileStore[K any, V any] struct {
+	file *os.File
+	path string
+
+	// next free byte in the file, bump-allocated so that concurrent
+	// Put/Update calls can write in parallel without serializing on
+	// the mutex below.
+	offset atomic.Uint64
+
+	mu    sync.Mutex
+	index []record
+}
+
+// New creates a new FileStore backed by a file named name inside dir.
+// dir is created if it doesn't exist.
+func New[K any, V any](dir, name string) (*FileStore[K, V], error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileStore[K, V]{
+		file: f,
+		path: path,
+	}, nil
+}
+
+func (s *FileStore[K, V]) Get(ptr int) (*btree.Node[K, int, V], error) {
+	s.mu.Lock()
+	if ptr < 0 || ptr >= len(s.index) {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("storage: no such node %d", ptr)
+	}
+	rec := s.index[ptr]
+	s.mu.Unlock()
+
+	buf := make([]byte, rec.length)
+	if _, err := s.file.ReadAt(buf, int64(rec.offset)); err != nil {
+		return nil, err
+	}
+
+	node := &btree.Node[K, int, V]{}
+	if err := msgpack.Unmarshal(buf, node); err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+// write appends the encoded node to the file at a freshly reserved
+// offset and returns where it landed.
+func (s *FileStore[K, V]) write(node *btree.Node[K, int, V]) (record, error) {
+	buf, err := msgpack.Marshal(node)
+	if err != nil {
+		return record{}, err
+	}
+
+	off := s.offset.Add(uint64(len(buf))) - uint64(len(buf))
+	if _, err := s.file.WriteAt(buf, int64(off)); err != nil {
+		return record{}, err
+	}
+
+	return record{offset: off, length: uint32(len(buf))}, nil
+}
+
+func (s *FileStore[K, V]) Update(ptr int, node *btree.Node[K, int, V]) error {
+	rec, err := s.write(node)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ptr < 0 || ptr >= len(s.index) {
+		return fmt.Errorf("storage: no such node %d", ptr)
+	}
+	s.index[ptr] = rec
+	return nil
+}
+
+func (s *FileStore[K, V]) Put(node *btree.Node[K, int, V]) (int, error) {
+	rec, err := s.write(node)
+	if err != nil {
+		return 0, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ptr := len(s.index)
+	s.index = append(s.index, rec)
+	return ptr, nil
+}
+
+// Close closes and removes the backing file.
+func (s *FileStore[K, V]) Close() error {
+	err := s.file.Close()
+	if path := s.file.Name(); filepath.IsAbs(path) {
+		if rerr := os.Remove(s.file.Name()); err == nil {
+			err = rerr
+		}
+	}
+	return err
+}

--- a/btree/filestore/filestore_test.go
+++ b/btree/filestore/filestore_test.go
@@ -1,4 +1,4 @@
-package storage
+package filestore
 
 import (
 	"os"

--- a/btree/filestore/filestore_test.go
+++ b/btree/filestore/filestore_test.go
@@ -1,0 +1,124 @@
+package storage
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/btree"
+	"github.com/stretchr/testify/require"
+)
+
+func mkstore[k, v any](t *testing.T, name string) *FileStore[k, v] {
+	store, err := New[k, v](t.TempDir(), name)
+	require.NoError(t, err)
+	return store
+}
+
+func TestFileStorePutGetUpdate(t *testing.T) {
+	store := mkstore[string, int](t, "test.db")
+	defer store.Close()
+
+	node := &btree.Node[string, int, int]{
+		Keys:   []string{"alpha", "beta"},
+		Values: []int{1, 2},
+	}
+
+	idx, err := store.Put(node)
+	require.NoError(t, err)
+
+	retrieved, err := store.Get(idx)
+	require.NoError(t, err)
+	require.Equal(t, node.Keys, retrieved.Keys)
+	require.Equal(t, node.Values, retrieved.Values)
+
+	// Update the node with a larger payload than the original, to
+	// exercise the "rewritten at a new offset" path.
+	retrieved.Keys = []string{"alpha", "beta", "gamma"}
+	retrieved.Values = []int{10, 20, 30}
+	require.NoError(t, store.Update(idx, retrieved))
+
+	updated, err := store.Get(idx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "beta", "gamma"}, updated.Keys)
+	require.Equal(t, []int{10, 20, 30}, updated.Values)
+}
+
+func TestFileStoreMultiplePuts(t *testing.T) {
+	store := mkstore[int, string](t, "multi.db")
+	defer store.Close()
+
+	var indices []int
+	for i := range 5 {
+		node := &btree.Node[int, int, string]{
+			Keys:   []int{i},
+			Values: []string{"value"},
+		}
+		idx, err := store.Put(node)
+		require.NoError(t, err)
+		indices = append(indices, idx)
+	}
+
+	seen := make(map[int]bool)
+	for _, idx := range indices {
+		require.False(t, seen[idx], "duplicate index %d", idx)
+		seen[idx] = true
+	}
+}
+
+func TestFileStoreGetUnknown(t *testing.T) {
+	store := mkstore[string, int](t, "unknown.db")
+	defer store.Close()
+
+	_, err := store.Get(0)
+	require.Error(t, err)
+}
+
+func TestFileStoreCloseRemovesFile(t *testing.T) {
+	store := mkstore[string, int](t, "close.db")
+
+	_, err := os.Stat(store.path)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Close())
+
+	_, err = os.Stat(store.path)
+	require.True(t, os.IsNotExist(err))
+}
+
+// TestFileStoreConcurrentPut exercises the bump-allocator path: many
+// goroutines Put into the same store concurrently.
+func TestFileStoreConcurrentPut(t *testing.T) {
+	store := mkstore[int, int](t, "concurrent.db")
+	defer store.Close()
+
+	const n = 500
+	ids := make([]int, n)
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			node := &btree.Node[int, int, int]{
+				Keys:   []int{i},
+				Values: []int{i * i},
+			}
+			idx, err := store.Put(node)
+			require.NoError(t, err)
+			ids[i] = idx
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[int]bool)
+	for i, idx := range ids {
+		require.False(t, seen[idx], "duplicate index %d", idx)
+		seen[idx] = true
+
+		node, err := store.Get(idx)
+		require.NoError(t, err)
+		require.Equal(t, []int{i}, node.Keys)
+		require.Equal(t, []int{i * i}, node.Values)
+	}
+}

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -16,6 +16,7 @@ import (
 
 	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
 	"github.com/PlakarKorp/kloset/btree"
+	"github.com/PlakarKorp/kloset/btree/filestore"
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/importer"
@@ -675,32 +676,32 @@ func (snap *Builder) tmpCacheDir() string {
 func (snap *Builder) makeBackupIndexes() (*sourceIndexes, error) {
 	bi := &sourceIndexes{}
 
-	vfsstore, err := caching.NewSQLiteDBStore[string, []byte](snap.tmpCacheDir(), "vfs")
+	vfsstore, err := filestore.New[string, []byte](snap.tmpCacheDir(), "vfs")
 	if err != nil {
 		return nil, err
 	}
 
-	summarystore, err := caching.NewSQLiteDBStore[string, []byte](snap.tmpCacheDir(), "summary")
+	summarystore, err := filestore.New[string, []byte](snap.tmpCacheDir(), "summary")
 	if err != nil {
 		return nil, err
 	}
 
-	errstore, err := caching.NewSQLiteDBStore[string, objects.MAC](snap.tmpCacheDir(), "error")
+	errstore, err := filestore.New[string, objects.MAC](snap.tmpCacheDir(), "error")
 	if err != nil {
 		return nil, err
 	}
 
-	xattrstore, err := caching.NewSQLiteDBStore[string, objects.MAC](snap.tmpCacheDir(), "xattr")
+	xattrstore, err := filestore.New[string, objects.MAC](snap.tmpCacheDir(), "xattr")
 	if err != nil {
 		return nil, err
 	}
 
-	ctstore, err := caching.NewSQLiteDBStore[string, objects.MAC](snap.tmpCacheDir(), "contenttype")
+	ctstore, err := filestore.New[string, objects.MAC](snap.tmpCacheDir(), "contenttype")
 	if err != nil {
 		return nil, err
 	}
 
-	dirpackstore, err := caching.NewSQLiteDBStore[string, objects.MAC](snap.tmpCacheDir(), "dirpack")
+	dirpackstore, err := filestore.New[string, objects.MAC](snap.tmpCacheDir(), "dirpack")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
filestore is a naïve btree.Storer that appends new nodes to the end of a file, with an in-memory index to map IDs to records on disk.

With the current btree size of 50 (as used by snapshot/backup.go) it's about 4 time faster, while consuming a tad less disk and memory.