### PR TITLE
iostat: Introduce a comeon histogram.

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -357,7 +357,7 @@ func ioStatsToMap(s iostat.IOStats) map[string]any {
 		"overall_wall": s.OverallWall,
 		"min":          s.Min,
 		"avg":          s.Avg,
-		"median":       s.Median,
+		"median":       s.P50, // deprecated wire-compatibility alias of p50
 		"p50":          s.P50,
 		"p75":          s.P75,
 		"p80":          s.P80,

--- a/iostat/histogram.go
+++ b/iostat/histogram.go
@@ -1,0 +1,118 @@
+package iostat
+
+import "math"
+
+// histNumBuckets is derived from the octave count so changing either
+// constant visibly changes the covered range with it.
+const (
+	histBucketsPerOctave = 8
+	histOctaves          = 60
+	histNumBuckets       = histBucketsPerOctave * histOctaves // covers 1 .. 2^60 in the caller's unit
+)
+
+// histogram is a fixed-size geometric histogram: values are counted in
+// buckets whose width grows by ~9% per step (histBucketsPerOctave buckets
+// per power of two), so memory stays constant no matter how many values are
+// observed. Values are dimensionless: callers pick a base unit (values at or
+// below 1 land in the first bucket, values at or above 2^60 in the last) and
+// convert on the way in and out. The exact min, max and sum are tracked
+// alongside, so only the percentiles are approximate — interpolated within
+// their bucket, accurate to one bucket width, and always within the observed
+// extremes. It is not safe for concurrent use: the owner's mutex guards it.
+type histogram struct {
+	count   int64
+	sum     float64
+	min     float64
+	max     float64
+	buckets [histNumBuckets]int64
+}
+
+func (h *histogram) observe(v float64) {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		// a non-finite value would poison min/max/sum until the next reset;
+		// this histogram tracks measurements, which are finite by
+		// construction
+		return
+	}
+	if h.count == 0 || v < h.min {
+		h.min = v
+	}
+	if h.count == 0 || v > h.max {
+		h.max = v
+	}
+	h.count++
+	h.sum += v
+	h.buckets[histBucketIndex(v)]++
+}
+
+func (h *histogram) reset() {
+	*h = histogram{}
+}
+
+func (h *histogram) avg() float64 {
+	if h.count == 0 {
+		return 0
+	}
+	return h.sum / float64(h.count)
+}
+
+func histBucketIndex(v float64) int {
+	if !(v > 1) { // also catches NaN, whose comparisons are all false
+		return 0
+	}
+	idx := math.Log2(v) * histBucketsPerOctave
+	if idx >= histNumBuckets { // compared as floats so +Inf lands here too
+		return histNumBuckets - 1
+	}
+	// Log2 rounding can misfile a value a few ulps from a bucket boundary
+	// into a neighboring bucket; one corrective step keeps the invariant
+	// that bucket contents lie within the bucket's nominal bounds, which
+	// percentile interpolation relies on
+	i := int(idx)
+	if v < histBucketLower(i) {
+		i--
+	} else if i+1 < histNumBuckets && v >= histBucketLower(i+1) {
+		i++
+	}
+	return i
+}
+
+// histBucketLower returns the lower bound of bucket idx; the formula extends
+// one past the last bucket so it also yields upper bounds.
+func histBucketLower(idx int) float64 {
+	return math.Exp2(float64(idx) / histBucketsPerOctave)
+}
+
+// percentile returns an estimate of the p-th percentile, interpolated
+// within the bucket holding it.
+func (h *histogram) percentile(p float64) float64 {
+	if h.count == 0 {
+		return 0
+	}
+
+	target := p / 100 * float64(h.count)
+	var cum int64
+	for i, c := range h.buckets {
+		if c == 0 {
+			continue
+		}
+		if float64(cum+c) >= target {
+			// interpolate within the bucket, tightening its nominal bounds
+			// to the exact observed extremes: the first and last buckets are
+			// open-ended, and the buckets holding the extremes span past
+			// them
+			lower := histBucketLower(i)
+			upper := histBucketLower(i + 1)
+			if i == 0 || lower < h.min {
+				lower = h.min
+			}
+			if i == histNumBuckets-1 || upper > h.max {
+				upper = h.max
+			}
+			frac := (target - float64(cum)) / float64(c)
+			return lower + (upper-lower)*frac
+		}
+		cum += c
+	}
+	return h.max
+}

--- a/iostat/histogram_test.go
+++ b/iostat/histogram_test.go
@@ -1,0 +1,185 @@
+package iostat
+
+import (
+	"math"
+	"testing"
+)
+
+// histBucketIndex must file every value inside its bucket's nominal bounds
+// even a few ulps around a boundary, where Log2/Exp2 rounding disagree.
+func TestHistogramBucketIndexInvariant(t *testing.T) {
+	for k := 1; k < histNumBuckets; k++ {
+		b := histBucketLower(k)
+		for _, v := range []float64{math.Nextafter(b, 0), b, math.Nextafter(b, math.Inf(1))} {
+			i := histBucketIndex(v)
+			if histBucketLower(i) > v {
+				t.Fatalf("v=%v filed in bucket %d with lower bound %v > v", v, i, histBucketLower(i))
+			}
+			if i+1 < histNumBuckets && v >= histBucketLower(i+1) {
+				t.Fatalf("v=%v filed in bucket %d with upper bound %v <= v", v, i, histBucketLower(i+1))
+			}
+		}
+	}
+}
+
+// A dense uniform distribution interpolates almost exactly (the ~9% bucket
+// width only bounds the worst case), so 2% is tight enough to catch a broken
+// interpolation, not just a broken clamp.
+func TestHistogramPercentiles(t *testing.T) {
+	var h histogram
+	for i := 1; i <= 1000; i++ {
+		h.observe(float64(i))
+	}
+
+	if h.count != 1000 {
+		t.Errorf("expected count 1000, got %d", h.count)
+	}
+	if h.min != 1 || h.max != 1000 {
+		t.Errorf("expected exact min/max 1/1000, got %f/%f", h.min, h.max)
+	}
+	if avg := h.avg(); avg != 500.5 {
+		t.Errorf("expected exact avg 500.5, got %f", avg)
+	}
+
+	for p, want := range map[float64]float64{
+		50: 500, 75: 750, 90: 900, 95: 950, 99: 990,
+	} {
+		got := h.percentile(p)
+		if math.Abs(got-want)/want > 0.02 {
+			t.Errorf("p%v: got %f, want %f ±2%%", p, got, want)
+		}
+	}
+}
+
+func TestHistogramPercentileEdgeCases(t *testing.T) {
+	var h histogram
+	if v := h.percentile(50); v != 0 {
+		t.Errorf("expected 0 for empty histogram, got %f", v)
+	}
+
+	for _, v := range []float64{1.0, 2.0, 3.0} {
+		h.observe(v)
+	}
+	if v := h.percentile(0); v != 1.0 {
+		t.Errorf("expected the exact minimum for p=0, got %f", v)
+	}
+	if v := h.percentile(100); v != 3.0 {
+		t.Errorf("expected the exact maximum for p=100, got %f", v)
+	}
+	if v := h.percentile(50); v < 1.0 || v > 3.0 {
+		t.Errorf("expected p=50 within observed range, got %f", v)
+	}
+}
+
+// The first bucket is open-ended below: a distribution entirely below the
+// base unit must still interpolate over the observed range instead of
+// collapsing every percentile onto the extremes.
+func TestHistogramSubUnitDistribution(t *testing.T) {
+	var h histogram
+	for i := 1; i <= 900; i++ {
+		h.observe(float64(i) / 1000) // uniform over 0.001..0.9, all in bucket 0
+	}
+
+	for p, want := range map[float64]float64{
+		25: 0.225, 50: 0.45, 90: 0.81,
+	} {
+		got := h.percentile(p)
+		if math.Abs(got-want)/want > 0.05 {
+			t.Errorf("p%v: got %f, want %f ±5%%", p, got, want)
+		}
+	}
+}
+
+// The last bucket is symmetric: values beyond the nominal range interpolate
+// over [bucket lower, observed max] without inverting the bounds.
+func TestHistogramOverflowDistribution(t *testing.T) {
+	var h histogram
+	lo, hi := math.Exp2(61), math.Exp2(65) // both beyond the last bucket bound
+	h.observe(lo)
+	h.observe(hi)
+
+	if p := h.percentile(50); p < lo || p > hi {
+		t.Errorf("p50 %f outside observed range [%f, %f]", p, lo, hi)
+	}
+	if p99, p50 := h.percentile(99), h.percentile(50); p99 < p50 {
+		t.Errorf("p99 %f below p50 %f", p99, p50)
+	}
+}
+
+func TestHistogramBucketIndexNonFinite(t *testing.T) {
+	cases := map[string]struct {
+		v    float64
+		want int
+	}{
+		"NaN":      {math.NaN(), 0},
+		"+Inf":     {math.Inf(1), histNumBuckets - 1},
+		"-Inf":     {math.Inf(-1), 0},
+		"negative": {-42, 0},
+		"zero":     {0, 0},
+	}
+	for name, c := range cases {
+		if got := histBucketIndex(c.v); got != c.want {
+			t.Errorf("%s: got bucket %d, want %d", name, got, c.want)
+		}
+	}
+}
+
+func TestHistogramExtremes(t *testing.T) {
+	var h histogram
+	h.observe(0)             // below the first bucket
+	h.observe(0.25)          // below the first bucket
+	h.observe(math.Exp2(70)) // beyond the last bucket
+
+	if h.count != 3 {
+		t.Errorf("expected count 3, got %d", h.count)
+	}
+	if h.min != 0 {
+		t.Errorf("expected min 0, got %f", h.min)
+	}
+	if h.max != math.Exp2(70) {
+		t.Errorf("expected max 2^70, got %f", h.max)
+	}
+	if p := h.percentile(99); p > h.max {
+		t.Errorf("p99 %f exceeds max %f", p, h.max)
+	}
+}
+
+func TestHistogramNegativeOnly(t *testing.T) {
+	var h histogram
+	h.observe(-5)
+	h.observe(-2)
+
+	if h.min != -5 || h.max != -2 {
+		t.Errorf("expected exact min/max -5/-2, got %f/%f", h.min, h.max)
+	}
+	if p := h.percentile(50); p < -5 || p > -2 {
+		t.Errorf("p50 %f outside observed range [-5, -2]", p)
+	}
+}
+
+// Non-finite values would poison min/max/sum until reset; observe drops
+// them.
+func TestHistogramObserveNonFinite(t *testing.T) {
+	var h histogram
+	h.observe(math.NaN())
+	h.observe(math.Inf(1))
+	h.observe(math.Inf(-1))
+	if h.count != 0 {
+		t.Errorf("expected non-finite values to be dropped, count %d", h.count)
+	}
+
+	h.observe(42)
+	if h.count != 1 || h.min != 42 || h.max != 42 || h.sum != 42 {
+		t.Errorf("expected stats unpoisoned after non-finite values, got %+v", h)
+	}
+}
+
+func TestHistogramReset(t *testing.T) {
+	var h histogram
+	h.observe(42)
+	h.reset()
+
+	if h.count != 0 || h.sum != 0 || h.percentile(50) != 0 {
+		t.Errorf("expected empty histogram after reset, got %+v", h)
+	}
+}

--- a/iostat/iostat.go
+++ b/iostat/iostat.go
@@ -3,7 +3,6 @@ package iostat
 import (
 	"fmt"
 	"math"
-	"sort"
 	"sync"
 	"time"
 
@@ -15,13 +14,18 @@ const sampleWindow = 50 * time.Millisecond
 // represents I/O statistics collected over a period of time.
 //
 // Two notions of throughput are reported and answer different questions:
-//   - the active-time figures (Overall and the Min/Avg/Median/Max/Pxx
-//     distribution) divide bytes by the time actually spent inside read/write
-//     calls. They characterise how fast the medium is *when working*, ignoring
+//   - the active-time figures (Overall and the Min/Avg/Max/Pxx distribution)
+//     divide bytes by the time actually spent inside read/write calls. They
+//     characterise how fast the medium is *when working*, ignoring
 //     idle/blocked time — the right metric for benchmarking the storage layer.
 //   - OverallWall divides bytes by wall-clock elapsed (first to last operation),
 //     so it includes stalls and waits. It is the throughput a user actually
 //     experiences and the right basis for progress/ETA.
+//
+// Min, Avg and Max are exact; the Pxx percentiles are estimated from a
+// fixed-size geometric histogram (~9% bucket resolution) and are unreliable
+// below a few dozen samples — short operations emit one sample per 50ms of
+// active I/O.
 type IOStats struct {
 	Duration     time.Duration // active time spent in I/O
 	WallDuration time.Duration // wall-clock span first→last operation
@@ -29,7 +33,6 @@ type IOStats struct {
 
 	Min     float64 // bytes/sec (active)
 	Avg     float64 // bytes/sec (active)
-	Median  float64 // bytes/sec (active)
 	Max     float64 // bytes/sec (active)
 	Overall float64 // overall active throughput (bytes/sec)
 
@@ -62,9 +65,9 @@ type tracker struct {
 	// I/O time) reaches sampleWindow.
 	bucketBytes    int64
 	bucketDuration time.Duration
-	samples        []float64
 
-	lat latencyHistogram
+	tput histogram // throughput samples in bytes/sec (~9% buckets over 1 B/s .. 2^60 B/s)
+	lat  latencyHistogram
 }
 
 func newTracker() *tracker {
@@ -108,8 +111,7 @@ func (t *tracker) add(n int64, dt time.Duration, now time.Time) {
 	}
 
 	// create a sample for this bucket
-	throughput := float64(t.bucketBytes) / t.bucketDuration.Seconds()
-	t.samples = append(t.samples, throughput)
+	t.tput.observe(float64(t.bucketBytes) / t.bucketDuration.Seconds())
 
 	// reset the bucket
 	t.bucketBytes = 0
@@ -124,9 +126,9 @@ func (t *tracker) Reset() {
 	t.totalBytes = 0
 	t.firstAt = time.Time{}
 	t.lastAt = time.Time{}
-	t.samples = nil
 	t.bucketBytes = 0
 	t.bucketDuration = 0
+	t.tput.reset()
 	t.lat.reset()
 }
 
@@ -136,28 +138,6 @@ func (t *tracker) ObserveLatency(d time.Duration) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.lat.observe(d)
-}
-
-func percentile(sorted []float64, p float64) float64 {
-	n := len(sorted)
-	if n == 0 {
-		return 0
-	}
-	if p <= 0 {
-		return sorted[0]
-	}
-	if p >= 100 {
-		return sorted[n-1]
-	}
-
-	pos := (p / 100.0) * float64(n-1)
-	lower := int(math.Floor(pos))
-	upper := int(math.Ceil(pos))
-	if lower == upper {
-		return sorted[lower]
-	}
-	weight := pos - float64(lower)
-	return sorted[lower]*(1-weight) + sorted[upper]*weight
 }
 
 // TotalBytes returns the cumulative bytes accounted so far. Unlike Stats() it
@@ -176,8 +156,7 @@ func (t *tracker) Stats() IOStats {
 
 	// flush any partially-filled active bucket as one last sample
 	if t.bucketDuration > 0 && t.bucketBytes > 0 {
-		throughput := float64(t.bucketBytes) / t.bucketDuration.Seconds()
-		t.samples = append(t.samples, throughput)
+		t.tput.observe(float64(t.bucketBytes) / t.bucketDuration.Seconds())
 		t.bucketBytes = 0
 		t.bucketDuration = 0
 	}
@@ -199,36 +178,18 @@ func (t *tracker) Stats() IOStats {
 		stats.OverallWall = float64(t.totalBytes) / wall.Seconds()
 	}
 
-	if len(t.samples) == 0 {
-		return stats
-	}
+	// min, max and avg are exact; the percentiles are interpolated from the
+	// histogram buckets; everything is zero when no sample was recorded
+	stats.Min = t.tput.min
+	stats.Max = t.tput.max
+	stats.Avg = t.tput.avg()
 
-	sorted := make([]float64, len(t.samples))
-	copy(sorted, t.samples)
-	sort.Float64s(sorted)
-
-	min := sorted[0]
-	max := sorted[len(sorted)-1]
-
-	var sum float64
-	for _, v := range sorted {
-		sum += v
-	}
-	avg := sum / float64(len(sorted))
-
-	median := percentile(sorted, 50)
-
-	stats.Min = min
-	stats.Max = max
-	stats.Avg = avg
-	stats.Median = median
-
-	stats.P50 = percentile(sorted, 50)
-	stats.P75 = percentile(sorted, 75)
-	stats.P80 = percentile(sorted, 80)
-	stats.P90 = percentile(sorted, 90)
-	stats.P95 = percentile(sorted, 95)
-	stats.P99 = percentile(sorted, 99)
+	stats.P50 = t.tput.percentile(50)
+	stats.P75 = t.tput.percentile(75)
+	stats.P80 = t.tput.percentile(80)
+	stats.P90 = t.tput.percentile(90)
+	stats.P95 = t.tput.percentile(95)
+	stats.P99 = t.tput.percentile(99)
 
 	return stats
 }
@@ -327,7 +288,7 @@ func (ioT *IOTracker) SummaryString() string {
 			" overall_wall=%s,"+
 			" min=%s,"+
 			" avg=%s,"+
-			" median=%s,"+
+			" p50=%s,"+
 			" p75=%s,"+
 			" p80=%s,"+
 			" p90=%s,"+
@@ -342,7 +303,7 @@ func (ioT *IOTracker) SummaryString() string {
 			" overall_wall=%s,"+
 			" min=%s,"+
 			" avg=%s,"+
-			" median=%s,"+
+			" p50=%s,"+
 			" p75=%s,"+
 			" p80=%s,"+
 			" p90=%s,"+
@@ -354,7 +315,7 @@ func (ioT *IOTracker) SummaryString() string {
 		formatThroughput(r.OverallWall),
 		formatThroughput(r.Min),
 		formatThroughput(r.Avg),
-		formatThroughput(r.Median),
+		formatThroughput(r.P50),
 		formatThroughput(r.P75),
 		formatThroughput(r.P80),
 		formatThroughput(r.P90),
@@ -368,7 +329,7 @@ func (ioT *IOTracker) SummaryString() string {
 		formatThroughput(w.OverallWall),
 		formatThroughput(w.Min),
 		formatThroughput(w.Avg),
-		formatThroughput(w.Median),
+		formatThroughput(w.P50),
 		formatThroughput(w.P75),
 		formatThroughput(w.P80),
 		formatThroughput(w.P90),

--- a/iostat/iostat_test.go
+++ b/iostat/iostat_test.go
@@ -56,8 +56,8 @@ func TestTrackerAddZeroBytes(t *testing.T) {
 	if s.TotalBytes != 0 {
 		t.Errorf("expected 0 bytes, got %d", s.TotalBytes)
 	}
-	if len(tr.samples) != 0 {
-		t.Errorf("expected no samples after adding 0 bytes, got %d", len(tr.samples))
+	if tr.tput.count != 0 {
+		t.Errorf("expected no samples after adding 0 bytes, got %d", tr.tput.count)
 	}
 }
 
@@ -123,7 +123,6 @@ func TestWallClockThroughput(t *testing.T) {
 	}
 }
 
-
 func TestSpanAddNil(t *testing.T) {
 	var s *Span
 	// should not panic
@@ -175,29 +174,6 @@ func TestStatsMultipleSamples(t *testing.T) {
 	}
 	if s.P99 == 0 {
 		t.Error("expected non-zero P99")
-	}
-}
-
-func TestPercentileEdgeCases(t *testing.T) {
-	// empty slice
-	if v := percentile([]float64{}, 50); v != 0 {
-		t.Errorf("expected 0 for empty slice, got %f", v)
-	}
-
-	// p <= 0 returns first element
-	data := []float64{1.0, 2.0, 3.0}
-	if v := percentile(data, 0); v != 1.0 {
-		t.Errorf("expected 1.0 for p=0, got %f", v)
-	}
-
-	// p >= 100 returns last element
-	if v := percentile(data, 100); v != 3.0 {
-		t.Errorf("expected 3.0 for p=100, got %f", v)
-	}
-
-	// interpolation
-	if v := percentile(data, 50); v == 0 {
-		t.Error("expected non-zero for p=50")
 	}
 }
 
@@ -270,8 +246,8 @@ func TestBucketAccumulation(t *testing.T) {
 
 	// Add bytes with a duration shorter than sampleWindow — no sample yet
 	tr.add(1024, 10*time.Millisecond, time.Time{})
-	if len(tr.samples) != 0 {
-		t.Errorf("expected 0 samples for short duration, got %d", len(tr.samples))
+	if tr.tput.count != 0 {
+		t.Errorf("expected 0 samples for short duration, got %d", tr.tput.count)
 	}
 
 	// Stats flushes partial bucket

--- a/iostat/latency.go
+++ b/iostat/latency.go
@@ -5,19 +5,10 @@ import (
 	"time"
 )
 
-// Latency percentiles are computed from a fixed-size geometric histogram:
-// per-operation durations are counted in buckets whose width grows by ~9%
-// per step (8 buckets per power of two), so memory stays constant no matter
-// how many operations are observed. Percentiles are interpolated within
-// their bucket and accurate to one bucket width.
-const (
-	latencyMinBucket        = time.Microsecond
-	latencyBucketsPerOctave = 8
-	latencyNumBuckets       = 256 // covers 1µs .. ~71min, clamps beyond
-)
-
 // LatencyStats describes the distribution of per-operation durations
-// observed so far.
+// observed so far. Count, Total, Min, Avg and Max are exact; the percentiles
+// are estimated from a fixed-size geometric histogram (~9% bucket
+// resolution) and are unreliable below a few dozen observations.
 type LatencyStats struct {
 	Count int64
 	Total time.Duration
@@ -34,95 +25,48 @@ type LatencyStats struct {
 	P99 time.Duration
 }
 
-// latencyHistogram accumulates duration samples. It is not safe for
-// concurrent use: the owning tracker's mutex guards it.
+// latencyHistogram accumulates duration samples in a histogram in
+// nanoseconds (~9% resolution from 1ns up to ~2^60ns, about 36 years). Only
+// the total is tracked separately: float64 loses integer precision as the
+// sum grows, while the min and max round-trip through float64 exactly for
+// any duration below 2^53ns (~104 days).
 type latencyHistogram struct {
-	count   int64
-	total   time.Duration
-	min     time.Duration
-	max     time.Duration
-	buckets [latencyNumBuckets]int64
+	total time.Duration
+	hist  histogram
 }
 
 func (h *latencyHistogram) observe(d time.Duration) {
-	if h.count == 0 || d < h.min {
-		h.min = d
-	}
-	if d > h.max {
-		h.max = d
-	}
-	h.count++
 	h.total += d
-	h.buckets[latencyBucketIndex(d)]++
+	h.hist.observe(float64(d))
 }
 
 func (h *latencyHistogram) reset() {
 	*h = latencyHistogram{}
 }
 
-func latencyBucketIndex(d time.Duration) int {
-	if d <= latencyMinBucket {
-		return 0
-	}
-	idx := int(math.Log2(float64(d)/float64(latencyMinBucket)) * latencyBucketsPerOctave)
-	if idx >= latencyNumBuckets {
-		return latencyNumBuckets - 1
-	}
-	return idx
-}
-
-// latencyBucketLower returns the lower bound of bucket idx in nanoseconds;
-// the formula extends one past the last bucket so it also yields upper
-// bounds.
-func latencyBucketLower(idx int) float64 {
-	return float64(latencyMinBucket) * math.Exp2(float64(idx)/latencyBucketsPerOctave)
-}
-
-func (h *latencyHistogram) percentile(p float64) time.Duration {
-	if h.count == 0 {
-		return 0
-	}
-
-	target := p / 100 * float64(h.count)
-	var cum int64
-	for i, c := range h.buckets {
-		if c == 0 {
-			continue
-		}
-		if float64(cum+c) >= target {
-			lower := latencyBucketLower(i)
-			upper := latencyBucketLower(i + 1)
-			frac := (target - float64(cum)) / float64(c)
-			v := time.Duration(lower + (upper-lower)*frac)
-			// the histogram is approximate; the observed extremes are exact
-			if v < h.min {
-				v = h.min
-			}
-			if v > h.max {
-				v = h.max
-			}
-			return v
-		}
-		cum += c
-	}
-	return h.max
-}
-
 func (h *latencyHistogram) stats() LatencyStats {
-	if h.count == 0 {
+	if h.hist.count == 0 {
 		return LatencyStats{}
 	}
+
+	// nanoseconds are the histogram's base unit, so the estimates only need
+	// rounding to the nearest integer duration; the histogram already keeps
+	// them within the observed extremes
+	toDur := func(p float64) time.Duration {
+		return time.Duration(math.Round(h.hist.percentile(p)))
+	}
+
 	return LatencyStats{
-		Count: h.count,
+		Count: h.hist.count,
 		Total: h.total,
-		Min:   h.min,
-		Avg:   h.total / time.Duration(h.count),
-		Max:   h.max,
-		P50:   h.percentile(50),
-		P75:   h.percentile(75),
-		P80:   h.percentile(80),
-		P90:   h.percentile(90),
-		P95:   h.percentile(95),
-		P99:   h.percentile(99),
+		Min:   time.Duration(h.hist.min),
+		Avg:   h.total / time.Duration(h.hist.count),
+		Max:   time.Duration(h.hist.max),
+		P50:   toDur(50),
+		P75:   toDur(75),
+		P80:   toDur(80),
+		P90:   toDur(90),
+		P95:   toDur(95),
+		P99:   toDur(99),
 	}
 }

--- a/iostat/latency_test.go
+++ b/iostat/latency_test.go
@@ -44,8 +44,9 @@ func TestLatencyExactFields(t *testing.T) {
 	}
 }
 
-// The histogram buckets grow ~9% per step, so percentiles must land within
-// one bucket of the true value.
+// A dense uniform distribution interpolates almost exactly (the ~9% bucket
+// width only bounds the worst case), so 2% is tight enough to catch a broken
+// interpolation, not just a broken clamp.
 func TestLatencyPercentiles(t *testing.T) {
 	tr := newTracker()
 	// 1ms .. 1000ms, uniform
@@ -68,8 +69,8 @@ func TestLatencyPercentiles(t *testing.T) {
 	}
 	for _, c := range checks {
 		relErr := math.Abs(float64(c.got)-float64(c.want)) / float64(c.want)
-		if relErr > 0.10 {
-			t.Errorf("%s: got %v, want %v ±10%%", c.name, c.got, c.want)
+		if relErr > 0.02 {
+			t.Errorf("%s: got %v, want %v ±2%%", c.name, c.got, c.want)
 		}
 	}
 
@@ -97,9 +98,9 @@ func TestLatencyPercentilesClampedToObserved(t *testing.T) {
 
 func TestLatencyBucketExtremes(t *testing.T) {
 	tr := newTracker()
-	tr.ObserveLatency(0) // below first bucket
+	tr.ObserveLatency(0) // at the first bucket bound (1ns)
 	tr.ObserveLatency(100 * time.Nanosecond)
-	tr.ObserveLatency(24 * time.Hour) // beyond last bucket
+	tr.ObserveLatency(50 * 365 * 24 * time.Hour) // beyond the last bucket (~36 years)
 
 	s := tr.Stats().Latency
 	if s.Count != 3 {
@@ -108,11 +109,85 @@ func TestLatencyBucketExtremes(t *testing.T) {
 	if s.Min != 0 {
 		t.Errorf("expected min 0, got %v", s.Min)
 	}
-	if s.Max != 24*time.Hour {
-		t.Errorf("expected max 24h, got %v", s.Max)
+	if s.Max != 50*365*24*time.Hour {
+		t.Errorf("expected max 50y, got %v", s.Max)
 	}
 	if s.P99 > s.Max {
 		t.Errorf("p99 %v exceeds max %v", s.P99, s.Max)
+	}
+}
+
+// Count, Total, Min, Avg and Max are exact integer durations: the float64
+// nanosecond representation inside the histogram must not leak truncation
+// into them.
+func TestLatencyExactness(t *testing.T) {
+	tr := newTracker()
+	tr.ObserveLatency(1001 * time.Nanosecond)
+	tr.ObserveLatency(1001 * time.Nanosecond)
+
+	s := tr.Stats().Latency
+	if s.Min != 1001 || s.Max != 1001 {
+		t.Errorf("expected exact min/max 1001ns, got %v/%v", s.Min, s.Max)
+	}
+	if s.Total != 2002 {
+		t.Errorf("expected exact total 2002ns, got %v", s.Total)
+	}
+	if s.Avg != 1001 {
+		t.Errorf("expected exact avg 1001ns, got %v", s.Avg)
+	}
+	for name, p := range map[string]time.Duration{"p50": s.P50, "p99": s.P99} {
+		if p != 1001 {
+			t.Errorf("%s: expected 1001ns (single observed value), got %v", name, p)
+		}
+	}
+}
+
+// The nanosecond base unit must keep its ~9% resolution below 1µs: a
+// sub-microsecond bulk (the realistic shape for a page-cache-backed local
+// store) with one huge outlier may not drag the low percentiles upward.
+func TestLatencySubMicrosecondWithOutlier(t *testing.T) {
+	tr := newTracker()
+	for i := 0; i < 999; i++ {
+		tr.ObserveLatency(200 * time.Nanosecond)
+	}
+	tr.ObserveLatency(time.Second)
+
+	s := tr.Stats().Latency
+	for _, c := range []struct {
+		name string
+		got  time.Duration
+	}{
+		{"p50", s.P50},
+		{"p90", s.P90},
+	} {
+		relErr := math.Abs(float64(c.got)-200) / 200
+		if relErr > 0.10 {
+			t.Errorf("%s: got %v, want ~200ns ±10%%", c.name, c.got)
+		}
+	}
+}
+
+// Sub-microsecond distributions must reflect the observed range instead of
+// collapsing onto the extremes.
+func TestLatencySubMicrosecond(t *testing.T) {
+	tr := newTracker()
+	for i := 100; i <= 900; i++ {
+		tr.ObserveLatency(time.Duration(i) * time.Nanosecond)
+	}
+
+	s := tr.Stats().Latency
+	for _, c := range []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"p50", s.P50, 500 * time.Nanosecond},
+		{"p90", s.P90, 820 * time.Nanosecond},
+	} {
+		relErr := math.Abs(float64(c.got)-float64(c.want)) / float64(c.want)
+		if relErr > 0.05 {
+			t.Errorf("%s: got %v, want %v ±5%%", c.name, c.got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
* Now that we have iostat and latency both using an histogram, introduce a common implementation based on the one from LatencyTracker, which is based on a fixed size slice rather than an ever growing slice.

* We do loose a tiny bit of precision but that's fair given the huge win both in memory and cpu (that copy+sort was showing up in profiles)